### PR TITLE
Cleans up after #34

### DIFF
--- a/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/analysis/GlobalIndexes.scala
+++ b/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/analysis/GlobalIndexes.scala
@@ -33,26 +33,6 @@ trait GlobalIndexes extends Indexes with DependentSymbolExpanders with Compilati
           OverridesInSuperClasses {
 
             val cus = compilationUnits
-
-            @tailrec
-            def linkSymbols(uf: UnionFind[Symbol], syms:List[Symbol], seen:HashSet[Symbol]): UnionFind[Symbol] = {
-              if (syms.nonEmpty){
-                val nextSymbols = ListBuffer[Symbol]()
-                for (s <- syms) {
-                  for (es <- expand(s) filterNot (_ == NoSymbol)){
-                    uf.union(s, es)
-                    if (!seen(es)) nextSymbols += es
-                  }
-                  seen += s
-                }
-                linkSymbols(uf,nextSymbols.toList, seen)
-              } else uf
-            }
-
-            private lazy val symbolsUF: UnionFind[Symbol] = linkSymbols(new UnionFind(), allSymbols(), new HashSet[Symbol]())
-
-            override def expandSymbol(s: Symbol): List[Symbol] = symbolsUF.equivalenceClass(s)
-
           }
 
     def apply(t: Tree): IndexLookup = apply(List(CompilationUnitIndex(t)))
@@ -86,24 +66,27 @@ trait GlobalIndexes extends Indexes with DependentSymbolExpanders with Compilati
       }).distinct
     }
 
-    def expandSymbol(s: global.Symbol): List[global.Symbol] = {
-
-      @tailrec
-      def expandSymbols(res:ListBuffer[Symbol], seen: HashSet[Symbol], ss: List[Symbol], n:Int):List[Symbol] =
-        if (n == 0) res.toList else{
-          val nuS = ss flatMap expand filterNot (x => seen(x) || x == NoSymbol)
-          if (nuS.isEmpty) res.toList else {
-            nuS foreach { s =>
-              seen += s
-              res += s
-              }
-            expandSymbols(res, seen, nuS, n-1)
-            }
+    @tailrec
+    private def linkSymbols(uf: UnionFind[Symbol], syms:List[Symbol], seen:HashSet[Symbol]): UnionFind[Symbol] = {
+      if (syms.nonEmpty){
+        val nextSymbols = ListBuffer[Symbol]()
+        for (s <- syms) {
+          for (es <- expand(s) filterNot (_ == NoSymbol)){
+            uf.union(s, es)
+            if (!seen(es)) nextSymbols += es
           }
-
-      // we should probably do this until a fixpoint is reached. but for now, three times seems to be enough
-      expandSymbols(ListBuffer(s), HashSet(s), List(s), 3)
+          seen += s
+        }
+        linkSymbols(uf,nextSymbols.toList, seen)
+      } else uf
     }
+
+    /*
+     * This stores knows symbols into connected components, where the connection is to refer to the same symbol name
+     */
+    private lazy val symbolsUF: UnionFind[Symbol] = linkSymbols(new UnionFind(), allSymbols(), new HashSet[Symbol]())
+
+    def expandSymbol(s: Symbol): List[Symbol] = symbolsUF.equivalenceClass(s)
 
     def occurences(s: global.Symbol) = {
       val expandedSymbol = expandSymbol(s)

--- a/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/analysis/SymbolExpanders.scala
+++ b/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/analysis/SymbolExpanders.scala
@@ -77,31 +77,6 @@ trait DependentSymbolExpanders {
     }
   }
 
-  trait OverridesInClassHierarchy extends SymbolExpander {
-
-    this: IndexLookup =>
-
-    abstract override def expand(s: Symbol) = super.expand(s) ++ (s match {
-      case s @ (_: global.TypeSymbol | _: global.TermSymbol) if s.owner.isClass => {
-
-        def allSubClasses(clazz: Symbol) = allDefinedSymbols.filter {
-          case decl if decl.isClass || decl.isModule =>
-            val ancestors = decl.ancestors
-            ancestors.exists { _ == clazz }
-          case _ => false
-        }
-        val containingClass = s.owner
-
-        val subClasses = allSubClasses(containingClass)
-
-        val overrides = (subClasses map (s overridingSymbol _)) ++ s.allOverriddenSymbols
-
-        overrides
-      }
-      case _ => Nil
-    })
-  }
-
   trait OverridesInSuperClasses extends SymbolExpander {
     this : IndexLookup =>
 


### PR DESCRIPTION
removes obsolete OverridesInClassHierarchy, plugs in the UF by default in
expandSymbols
