### PR TITLE
Allow specifying the target class/object by the offset to the definition

### DIFF
--- a/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/implementations/AddMethod.scala
+++ b/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/implementations/AddMethod.scala
@@ -16,12 +16,35 @@ abstract class AddMethod extends Refactoring with InteractiveScalaCompiler {
     val astRoot = abstractFileToTree(file)
 
     //it would be nice to pass in the symbol and use that rather than compare the name, but it might not be available
-    val classOrObjectDef = astRoot.find {
-      case classDef: ClassDef if target == AddToClass => classDef.name.decode == className
-      case moduleDef: ModuleDef if target == AddToObject => moduleDef.name.decode == className
-      case _ => false
+    val classOrObjectDef = target match {
+      case AddToClosest(offset: Int) => {
+	    case class UnknownDef(tree: Tree, offset: Int)
+	    
+	    val classAndObjectDefs = astRoot.collect {
+	      case classDef: ClassDef if classDef.name.decode == className =>
+	        UnknownDef(classDef, classDef.namePosition.offset.getOrElse(0))
+	      case moduleDef: ModuleDef if moduleDef.name.decode == className => 
+	        UnknownDef(moduleDef, moduleDef.namePosition.offset.getOrElse(0))
+	    }
+	    
+	    //the class/object definition just before the given offset
+	    classAndObjectDefs.sortBy(_.offset).reverse.find(_.offset < offset).map(_.tree)
+      }
+      case _ => {
+        astRoot.find {
+          case classDef: ClassDef if target == AddToClass => classDef.name.decode == className
+          case moduleDef: ModuleDef if target == AddToObject => moduleDef.name.decode == className
+          case _ => false
+        }
+      }
     }
+      
 
+
+    addMethod(file, className, methodName, parameters, returnType, classOrObjectDef.get)
+  }
+  
+  private def addMethod(file: AbstractFile, className: String, methodName: String, parameters: List[List[(String, String)]], returnType: Option[String], classOrObjectDef: Tree): List[TextChange] = {
     val nscParameters = for (paramList <- parameters) yield for ((paramName, typeName) <- paramList) yield {
       val paramSymbol = NoSymbol.newValue(newTermName(paramName))
       paramSymbol.setInfo(newType(typeName))
@@ -38,7 +61,7 @@ abstract class AddMethod extends Refactoring with InteractiveScalaCompiler {
       case ModuleDef(_, _, tpl) => addMethodToTemplate(tpl)
     }
 
-    refactor((insertMethodCall apply classOrObjectDef.get).toList)
+    refactor((insertMethodCall apply classOrObjectDef).toList)
   }
 
   private def newType(name: String) = new Type {
@@ -49,3 +72,4 @@ abstract class AddMethod extends Refactoring with InteractiveScalaCompiler {
 sealed trait AddMethodTarget
 case object AddToClass extends AddMethodTarget
 case object AddToObject extends AddMethodTarget
+case class AddToClosest(offset: Int) extends AddMethodTarget

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/AddMethodTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/AddMethodTest.scala
@@ -104,4 +104,24 @@ trait Main {
   }
 }""")
   }
+  
+  @Test
+  def addMethodByClosestPosition = {
+    addMethod("Main", "method", Nil, None, AddToClosest(30), """
+class Main {
+
+}
+object Main {
+
+}""",
+      """
+class Main {
+
+}
+object Main {
+  def method = {
+    ???
+  }
+}""")
+  }
 }


### PR DESCRIPTION
This is necessary for the "Add method" quickfix when the compiler tells us "not found: value <method name>", since we don't know from the error message whether the attempt to invoke that method is in a class or an object.
