### PR TITLE
Prevent `this` with transparent position to be indexed

### DIFF
--- a/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/common/TreeTraverser.scala
+++ b/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/common/TreeTraverser.scala
@@ -343,7 +343,7 @@ trait TreeTraverser {
             case _ => ()
           }
 
-        case t: This if t.pos.isRange =>
+        case t: This if t.pos.isOpaqueRange =>
           f(t.symbol, t)
 
         case _ => ()


### PR DESCRIPTION
@misto With this little tweak, all scala-refactoring tests work on top of my scala branch for fixing [SI-4287](https://issues.scala-lang.org/browse/SI-4287). The commit message elaborates on the reasoning that lead me to the current fix. Please, let me know what you think.

If it's ok to merge, I'll do it myself when I'm ready to push the PR on the Scala side.

By the way, I also verified that with this commit tests pass with both 2.10.x and 2.11.x, i.e., the change I made doesn't seem to influence existing behavior.
