### PR TITLE
Tree traversing was skipping Select `apply` Tree where the qualifier has an opaque position

### DIFF
--- a/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/analysis/CompilationUnitDependencies.scala
+++ b/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/analysis/CompilationUnitDependencies.scala
@@ -230,7 +230,7 @@ trait CompilationUnitDependencies {
           ()
 
         // workaround for SI-5064
-        case t @ Select(qual: Select, nme.apply) if qual.pos.isTransparent && t.pos.isOpaqueRange =>
+        case t @ Select(qual: Select, nme.apply) if (qual.pos.isTransparent && t.pos.isOpaqueRange) || qual.pos.isOpaqueRange =>
           if(hasStableQualifier(qual) && !isSelectFromInvisibleThis(qual.qualifier)) {
             addToResult(qual)
           }


### PR DESCRIPTION
My proposed fix for https://issues.scala-lang.org/browse/SI-8125 correct the
positions assigned to synthetic Apply Tree. However, the fix caused the
`CompilationUnitDependenciesTest.evidence` test to start failing. The issue is
that the positions assigned to a Select tree with a synthetic `apply` now fails
the condition `qual.pos.isTransparent && t.pos.isOpaqueRange` because the
qualifier now has an opaque position (it's now the Apply tree that has a
transparent position, which makes sense because the `apply` call is synthetic,
i.e., injected by the compiler).

Considering scala-refactoring needs to be compiled for both Scala 2.10 and 2.11,
and because the proposed fix for SI-8125 only targets 2.11, I've updated the
above condition to include the case where the qualifier's position is opaque.

Last but not least, I wonder if after we drop 2.10 support, the workaround put
in place for https://issues.scala-lang.org/browse/SI-5064 are still needed. In
fact, I noticed this discussion
https://github.com/scala/scala/pull/1251/files#r1573933, and the fix to SI-8125
will indeed break hyperlinking to `apply` method when the `apply` is synthetic.
I discussed this with @dragos and 1) he agreed that it's best to assing the
correct (and expected) kind of position for synthetic `apply`, and 2) that we
can restore the functionality for hyperlinking to synthetic `apply` by changing
the signature of `askTypeAt(pos)` in the compiler, so that instead of returning
the innermost tree for the passed `pos`, it will instead return the list of
parents including `pos` (see https://issues.scala-lang.org/browse/SI-8136).
