### PR TITLE
Insert extracted method after its previous surrounding method

### DIFF
--- a/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/implementations/ExtractMethod.scala
+++ b/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/implementations/ExtractMethod.scala
@@ -86,7 +86,9 @@ abstract class ExtractMethod extends MultiStageRefactoring with TreeAnalysis wit
 
     val insertMethodCall = transform {
       case tpl @ Template(_, _, body) =>
-        tpl copy(body = body ::: newDef :: Nil) replaces tpl
+        val p = selectedMethod.pos.point
+        val (before, after) = body.span(_.pos.point <= p)
+        tpl copy(body = before ::: newDef :: after) replaces tpl
     }
 
     val extractMethod = topdown {

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/ExtractMethodTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/ExtractMethodTest.scala
@@ -737,6 +737,10 @@ object ExtractMethod3 {
           println("It's true")
       }
 
+      private def isFalse(check: Boolean): Boolean = {
+        /*(*/check == false/*)*/ /*hi*/
+      }
+
       def unrelated1 {
         println("unrelated1")
       }
@@ -747,10 +751,6 @@ object ExtractMethod3 {
 
       def unrelated3 {
         println("unrelated3")
-      }
-
-      private def isFalse(check: Boolean): Boolean = {
-        /*(*/check == false/*)*/ /*hi*/
       }
     }
 


### PR DESCRIPTION
**Good to merge, the PR message is obsolete**

Mirko, this is not yet ready to merge. While the refactoring works, the problem is that it inserts whitespace before the extracted method, which breaks the test.

```
  ExtractMethodTest.extractLarger:763 expected:<...It's true")
      }
[]
      private def i...> but was:<...It's true")
      }
[      ]
      private def i...>
```

Can you give me a hint on where to start searching for the code that inserts the whitespace?

Furthermore there is another test that breaks:

```
  MarkOccurrencesTest.annotatedType:218->markOccurrences:44 expected:<...ef go(t: List[ /*(*/[######/*)*/ ]) = {
          val s: ###### = ""
          t: List[######]]
        }
      }
...> but was:<...ef go(t: List[ /*(*/[String/*)*/ ]) = {
          val s: String = ""
          t: List[String]]
        }
      }
...>
```

Unfortunately I don't know how it relates to the change in the extract method implementation.
