### PR TITLE
2 test cases which reproduce extract local bug

### DIFF
--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/ExtractLocalTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/ExtractLocalTest.scala
@@ -706,6 +706,44 @@ object ExtractMethod2 {
   } applyRefactoring(extract("len"))
 
   @Test
+  def extractFromForEntireRhs = new FileSet {
+    """
+    object ExtractFromFor {
+      def foo {
+        for (i <- /*(*/List()/*)*/) println(i)
+      }
+    }
+    """ becomes
+    """
+    object ExtractFromFor {
+      def foo {
+        val extractedValue = List()
+        for (i <- /*(*/extractedValue) println(i)
+      }
+    }
+    """
+  } applyRefactoring(extract("extractedValue"))
+
+  @Test
+  def extractFromForEntireRhsYield = new FileSet {
+    """
+    object ExtractFromFor {
+      def foo {
+        println(for (i <- /*(*/List()/*)*/) yield i)
+      }
+    }
+    """ becomes
+    """
+    object ExtractFromFor {
+      def foo {
+        val extractedValue = List()
+        println(for (i <- /*(*/extractedValue) yield i)
+      }
+    }
+    """
+  } applyRefactoring(extract("extractedValue"))
+
+  @Test
   def extractFromForFilter = new FileSet {
     """
     object ExtractFromFor {


### PR DESCRIPTION
When performing an extract local on the entire right-hand
side of a '<-' in a for expression, one either gets
an UnsupportedOperationException, or ends up with
a refactoring that mangles the input. These test cases
reproduce instances of both of those bad behaviors.

Re #1001646
