### PR TITLE
Make scala-refactoring compatible with unit-unloading of askLoadedTyped

### DIFF
--- a/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/util/CompilerProvider.scala
+++ b/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/util/CompilerProvider.scala
@@ -85,7 +85,7 @@ trait TreeCreationMethods {
 
     val response = new Response[global.Tree]
 
-    global.ask(() => global.askLoadedTyped(file, response))
+    global.ask(() => global.askLoadedTyped(file, true, response))
 
     response.get match {
       case Left(tree) => tree


### PR DESCRIPTION
The new behavior of unit unloading is introduced in
https://github.com/scala/scala/pull/3158 on which this commit is strictly
dependent.

In the longer term, scala-refactoring depends on a global
"load-all-before-index" and "remove-all-after" semantics.

It would be wise  to refactor scala-refactoring to load files parcimoniously
throughout the index building process. But this is already a step in the right
direction.
