### PR TITLE
Upgrade to scala-maven-plugin 3.1.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
       <plugin>
         <groupId>net.alchim31.maven</groupId>
         <artifactId>scala-maven-plugin</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.5</version>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
This newer version of the scala plugin for maven doesn't crash on a modularized scala (scala/scala#2855).

Full disclosure: I wouldn't go as far as saying that 3.1.5 fully supports a modularized Scala -- a fix is in the works for 3.1.6

Review by @misto, /cc @dotta
