### PR TITLE
Parenthetizes test nullary methods

### DIFF
--- a/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/implementations/InlineLocal.scala
+++ b/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/implementations/InlineLocal.scala
@@ -32,7 +32,7 @@ abstract class InlineLocal extends MultiStageRefactoring with ParameterlessRefac
         && t.symbol.enclMethod != NoSymbol => Right(t)
       case Some(t) =>
         Left(PreparationError("The selected value cannot be inlined."))
-      case _ =>
+      case None =>
         Left(PreparationError("No local value selected."))
     }
   }

--- a/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/sourcegen/ReusingPrinter.scala
+++ b/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/sourcegen/ReusingPrinter.scala
@@ -88,25 +88,22 @@ trait ReusingPrinter extends TreePrintingTraversals with AbstractPrinter {
       EmptyTree
     }
 
-    /**
-     * Returns a NameTree for a tree's name and gives it the position of
-     * the original tree's name.
+    /** Returns a NameTree for a tree's name and gives it the position of
+     *  the original tree's name.
      */
     def nameOf(tree: Tree): NameTree = {
       val namePos = orig(tree).namePosition
       outer.NameTree(tree.nameString) setPos namePos
     }
 
-    /**
-     * Prints the children of the tree, surrounded with the layout from
-     * the existing code.
+    /** Prints the children of the tree, surrounded with the layout from
+     *  the existing code.
      */
     def printChildren(tree: Tree)(implicit ctx: PrintingContext) = {
       l ++ children(tree).foldLeft(EmptyFragment: Fragment)(_ ++ p(_)) ++ r
     }
 
-    /**
-     * This is the default handler that is called for non-overriden methods.
+    /** This is the default handler that is called for non-overriden methods.
      */
     override def default(tree: Tree)(implicit ctx: PrintingContext): Fragment = {
       printChildren(tree)
@@ -212,8 +209,8 @@ trait ReusingPrinter extends TreePrintingTraversals with AbstractPrinter {
         // It's just nice to have a whitespace before and after the arrow
         def getLayout = Layout(" => ")
       }
-      
-      val ifReq = new Requisite{
+
+      val ifReq = new Requisite {
         def isRequired(l: Layout, r: Layout) = {
           !(l.contains("if") || r.contains("if"))
         }
@@ -474,17 +471,15 @@ trait ReusingPrinter extends TreePrintingTraversals with AbstractPrinter {
             receiver.qualifier.pos.isRange && betweenEndAndPoint(receiver.qualifier, receiver).contains(".")
           }
 
-          if (isReceiverMethodCallWithDot) {
+          if (isReceiverMethodCallWithDot || !keepTree(receiver.qualifier) || l.contains("(") || r.contains(")")) {
             l ++ p(fun) ++ p(arg, before = Requisite.anywhere("("), after = Requisite.anywhere(")")) ++ r
-          } else if (keepTree(receiver.qualifier) && !l.contains("(") && !r.contains(")")) {
+          } else {
             val arg_ = p(arg)
             if (arg_.asText.matches("""(?ms)\s*\{.*""") && !arg_.asText.matches("""(?ms).*\}\s*""")) {
               l ++ p(fun) ++ arg_ ++ indentedNewline ++ "}" ++ r
             } else {
               l ++ p(fun) ++ arg_ ++ r
             }
-          } else {
-            l ++ p(fun) ++ p(arg, before = Requisite.anywhere("("), after = Requisite.anywhere(")")) ++ r
           }
 
         case (fun, arg :: Nil) if !keepTree(fun) =>

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/analysis/CompilationUnitDependenciesTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/analysis/CompilationUnitDependenciesTest.scala
@@ -28,7 +28,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
     assertTrees(expected, src, dependencies)
 
   @Test
-  def evidenceNoImport = assertNeededImports(
+  def evidenceNoImport() = assertNeededImports(
     """""",
     """
     trait Transformations {
@@ -46,7 +46,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
     """)
 
   @Test
-  def evidence = assertDependencies(
+  def evidence() = assertDependencies(
     """scala.Some""",
     """
     trait Transformations {
@@ -64,14 +64,14 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
     """)
 
   @Test
-  def typeFromScalaPackage = assertDependencies(
+  def typeFromScalaPackage() = assertDependencies(
     """""",
     """
        object NoRuleApplies extends Exception("No Rule Applies")
     """)
 
   @Test
-  def abstractValType = assertDependencies(
+  def abstractValType() = assertDependencies(
     """java.util.Observable
        scala.collection.mutable.ListBuffer""",
     """
@@ -81,7 +81,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
     """)
 
   @Test
-  def dependencyOnMultipleOverloadedMethods = assertNeededImports(
+  def dependencyOnMultipleOverloadedMethods() = assertNeededImports(
     """scala.math.BigDecimal.apply""",
     """
       import scala.math.BigDecimal._
@@ -95,7 +95,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
     """)
 
   @Test
-  def typeArgument = assertDependencies(
+  def typeArgument() = assertDependencies(
     """scala.collection.mutable.ListBuffer""",
     """
        import collection.mutable._
@@ -105,7 +105,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
     """)
 
   @Test
-  def objectType = assertDependencies(
+  def objectType() = assertDependencies(
     """<root>.scala.io.Source""",
     """
       import scala.io._
@@ -113,7 +113,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
       """)
 
   @Test
-  def objectTypeRequiresImport = assertNeededImports(
+  def objectTypeRequiresImport() = assertNeededImports(
     """<root>.scala.io.Source""",
     """
       import scala.io._
@@ -121,7 +121,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
       """)
 
   @Test
-  def valAnnotation = assertDependencies(
+  def valAnnotation() = assertDependencies(
     """java.lang.Object
        scala.beans.BeanProperty
        scala.this.Predef.String""",
@@ -132,7 +132,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
 
   @Test
   @ScalaVersion(matches="2.10.0")
-  def switchAnnotation210 = assertDependencies(
+  def switchAnnotation210() = assertDependencies(
     """Integer.parseInt
        java.this.lang.Integer
        scala.annotation.switch""",
@@ -148,7 +148,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
 
   @Test
   @ScalaVersion(matches="2.10.1")
-  def switchAnnotation2101 = assertDependencies(
+  def switchAnnotation2101() = assertDependencies(
     """java.this.lang.Integer
        scala.annotation.switch""",
     """
@@ -163,7 +163,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
 
   @Test
   @ScalaVersion(matches="2.11")
-  def switchAnnotation = assertDependencies(
+  def switchAnnotation() = assertDependencies(
     """java.this.lang.Integer
        scala.annotation.switch""",
     """
@@ -177,7 +177,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
       """)
 
   @Test
-  def annotationRequiresImport = assertNeededImports(
+  def annotationRequiresImport() = assertNeededImports(
     """scala.beans.BeanProperty""",
     """
       import scala.beans.BeanProperty
@@ -185,7 +185,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
       """)
 
   @Test
-  def classAttributeDeps = assertDependencies(
+  def classAttributeDeps() = assertDependencies(
     """scala.collection.mutable.Map
        scala.this.Predef.String""",
     """
@@ -194,7 +194,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
       """)
 
   @Test
-  def classAttributeRequiresImport = assertNeededImports(
+  def classAttributeRequiresImport() = assertNeededImports(
     """scala.collection.mutable.Map""",
     """
       import scala.collection.mutable.Map
@@ -202,7 +202,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
     """)
 
   @Test
-  def fullAndShortNames = assertNeededImports(
+  def fullAndShortNames() = assertNeededImports(
     """scala.collection.mutable.Map
        scala.collection.mutable.Set""",
     """
@@ -218,7 +218,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
     """)
 
   @Test
-  def renamedImport = assertDependencies(
+  def renamedImport() = assertDependencies(
     """scala.collection.mutable.Map
        scala.this.Predef.String""",
     """
@@ -227,7 +227,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
       """)
 
   @Test
-  def renamedImportIsNeeded = assertNeededImports(
+  def renamedImportIsNeeded() = assertNeededImports(
     """scala.collection.mutable.Map""",
     """
       import scala.collection.mutable.{Map => M}
@@ -235,7 +235,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
     """)
 
   @Test
-  def localImport = assertDependencies(
+  def localImport() = assertDependencies(
     """scala.this.Predef.println
        x.B""",
     """
@@ -254,7 +254,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
       """)
 
   @Test
-  def localImportNotNeeded = assertNeededImports(
+  def localImportNotNeeded() = assertNeededImports(
     "",
     """
       class A {
@@ -272,7 +272,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
       """)
 
   @Test
-  def classAttributeWithFullPackage = assertDependencies(
+  def classAttributeWithFullPackage() = assertDependencies(
     """scala.collection.mutable.Map
        scala.this.Predef.String""",
     """
@@ -280,14 +280,14 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
       """)
 
   @Test
-  def classAttributeWithFullPackageNoImports = assertNeededImports(
+  def classAttributeWithFullPackageNoImports() = assertNeededImports(
     "",
     """
       class UsesMap { val x = collection.mutable.Map[Int, String]() }
       """)
 
   @Test
-  def etaExpandedMethod = assertNeededImports(
+  def etaExpandedMethod() = assertNeededImports(
     "",
     """
       trait A {
@@ -296,7 +296,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
       }      """)
 
   @Test
-  def classAttributeWithWildcardImport = assertDependencies(
+  def classAttributeWithWildcardImport() = assertDependencies(
     """scala.collection.mutable.HashSet""",
     """
       import collection._
@@ -304,7 +304,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
       """)
 
   @Test
-  def classAttributeWithWildcardImportNeeded = assertNeededImports(
+  def classAttributeWithWildcardImportNeeded() = assertNeededImports(
     """scala.collection.mutable""",
     """
       import collection._
@@ -312,7 +312,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
       """)
 
   @Test
-  def importIsUsedAsType = assertDependencies(
+  def importIsUsedAsType() = assertDependencies(
     """java.util.ArrayList""",
     """
       import java.util._
@@ -320,7 +320,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
       """)
 
   @Test
-  def importIsUsedAsTypeButNotNeeded = assertNeededImports(
+  def importIsUsedAsTypeButNotNeeded() = assertNeededImports(
     "",
     """
       import java.util._
@@ -329,7 +329,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
 
   @Test
   @ScalaVersion(matches="2.10")
-  def importIsUsedAsTypeAscription210 = assertDependencies(
+  def importIsUsedAsTypeAscription210() = assertDependencies(
     """scala.collection.immutable.Set
        scala.this.Predef.Map
        scala.this.Predef.any2ArrowAssoc""",
@@ -339,7 +339,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
 
   @Test
   @ScalaVersion(matches="2.11")
-  def importIsUsedAsTypeAscription = assertDependencies(
+  def importIsUsedAsTypeAscription() = assertDependencies(
     """scala.collection.immutable.Set
        scala.this.Predef.ArrowAssoc
        scala.this.Predef.Map""",
@@ -348,14 +348,14 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
       """)
 
   @Test
-  def importIsUsedAsTypeAscriptionNeeded = assertNeededImports(
+  def importIsUsedAsTypeAscriptionNeeded() = assertNeededImports(
     "",
     """
       class UsesSet { val s: collection.immutable.Set[Any] = Map(1 -> 2).toSet }
       """)
 
   @Test
-  def typeUsedAsParent = assertDependencies(
+  def typeUsedAsParent() = assertDependencies(
     """java.util.Observer""",
     """
       import java.util.Observer
@@ -363,7 +363,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
       """)
 
   @Test
-  def typeUsedAsParentImportNeeded = assertNeededImports(
+  def typeUsedAsParentImportNeeded()= assertNeededImports(
     """java.util.Observer""",
     """
       import java.util.Observer
@@ -371,7 +371,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
       """)
 
   @Test
-  def singleTypeUsedAsSelfTypeAnnotation = assertDependencies(
+  def singleTypeUsedAsSelfTypeAnnotation() = assertDependencies(
     """java.util.Observer""",
     """
       package singleTypeUsedAsSelfTypeAnnotation
@@ -382,7 +382,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
       """)
 
   @Test
-  def singleTypeUsedAsSelfTypeAnnotationImport = assertNeededImports(
+  def singleTypeUsedAsSelfTypeAnnotationImport() = assertNeededImports(
     """java.util.Observer""",
     """
       import java.util.Observer
@@ -392,7 +392,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
       """)
 
   @Test
-  def typeUsedAsSelfTypeAnnotation = assertDependencies(
+  def typeUsedAsSelfTypeAnnotation() = assertDependencies(
     """java.util.Observable
          java.util.Observer""",
     """
@@ -405,7 +405,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
       """)
 
   @Test
-  def typeUsedAsSelfTypeAnnotationImportsNeeded = assertNeededImports(
+  def typeUsedAsSelfTypeAnnotationImportsNeeded() = assertNeededImports(
     """java.util.Observable
          java.util.Observer""",
     """
@@ -418,7 +418,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
       """)
 
   @Test
-  def compoundTypeTree = assertDependencies(
+  def compoundTypeTree() = assertDependencies(
     """java.util.Observable
          java.util.Observer""",
     """
@@ -429,7 +429,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
       """)
 
   @Test
-  def typeUsedAsBound = assertDependencies(
+  def typeUsedAsBound()= assertDependencies(
     """java.util.Observer""",
     """
       import java.util.Observer
@@ -438,7 +438,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
       """)
 
   @Test
-  def typeUsedAsBoundNeeded = assertNeededImports(
+  def typeUsedAsBoundNeeded() = assertNeededImports(
     """java.util.Observer""",
     """
       import java.util.Observer
@@ -447,7 +447,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
       """)
 
   @Test
-  def qualifiedAndUnqualifiedImports = assertNeededImports(
+  def qualifiedAndUnqualifiedImports() = assertNeededImports(
     """scala.collection.mutable.HashMap""",
     """
       import collection.mutable.HashMap
@@ -459,7 +459,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
       """)
 
   @Test
-  def importStaticMethodDependency = assertDependencies(
+  def importStaticMethodDependency() = assertDependencies(
     """java.lang.Integer.parseInt""",
     """
       import java.lang.Integer._
@@ -469,7 +469,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
       """)
 
   @Test
-  def importStaticMethodNeeded = assertNeededImports(
+  def importStaticMethodNeeded() = assertNeededImports(
     """java.lang.Integer.parseInt""",
     """
       import java.lang.Integer._
@@ -479,7 +479,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
       """)
 
   @Test
-  def typeUsedInNew = assertDependencies(
+  def typeUsedInNew() = assertDependencies(
     """scala.this.Predef.intWrapper
        scala.util.Random""",
     """
@@ -491,7 +491,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
       """)
 
   @Test
-  def typeUsedInNewNeeded = assertNeededImports(
+  def typeUsedInNewNeeded() = assertNeededImports(
     """scala.util.Random""",
     """
       import scala.util._
@@ -502,7 +502,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
       """)
 
   @Test
-  def dependenciesAreUnique = assertDependencies(
+  def dependenciesAreUnique() = assertDependencies(
     """scala.collection.mutable.ListBuffer""",
     """
       import scala.collection.mutable.ListBuffer
@@ -510,7 +510,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
       """)
 
   @Test
-  def existential = assertDependencies(
+  def existential() = assertDependencies(
     """java.util.Map""",
     """
       import java.util._
@@ -520,7 +520,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
       """)
 
   @Test
-  def existentialTypeTree = assertNeededImports(
+  def existentialTypeTree() = assertNeededImports(
     """java.util.Map""",
     """
       import java.util._
@@ -530,7 +530,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
       """)
 
   @Test
-  def renamedPackage = assertDependencies(
+  def renamedPackage() = assertDependencies(
     """java.util.Map""",
     """
       import java.{ lang => jl, util => ju }
@@ -540,7 +540,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
       """)
 
   @Test
-  def renamedPackageImport = assertNeededImports(
+  def renamedPackageImport() = assertNeededImports(
     """java.util""",
     """
       import java.{ lang => jl, util => ju }
@@ -550,7 +550,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
       """)
 
   @Test
-  def importFromPackageObject = assertDependencies(
+  def importFromPackageObject() = assertDependencies(
     """scala.collection.`package`.breakOut
        scala.this.Predef.Map
        scala.this.Predef.identity""",
@@ -562,7 +562,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
       """)
 
   @Test
-  def selfTypeFromThis = assertDependencies(
+  def selfTypeFromThis() = assertDependencies(
     """""",
     """
       trait A {
@@ -576,7 +576,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
       """)
 
   @Test
-  def somePackages = assertDependencies(
+  def somePackages() = assertDependencies(
     """a.X""",
     """
       package a {
@@ -589,7 +589,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
       """)
 
   @Test
-  def somePackagesButNoImports = assertNeededImports(
+  def somePackagesButNoImports() = assertNeededImports(
     "",
     """
       package a {
@@ -602,7 +602,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
       """)
 
   @Test
-  def importedImplicitConversion = assertDependencies(
+  def importedImplicitConversion() = assertDependencies(
     """java.util.List
        scala.collection.JavaConversions.bufferAsJavaList
        scala.collection.mutable.ListBuffer""",
@@ -615,7 +615,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
       """)
 
   @Test
-  def importedImplicitConversionNeedsImport = assertNeededImports(
+  def importedImplicitConversionNeedsImport() = assertNeededImports(
     """scala.collection.JavaConversions.bufferAsJavaList""",
     """
       import scala.collection.JavaConversions._
@@ -626,7 +626,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
       """)
 
   @Test
-  def importedImplicitConversionNeedsImportShortForm = assertNeededImports(
+  def importedImplicitConversionNeedsImportShortForm() = assertNeededImports(
     """scala.collection.JavaConversions.asScalaBuffer""",
     """
       import collection.JavaConversions._
@@ -637,7 +637,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
     """)
 
   @Test
-  def importedImplicitArgument {
+  def importedImplicitArgument() {
 
     addToCompiler("xy.scala", """
       package impl.args
@@ -669,7 +669,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
   }
 
   @Test
-  def importFromLocalValueDependency = assertDependencies(
+  def importFromLocalValueDependency() = assertDependencies(
     """param.global.X""",
     """
       trait Param {
@@ -685,7 +685,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
     """)
 
   @Test
-  def importFromLocalValueNoImport = assertNeededImports(
+  def importFromLocalValueNoImport() = assertNeededImports(
     """""",
     """
       trait Param {
@@ -701,7 +701,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
     """)
 
   @Test
-  def classOfRequiresImport = assertNeededImports(
+  def classOfRequiresImport() = assertNeededImports(
     """scala.io.Source""",
     """
       import scala.io.Source
@@ -712,7 +712,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
     """)
 
   @Test
-  def SystemcurrentTimeMillis = assertNeededImports(
+  def SystemcurrentTimeMillis() = assertNeededImports(
     """java.this.lang.System.currentTimeMillis""",
     """
       import System.currentTimeMillis
@@ -723,7 +723,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
     """)
 
   @Test
-  def SystemcurrentTimeMillisDeps = assertDependencies(
+  def SystemcurrentTimeMillisDeps() = assertDependencies(
     """java.this.lang.System.currentTimeMillis""",
     """
       import System.currentTimeMillis
@@ -734,7 +734,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
     """)
 
   @Test
-  def ClassInAnnotationAttrArg = assertNeededImports(
+  def ClassInAnnotationAttrArg() = assertNeededImports(
     """java.util.Calendar""",
     """
       import java.util.Calendar
@@ -746,7 +746,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
     """)
 
   @Test
-  def ClassInAnnotationImports = assertNeededImports(
+  def ClassInAnnotationImports() = assertNeededImports(
     """java.io.BufferedReader
        java.io.FileReader
        java.io.IOException""",
@@ -763,7 +763,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
     """)
 
   @Test
-  def ClassInAnnotationDeps = assertDependencies(
+  def ClassInAnnotationDeps() = assertDependencies(
     """java.io.BufferedReader
        java.io.FileReader
        java.io.IOException
@@ -781,7 +781,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
     """)
 
   @Test
-  def implicitDefImports  = assertNeededImports(
+  def implicitDefImports()  = assertNeededImports(
     "", """class ImplicitDef {
 
       val readBuffer = Array.ofDim[Byte](1024)
@@ -793,7 +793,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
     }""")
 
   @Test
-  def implicitDef = assertDependencies(
+  def implicitDef() = assertDependencies(
     """scala.reflect.ClassTag
        scala.this.Predef.byteArrayOps""",
     """class ImplicitDef {
@@ -814,7 +814,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
     }""")
 
   @Test
-  def annotationOnPrimaryConstructor = assertDependencies(
+  def annotationOnPrimaryConstructor() = assertDependencies(
     "java.lang.annotation.Documented",
     """
       import java.lang.annotation.Documented
@@ -824,7 +824,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
 
 
   @Test
-  def annotationOnField = assertDependencies(
+  def annotationOnField() = assertDependencies(
     "java.lang.annotation.Documented",
     """
       import java.lang.annotation.Documented

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/analysis/ImportAnalysisTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/analysis/ImportAnalysisTest.scala
@@ -8,7 +8,7 @@ class ImportAnalysisTest extends TestHelper with ImportAnalysis{
   import global._
 
   @Test
-  def importTrees = {
+  def importTrees() = {
     val s = toSelection("""
     import scala.collection.immutable.{LinearSeq, _}
 
@@ -16,22 +16,22 @@ class ImportAnalysisTest extends TestHelper with ImportAnalysis{
       import scala.math._
       val a = 1
     }
-        
+
     object P{
       import collection.mutable._
       import O.a
     }
     """)
-    
+
     val it = buildImportTree(s.root)
     assertEquals("{scala.collection.immutable.List{scala.`package`._{scala.Predef._{scala.collection.immutable.LinearSeq{scala.collection.immutable._{scala.math._{}, scala.collection.mutable._{O.a{}}}}}}}}", it.toString())
   }
 
   @Test
-  def isImported = {
+  def isImported() = {
     val s = toSelection("""
     import scala.math.E
-        
+
     object O{
       def fn = {
         import scala.math.Pi
@@ -39,21 +39,21 @@ class ImportAnalysisTest extends TestHelper with ImportAnalysis{
       }
     }
     """)
-    
+
     val it = buildImportTree(s.root)
     val piRef = findSymTree(s.root, "value Pi")
     val eRef = findSymTree(s.root, "value E")
     val fnDef = findSymTree(s.root, "method fn")
-    
+
     assertTrue(it.isImportedAt(piRef.symbol, piRef.pos))
     assertTrue(it.isImportedAt(eRef.symbol, eRef.pos))
-    
+
     assertFalse(it.isImportedAt(piRef.symbol, fnDef.pos))
     assertTrue(it.isImportedAt(eRef.symbol, fnDef.pos))
   }
 
   @Test
-  def isImportedWithWildcard = {
+  def isImportedWithWildcard() = {
     val s = toSelection("""
     object O{
       def fn = {
@@ -62,63 +62,63 @@ class ImportAnalysisTest extends TestHelper with ImportAnalysis{
       }
     }
     """)
-    
+
     val it = buildImportTree(s.root)
     val piRef = findSymTree(s.root, "value Pi")
     val eRef = findSymTree(s.root, "value E")
     val fnDef = findSymTree(s.root, "method fn")
-    
+
     assertTrue(it.isImportedAt(piRef.symbol, piRef.pos))
     assertTrue(it.isImportedAt(eRef.symbol, eRef.pos))
-    
+
     assertFalse(it.isImportedAt(piRef.symbol, fnDef.pos))
   }
 
   @Test
-  def predefsAreAlwaysImported = {
+  def predefsAreAlwaysImported() = {
     val s = toSelection("""
     object O{
       println(123)
       List(1, 2, 3)
     }
     """)
-    
+
     val it = buildImportTree(s.root)
     val printlnRef = findSymTree(s.root, "method println")
     val listRef = findSymTree(s.root, "object List")
-    
+
     val oDef = findSymTree(s.root, "object O")
-    
+
     assertTrue(it.isImportedAt(printlnRef.symbol, oDef.pos))
     assertTrue(it.isImportedAt(listRef.symbol, oDef.pos))
   }
 
   @Test
   @Ignore
-  def importsOfValueMembers = {
+  def importsOfValueMembers() = {
     val s = toSelection("""
     package pkg
     object O{
       val a = new{ val b = 1 }
 
       import a._
-      
+
       def fn = b
     }
     """)
-    
+
     val it = buildImportTree(s.root)
     val bRef = findSymTree(findSymTree(s.root, "method fn"), "value b")
-    
+
     val oDef = findSymTree(s.root, "object O")
     val aDef = findSymTree(s.root, "value a")
-    
+
     assertFalse(it.isImportedAt(bRef.symbol, oDef.pos))
     assertFalse(it.isImportedAt(bRef.symbol, aDef.pos))
 
     assertTrue(it.isImportedAt(bRef.symbol, bRef.pos))
   }
-  
+
   def findSymTree(t: Tree,s: String) =
     t.collect{
       case t: SymTree if t.symbol.toString == s => t

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/analysis/MultipleFilesIndexTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/analysis/MultipleFilesIndexTest.scala
@@ -100,7 +100,7 @@ class MultipleFilesIndexTest extends TestHelper with GlobalIndexes with FreshCom
   }
 
   @Test
-  def findReferencesToClass = global.ask { () =>
+  def findReferencesToClass() = global.ask { () =>
     new FileSet("p1") {
       """
       package p1
@@ -131,7 +131,7 @@ class MultipleFilesIndexTest extends TestHelper with GlobalIndexes with FreshCom
   }
 
   @Test
-  def findReferencesToMethod = global.ask { () =>
+  def findReferencesToMethod() = global.ask { () =>
     new FileSet("p2") {
       """
       package p2
@@ -171,7 +171,7 @@ class MultipleFilesIndexTest extends TestHelper with GlobalIndexes with FreshCom
   }
 
   @Test
-  def findReferencesToTraitMethod = global.ask { () =>
+  def findReferencesToTraitMethod() = global.ask { () =>
     new FileSet("p3") {
       """
       package p3
@@ -198,7 +198,7 @@ class MultipleFilesIndexTest extends TestHelper with GlobalIndexes with FreshCom
   }
 
   @Test
-  def findReferencesFromCallSite = global.ask { () =>
+  def findReferencesFromCallSite() = global.ask { () =>
     new FileSet("p4") {
       """
       package p4
@@ -219,7 +219,7 @@ class MultipleFilesIndexTest extends TestHelper with GlobalIndexes with FreshCom
   }
 
   @Test
-  def findValues = global.ask { () =>
+  def findValues() = global.ask { () =>
     new FileSet("p5") {
       """
       package p5
@@ -242,7 +242,7 @@ class MultipleFilesIndexTest extends TestHelper with GlobalIndexes with FreshCom
   }
 
   @Test
-  def findSuperCall = global.ask { () =>
+  def findSuperCall() = global.ask { () =>
     new FileSet("p6") {
       """
       package p6
@@ -255,7 +255,7 @@ class MultipleFilesIndexTest extends TestHelper with GlobalIndexes with FreshCom
   }
 
   @Test
-  def findCaseClassValues = global.ask { () =>
+  def findCaseClassValues() = global.ask { () =>
     new FileSet("p7") {
       """
       package p7
@@ -269,7 +269,7 @@ class MultipleFilesIndexTest extends TestHelper with GlobalIndexes with FreshCom
   }
 
   @Test
-  def passMethodAsFunction = global.ask { () =>
+  def passMethodAsFunction() = global.ask { () =>
     new FileSet("p8") {
       """
       package p8
@@ -286,7 +286,7 @@ class MultipleFilesIndexTest extends TestHelper with GlobalIndexes with FreshCom
   }
 
   @Test
-  def traitImplementation = global.ask { () =>
+  def traitImplementation() = global.ask { () =>
     new FileSet("p9") {
       """
       package p9
@@ -302,7 +302,7 @@ class MultipleFilesIndexTest extends TestHelper with GlobalIndexes with FreshCom
   }
 
   @Test
-  def findInImports = global.ask { () =>
+  def findInImports() = global.ask { () =>
     new FileSet("p10") {
       """
       package p10
@@ -320,7 +320,7 @@ class MultipleFilesIndexTest extends TestHelper with GlobalIndexes with FreshCom
   }
 
   @Test
-  def inClassHierarchy = global.ask { () =>
+  def inClassHierarchy() = global.ask { () =>
     new FileSet("p11") {
       """
     trait Abc
@@ -336,7 +336,7 @@ class MultipleFilesIndexTest extends TestHelper with GlobalIndexes with FreshCom
   }
 
   @Test
-  def allDeclarationsInClasses = global.ask { () =>
+  def allDeclarationsInClasses() = global.ask { () =>
     new FileSet {
       """
     trait Abc
@@ -352,7 +352,7 @@ class MultipleFilesIndexTest extends TestHelper with GlobalIndexes with FreshCom
   }
 
   @Test
-  def allSymbolsInIndex = global.ask { () =>
+  def allSymbolsInIndex() = global.ask { () =>
     new FileSet {
       """
     trait Abc
@@ -363,7 +363,7 @@ class MultipleFilesIndexTest extends TestHelper with GlobalIndexes with FreshCom
   }
 
   @Test
-  def allDeclarationsMethods = global.ask { () =>
+  def allDeclarationsMethods() = global.ask { () =>
     new FileSet {
       """
     trait Abc {
@@ -389,7 +389,7 @@ class MultipleFilesIndexTest extends TestHelper with GlobalIndexes with FreshCom
   }
 
   @Test
-  def overriddenMethods = global.ask { () =>
+  def overriddenMethods() = global.ask { () =>
     new FileSet {
       """
     trait Abc2 {
@@ -410,7 +410,7 @@ class MultipleFilesIndexTest extends TestHelper with GlobalIndexes with FreshCom
   }
 
   @Test
-  def overriddenMethods2 = global.ask { () =>
+  def overriddenMethods2() = global.ask { () =>
     new FileSet {
       """
     class Abc {
@@ -431,7 +431,7 @@ class MultipleFilesIndexTest extends TestHelper with GlobalIndexes with FreshCom
   }
 
   @Test
-  def overriddenMethods3 = global.ask { () =>
+  def overriddenMethods3() = global.ask { () =>
     new FileSet {
       """
     class Abc {
@@ -447,7 +447,7 @@ class MultipleFilesIndexTest extends TestHelper with GlobalIndexes with FreshCom
   }
 
   @Test
-  def overriddenMethods4 = global.ask { () =>
+  def overriddenMethods4() = global.ask { () =>
     new FileSet {
       """
     class Abc {

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/analysis/ScopeAnalysisTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/analysis/ScopeAnalysisTest.scala
@@ -9,7 +9,7 @@ class ScopeAnalysisTest extends TestHelper with ScopeAnalysis {
   import global._
 
   @Test
-  def simpleScopes = {
+  def simpleScopes() = {
     val s = toSelection("""
       package demo
       object Demo{
@@ -28,7 +28,7 @@ class ScopeAnalysisTest extends TestHelper with ScopeAnalysis {
   }
 
   @Test
-  def nestedLocalScopes = {
+  def nestedLocalScopes() = {
     val s = toSelection("""
       object Demo{
         def fn = {
@@ -50,7 +50,7 @@ class ScopeAnalysisTest extends TestHelper with ScopeAnalysis {
   }
 
   @Test
-  def LocalScopes = {
+  def LocalScopes() = {
     val s = toSelection("""
       class Demo(cp: Int){
         def fn(a: Int, b: Int) = {
@@ -65,7 +65,7 @@ class ScopeAnalysisTest extends TestHelper with ScopeAnalysis {
   }
 
   @Test
-  def scopesInForEnumerators = {
+  def scopesInForEnumerators() = {
     val s = toSelection("""
       object Demo{
         for(i <- 1 to 10; j <- 1 to 10){
@@ -80,7 +80,7 @@ class ScopeAnalysisTest extends TestHelper with ScopeAnalysis {
   }
 
   @Test
-  def scopeFromCase = {
+  def scopeFromCase() = {
     val s = toSelection("""
       object Demo{
         (1, 2) match {
@@ -95,14 +95,14 @@ class ScopeAnalysisTest extends TestHelper with ScopeAnalysis {
   }
 
   @Test
-  def nestedClassScopes = {
+  def nestedClassScopes() = {
     val s = toSelection("""
       object Demo {
         def fn(p: Int) = {
           class A {
             val a = /*(*/p/*)*/
           }
-        
+
           new A.a
         }
       }
@@ -114,26 +114,26 @@ class ScopeAnalysisTest extends TestHelper with ScopeAnalysis {
   }
 
   @Test
-  def visibility = {
+  def visibility() = {
     val s = toSelection("""
       package demo
-      
+
       class A
-      
+
       object Demo{
         val m1 = {
           val hidden = 1
           hidden
         }
-        
+
         def fn = {
           val a = 1
           /*(*/a/*)*/
         }
-        
+
         val m2 = 2
       }
-        
+
       trait C
       """)
 
@@ -156,13 +156,13 @@ class ScopeAnalysisTest extends TestHelper with ScopeAnalysis {
   }
 
   @Test
-  def visibilityOfImports = {
+  def visibilityOfImports() = {
     val s = toSelection("""
       import scala.collection.mutable
-        
+
       class Demo{
         import mutable.LinkedList
-        
+
         def local = {
           import scala.math.Pi
     	  /*(*/(Pi, new LinkedList)/*)*/
@@ -185,14 +185,14 @@ class ScopeAnalysisTest extends TestHelper with ScopeAnalysis {
 
   @Test
   @Ignore("Not yet supported")
-  def visibilityOfInheritedMembers = {
+  def visibilityOfInheritedMembers() = {
     val s = toSelection("""
       trait Base{
-        val baseVal = 1  
+        val baseVal = 1
       }
-        
+
       object O extends Base {
-        def fn = /*(*/baseVal/*)*/  
+        def fn = /*(*/baseVal/*)*/
       }
       """)
 
@@ -203,18 +203,18 @@ class ScopeAnalysisTest extends TestHelper with ScopeAnalysis {
     assertTrue(innermost.sees(baseVal))
 
     val outermost = innermost.outermostScope
-    
+
     assertFalse(outermost.sees(baseVal))
   }
 
   @Test
-  def visibilityOfRenamedImport = {
+  def visibilityOfRenamedImport() = {
     val s = toSelection("""
       import scala.collection.mutable
-        
+
       class Demo{
         import mutable.{LinkedList => LL}
-        
+
         def local = {
     	  /*(*/new LL/*)*/
         }
@@ -233,13 +233,13 @@ class ScopeAnalysisTest extends TestHelper with ScopeAnalysis {
   }
 
   @Test
-  def visibilityOfWildcardImport = {
+  def visibilityOfWildcardImport() = {
     val s = toSelection("""
       import scala.collection.mutable
-        
+
       class Demo{
         import mutable._
-        
+
         def local = {
     	  /*(*/new LinkedList/*)*/
         }
@@ -257,16 +257,16 @@ class ScopeAnalysisTest extends TestHelper with ScopeAnalysis {
   }
 
   @Test
-  def scopeLookup = {
+  def scopeLookup() = {
     val s = toSelection("""
       object Demo{
         val a = 1
-        
+
         val b = {
           val l = 123
     	  /*(*/2/*)*/
         }
-        
+
     	val c = 3
       }
     """)
@@ -284,7 +284,7 @@ class ScopeAnalysisTest extends TestHelper with ScopeAnalysis {
   }
 
   @Test
-  def scopeLookupOfParams = {
+  def scopeLookupOfParams() = {
     val s = toSelection("""
       class Demo(cp: Int){
         def fn(a: Int) = {
@@ -309,7 +309,7 @@ class ScopeAnalysisTest extends TestHelper with ScopeAnalysis {
   }
 
   @Test
-  def scopeLookupOfParamsOfDesugaredFunctions = {
+  def scopeLookupOfParamsOfDesugaredFunctions() = {
     val s = toSelection("""
       object Demo{
         for(i <- 1 to 10) /*(*/println(i)/*)*/
@@ -332,7 +332,7 @@ class ScopeAnalysisTest extends TestHelper with ScopeAnalysis {
   }
 
   @Test
-  def scopeLookupInNestedClasses = {
+  def scopeLookupInNestedClasses() = {
     val s = toSelection("""
       class Outer {
         def fn(p: Int) = {
@@ -356,7 +356,7 @@ class ScopeAnalysisTest extends TestHelper with ScopeAnalysis {
   }
 
   @Test
-  def scopeLookupInNestedClasses2 = {
+  def scopeLookupInNestedClasses2() = {
     val s = toSelection("""
       class Outer {
         class Inner {
@@ -373,14 +373,14 @@ class ScopeAnalysisTest extends TestHelper with ScopeAnalysis {
       case t: Template if t != inner => true
       case _ => false
     }.get
-    
+
     val outerScope = scopes.findScopeFor(outer)
 
     assertEquals("MemberScope(Outer) -> MemberScope(<empty>)", outerScope.toString())
     assertEquals("MemberScope(Inner) -> MemberScope(Outer) -> MemberScope(<empty>)", scopes.toString())
-    
+
     val aSym = s.inboundDeps.head
-    
+
     assertTrue(scopes.sees(aSym))
     assertFalse(outerScope.sees(aSym))
   }

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/common/InsertionPositionsTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/common/InsertionPositionsTest.scala
@@ -45,7 +45,7 @@ class InsertionPositionsTest extends TestHelper with InsertionPositions with Sel
                   assertEquals(expected, actual)
                 }
 
-                def toFail = {
+                def toFail() = {
                   assertFalse(ip.isDefinedAt(scope))
                 }
               }
@@ -56,7 +56,7 @@ class InsertionPositionsTest extends TestHelper with InsertionPositions with Sel
   }
 
   @Test
-  def insertInTemplate = global.ask { () => """
+  def insertInTemplate() = global.ask { () => """
     object O{
       /*(*/def fn = println(1)/*)*/
 
@@ -75,7 +75,7 @@ class InsertionPositionsTest extends TestHelper with InsertionPositions with Sel
   }
 
   @Test
-  def insertInBlock = global.ask { () => """
+  def insertInBlock() = global.ask { () => """
     object O{
       def fn = {
         val a = 1
@@ -95,7 +95,7 @@ class InsertionPositionsTest extends TestHelper with InsertionPositions with Sel
   }
 
   @Test
-  def insertInBlockBeforeFirstDeclaration = global.ask { () => """
+  def insertInBlockBeforeFirstDeclaration() = global.ask { () => """
     object O{
       def fn = {
         /*(*/val a = 1/*)*/
@@ -115,7 +115,7 @@ class InsertionPositionsTest extends TestHelper with InsertionPositions with Sel
   }
 
   @Test
-  def insertInBlockBeforeSelectionInSubexpression = global.ask { () => """
+  def insertInBlockBeforeSelectionInSubexpression() = global.ask { () => """
     object O{
       def fn = {
         val a = 1
@@ -136,7 +136,7 @@ class InsertionPositionsTest extends TestHelper with InsertionPositions with Sel
   }
 
   @Test
-  def insertInMethodBody = global.ask { () => """
+  def insertInMethodBody() = global.ask { () => """
     object O{
       def fn(a: Int) = /*(*/println(a)/*)*/
     }
@@ -152,7 +152,7 @@ class InsertionPositionsTest extends TestHelper with InsertionPositions with Sel
   }
 
   @Test
-  def insertInFunctionBody = global.ask { () => """
+  def insertInFunctionBody() = global.ask { () => """
     object O{
       val fn = (a: Int) => /*(*/println(a)/*)*/
     }
@@ -168,7 +168,7 @@ class InsertionPositionsTest extends TestHelper with InsertionPositions with Sel
   }
 
   @Test
-  def insertInCaseBody = global.ask { () => """
+  def insertInCaseBody() = global.ask { () => """
     object O{
       val i = 1 match {
         case i: Int => /*(*/i/*)*/

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/common/OccurrencesTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/common/OccurrencesTest.scala
@@ -19,7 +19,7 @@ class OccurrencesTest extends TestHelper with GlobalIndexes with Occurrences {
   }
 
   @Test
-  def termOccurrences = {
+  def termOccurrences() = {
     val src = """
       object O{
         def fn = {
@@ -42,11 +42,11 @@ class OccurrencesTest extends TestHelper with GlobalIndexes with Occurrences {
 
   @Test
   @Ignore("fails because of issue https://www.assembla.com/spaces/scala-refactoring/tickets/83")
-  def accessorNameOccurrences = {
+  def accessorNameOccurrences() = {
     val src = """
       object O{
         val field = 1
-      
+
         def fn = 2 * field
       }
       """
@@ -60,7 +60,7 @@ class OccurrencesTest extends TestHelper with GlobalIndexes with Occurrences {
 
   @Test
   @Ignore("fails because of issue https://www.assembla.com/spaces/scala-refactoring/tickets/83")
-  def paramsOccurrences = {
+  def paramsOccurrences() = {
     val src = """
       object O{
         def fn(a: Int, b: Int) = {

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/common/PimpedTreesTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/common/PimpedTreesTest.scala
@@ -69,7 +69,7 @@ class PimpedTreesTest extends TestHelper with PimpedTrees {
   }
 
   @Test
-  def namePositionOfFieldAccessor = {
+  def namePositionOfFieldAccessor() = {
     val src = """
     object O{
       val field = 1

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/common/SelectionDependenciesTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/common/SelectionDependenciesTest.scala
@@ -17,7 +17,7 @@ class SelectionDependenciesTest extends TestHelper with Selections {
   }
 
   @Test
-  def inboundDeps = {
+  def inboundDeps() = {
     val sel = """
       object O{
         val i = 1
@@ -32,7 +32,7 @@ class SelectionDependenciesTest extends TestHelper with Selections {
   }
 
   @Test
-  def inboundDepsDoesNotIncludeCalledMethods = {
+  def inboundDepsDoesNotIncludeCalledMethods() = {
     val sel = """
       object O{
         val i = 1
@@ -44,7 +44,7 @@ class SelectionDependenciesTest extends TestHelper with Selections {
   }
 
   @Test
-  def inboundDepsIncludesMethodArguments = {
+  def inboundDepsIncludesMethodArguments() = {
     val sel = """
       object O{
         def fn(i: Int) = /*(*/8.*(i)/*)*/
@@ -54,7 +54,7 @@ class SelectionDependenciesTest extends TestHelper with Selections {
   }
 
   @Test
-  def inboundDepsDoesNotIncludeMembersOfLiterals = {
+  def inboundDepsDoesNotIncludeMembersOfLiterals() = {
     val sel = """
       object O{
         /*(*/
@@ -67,13 +67,13 @@ class SelectionDependenciesTest extends TestHelper with Selections {
   }
 
   @Test
-  def inboundImplicitDeps = {
+  def inboundImplicitDeps() = {
     val sel = """
       object O{
         implicit def wrapInt(i: Int) = new {
           def extension = i * 2
         }
-      
+
         val i = /*(*/2.extension/*)*/
       }
       """.selection
@@ -81,14 +81,14 @@ class SelectionDependenciesTest extends TestHelper with Selections {
   }
 
   @Test
-  def inboundTypeDeps = {
+  def inboundTypeDeps() = {
     val sel = """
       class A(i: Int)
-      
+
       object N{
         def apply() = 1
       }
-      
+
       object O{
         val i = 1
         def fn = {
@@ -100,12 +100,12 @@ class SelectionDependenciesTest extends TestHelper with Selections {
   }
 
   @Test
-  def inboundTypeDepsByOwner = {
+  def inboundTypeDepsByOwner() = {
     val sel = """
       object N{
         def apply() = 1
       }
-      
+
       object O{
         val i = 1
         def fn = {
@@ -118,7 +118,7 @@ class SelectionDependenciesTest extends TestHelper with Selections {
   }
 
   @Test
-  def inboundDepsOfWildcardsInMatch = {
+  def inboundDepsOfWildcardsInMatch() = {
     val sel = """
       object O{
         /*(*/1 match{
@@ -130,12 +130,12 @@ class SelectionDependenciesTest extends TestHelper with Selections {
   }
 
   @Test
-  def inboundDepsOfImported = {
+  def inboundDepsOfImported() = {
     val sel = """
       object O{
         import scala.math.Pi
     	import scala.collection.mutable
-      
+
     	/*(*/(Pi, new mutable.LinkedList)/*)*/
       }
       """.selection
@@ -143,7 +143,7 @@ class SelectionDependenciesTest extends TestHelper with Selections {
   }
 
   @Test
-  def outboundLocalDeps = {
+  def outboundLocalDeps() = {
     val sel = """
       object O{
         def fn(p: Int) = {
@@ -157,7 +157,7 @@ class SelectionDependenciesTest extends TestHelper with Selections {
   }
 
   @Test
-  def noOutboundLocalDeps = {
+  def noOutboundLocalDeps() = {
     val sel = """
       object O{
         def fn(c: Int) = {
@@ -173,7 +173,7 @@ class SelectionDependenciesTest extends TestHelper with Selections {
   }
 
   @Test
-  def outboundDepsInParameterLists = {
+  def outboundDepsInParameterLists() = {
     val sel = """
       object O{
         def fn(/*(*/c: Int, d: Int/*)*/) = {
@@ -185,7 +185,7 @@ class SelectionDependenciesTest extends TestHelper with Selections {
   }
 
   @Test
-  def outboundDepsInTemplateScope = {
+  def outboundDepsInTemplateScope() = {
     val sel = """
       object O{
         def fn = fm
@@ -196,9 +196,9 @@ class SelectionDependenciesTest extends TestHelper with Selections {
       """.selection
     assertEquals("method fm, method fo", sel.outboundLocalDeps.mkString(", "))
   }
-  
+
   @Test
-  def outboundDepsOfVars = {
+  def outboundDepsOfVars() = {
     val sel = """
       object O{
         def fn = {
@@ -213,7 +213,7 @@ class SelectionDependenciesTest extends TestHelper with Selections {
   }
 
   @Test
-  def outboundImportedDeps = {
+  def outboundImportedDeps() = {
     val sel = """
       object O{
         def fn = {
@@ -226,7 +226,7 @@ class SelectionDependenciesTest extends TestHelper with Selections {
   }
 
   @Test
-  def reassignedVariablesAsOutboundDeps = {
+  def reassignedVariablesAsOutboundDeps() = {
     val sel = """
       object O{
         def fn = {

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/common/SelectionExpansionsTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/common/SelectionExpansionsTest.scala
@@ -9,7 +9,7 @@ class SelectionExpansionsTest extends TestHelper with Selections {
   import global._
 
   @Test
-  def expandSelectionToBlock =
+  def expandSelectionToBlock() =
     """
     class C{
       def fn = {
@@ -35,7 +35,7 @@ class SelectionExpansionsTest extends TestHelper with Selections {
     }
 
   @Test
-  def expandSelectionInForEnumerator =
+  def expandSelectionInForEnumerator() =
     """
     class C{
       for{
@@ -45,7 +45,7 @@ class SelectionExpansionsTest extends TestHelper with Selections {
     """.assertExpansion(_.expandTo[Tree].get).toRemain
 
   @Test
-  def expandSelectionInYield =
+  def expandSelectionInYield() =
     """
     class C{
       for{
@@ -55,7 +55,7 @@ class SelectionExpansionsTest extends TestHelper with Selections {
     """.assertExpansion(_.expandTo[Tree].get).toRemain
 
   @Test
-  def expandWithLastTreePartiallySelected =
+  def expandWithLastTreePartiallySelected() =
     """
     class C{
       val first = 1
@@ -83,7 +83,7 @@ class SelectionExpansionsTest extends TestHelper with Selections {
     }
 
   @Test
-  def expandWithFirstTreePartiallySelected =
+  def expandWithFirstTreePartiallySelected() =
     """
     class C{
       def fn = {
@@ -107,7 +107,7 @@ class SelectionExpansionsTest extends TestHelper with Selections {
     }
 
   @Test
-  def expandValidSelection =
+  def expandValidSelection() =
     """
     class C{
       val a = /*(*/1/*)*/
@@ -115,7 +115,7 @@ class SelectionExpansionsTest extends TestHelper with Selections {
     """.assertExpansion(_.expand).toRemain
 
   @Test
-  def expandValidSelectionOfBlock =
+  def expandValidSelectionOfBlock() =
     """
     class C{
       val a = /*(*/{
@@ -126,7 +126,7 @@ class SelectionExpansionsTest extends TestHelper with Selections {
     """.assertExpansion(_.expand).toRemain
 
   @Test
-  def expandMethodCalls =
+  def expandMethodCalls() =
     """
     class C{
       val s = "abc"
@@ -142,7 +142,7 @@ class SelectionExpansionsTest extends TestHelper with Selections {
     }
 
   @Test
-  def expandPartiallySelectedMethodDefinitions1 =
+  def expandPartiallySelectedMethodDefinitions1() =
     """
     class C{
       def /*(*/fn(i: Int) = {
@@ -160,7 +160,7 @@ class SelectionExpansionsTest extends TestHelper with Selections {
     }
 
   @Test
-  def expandPartiallySelectedMethodDefinitions2 =
+  def expandPartiallySelectedMethodDefinitions2() =
     """
     class C{
       def /*(*/fn(i: Int) = {
@@ -178,7 +178,7 @@ class SelectionExpansionsTest extends TestHelper with Selections {
     }
 
   @Test
-  def expandPartiallySelectedMethodDefinitions3 =
+  def expandPartiallySelectedMethodDefinitions3() =
     """
     class C{
       def /*(*/fn = {
@@ -196,7 +196,7 @@ class SelectionExpansionsTest extends TestHelper with Selections {
     }
 
   @Test
-  def expandPartiallySelectedIf =
+  def expandPartiallySelectedIf() =
     """
     class C{
       if(/*(*/true)
@@ -216,7 +216,7 @@ class SelectionExpansionsTest extends TestHelper with Selections {
     }
 
   @Test
-  def expandPartiallySelectedMatch =
+  def expandPartiallySelectedMatch() =
     """
     class C{
       1 match{
@@ -236,7 +236,7 @@ class SelectionExpansionsTest extends TestHelper with Selections {
     }
 
   @Test
-  def expandSelectedPatternWithGuard =
+  def expandSelectedPatternWithGuard() =
     """
     class C{
       1 match{
@@ -254,7 +254,7 @@ class SelectionExpansionsTest extends TestHelper with Selections {
     }
 
   @Test
-  def expandAnonFunWithWildcardParam =
+  def expandAnonFunWithWildcardParam() =
     """
     class C{
       List(1).map(/*(*/_ + 1/*)*/)
@@ -271,7 +271,7 @@ class SelectionExpansionsTest extends TestHelper with Selections {
     }
 
   @Test
-  def expandEmptySelection =
+  def expandEmptySelection() =
     """
     object O{
       1/*(*//*)*/
@@ -285,7 +285,7 @@ class SelectionExpansionsTest extends TestHelper with Selections {
     }
 
   @Test
-  def expandEmptySelectionWithinTree =
+  def expandEmptySelectionWithinTree() =
     """
     object O{
       123/*(*//*)*/
@@ -324,7 +324,7 @@ class SelectionExpansionsTest extends TestHelper with Selections {
             }
           }
 
-          def toRemain = toBecome(src)
+          def toRemain() = toBecome(src)
         }
       }
     }
@@ -334,7 +334,7 @@ class SelectionExpansionsTest extends TestHelper with Selections {
     new Selection {
       val root = s.root
       val file = s.file
-      val pos = 
-        new RangePosition(s.pos.source, s.pos.start + dStart, s.pos.point, s.pos.end + dEnd) 
+      val pos =
+        new RangePosition(s.pos.source, s.pos.start + dStart, s.pos.point, s.pos.end + dEnd)
     }
 }

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/common/SelectionPropertiesTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/common/SelectionPropertiesTest.scala
@@ -18,7 +18,7 @@ class SelectionPropertiesTest extends TestHelper with Selections {
   }
 
   @Test
-  def representsValue = {
+  def representsValue() = {
     val sel = """
       object O{
         def fn = {
@@ -31,7 +31,7 @@ class SelectionPropertiesTest extends TestHelper with Selections {
   }
 
   @Test
-  def doesNotRepresentValue = {
+  def doesNotRepresentValue() = {
     val sel = """
       object O{
         def fn = {
@@ -42,30 +42,30 @@ class SelectionPropertiesTest extends TestHelper with Selections {
       """.selection
     assertFalse(sel.representsValue)
   }
-  
+
   @Test
-  def nonValuePatternsDoNotRepresentValues = {
+  def nonValuePatternsDoNotRepresentValues() = {
     val selWildcard = """object O { 1 match { case /*(*/_/*)*/ => () } }""".selection
     assertFalse(selWildcard.representsValue)
-    
+
     val selCtorPattern = """object O { Some(1) match { case /*(*/Some(i)/*)*/ => () } }""".selection
     assertFalse(selCtorPattern.representsValue)
-    
+
     val selBinding =  """object O { 1 match { case /*(*/i: Int/*)*/ => i } }""".selection
     assertFalse(selBinding.representsValue)
-    
+
     val selPatAndGuad = """object O { 1 match { case /*(*/i if i > 10/*)*/ => i } }""".selection
     assertFalse(selPatAndGuad.representsValue)
   }
-  
+
   @Test
-  def valuePatternsDoRepresentValues = {
+  def valuePatternsDoRepresentValues() = {
     val selCtorPattern = """object O { Some(1) match { case /*(*/Some(1)/*)*/ => () } }""".selection
     assertTrue(selCtorPattern.representsValue)
   }
 
   @Test
-  def argumentLists = {
+  def argumentLists() = {
     val sel = """
       object O{
         def fn = {
@@ -79,7 +79,7 @@ class SelectionPropertiesTest extends TestHelper with Selections {
   }
 
   @Test
-  def parameter = {
+  def parameter() = {
     val sel = """
       object O{
         def fn(/*(*/a: Int/*)*/) = {
@@ -93,7 +93,7 @@ class SelectionPropertiesTest extends TestHelper with Selections {
   }
 
   @Test
-  def multipleParameters = {
+  def multipleParameters() = {
     val sel = """
       object O{
         def fn(/*(*/a: Int, b: Int/*)*/) = {
@@ -107,7 +107,7 @@ class SelectionPropertiesTest extends TestHelper with Selections {
   }
 
   @Test
-  def triggersSideEffects = {
+  def triggersSideEffects() = {
     val sel = """
       object O{
         var a = 1

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/AddMethodTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/AddMethodTest.scala
@@ -24,7 +24,7 @@ class AddMethodTest extends TestHelper {
   }
 
   @Test
-  def addMethodToObject = {
+  def addMethodToObject() = {
     addMethod("Main", "method", Nil, None, AddToObject, """
 class Main
 object Main {
@@ -40,7 +40,7 @@ object Main {
   }
 
   @Test
-  def addMethodToClass = {
+  def addMethodToClass() = {
     addMethod("Main", "method", Nil, None, AddToClass, """
 object Main
 class Main {
@@ -58,7 +58,7 @@ class Main {
   }
 
   @Test
-  def addMethodWithParametersAndReturnType = {
+  def addMethodWithParametersAndReturnType() = {
     addMethod("Main", "method", List(List("a" -> "Any", "b" -> "Int"), List("c" -> "Double")), Some("String"), AddToClass, "class Main",
       """class Main {
   def method(a: Any, b: Int)(c: Double): String = {
@@ -68,7 +68,7 @@ class Main {
   }
 
   @Test
-  def addMethodToInnerClass = {
+  def addMethodToInnerClass() = {
     addMethod("Inner", "method", Nil, None, AddToClass, """
 class Main {
   class Inner
@@ -84,7 +84,7 @@ class Main {
   }
 
   @Test
-  def addMethodToCaseClass = {
+  def addMethodToCaseClass() = {
     addMethod("Main", "method", Nil, None, AddToClass, """
 case class Main""",
       """
@@ -96,7 +96,7 @@ case class Main {
   }
 
   @Test
-  def addMethodToTrait = {
+  def addMethodToTrait() = {
     addMethod("Main", "method", Nil, None, AddToClass, """
 trait Main""",
       """
@@ -108,7 +108,7 @@ trait Main {
   }
 
   @Test
-  def addMethodByClosestPosition = {
+  def addMethodByClosestPosition() = {
     addMethod("Main", "method", Nil, None, AddToClosest(30), """
 class Main {
 

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/ChangeParamOrderTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/ChangeParamOrderTest.scala
@@ -15,7 +15,7 @@ class ChangeParamOrderTest extends TestHelper with TestRefactoring {
   }.changes
 
   @Test
-  def exchangeTwoParams = new FileSet {
+  def exchangeTwoParams() = new FileSet {
     """
       package changeParamOrder.exchangeTwoParamsTest
       class Foo {
@@ -31,7 +31,7 @@ class ChangeParamOrderTest extends TestHelper with TestRefactoring {
   } applyRefactoring(changeParamOrder(List(1::0::Nil)))
 
   @Test
-  def multipleParameterLists = new FileSet {
+  def multipleParameterLists() = new FileSet {
     """
       package changeParamOrder.multipleParameterLists
       class Foo {
@@ -53,7 +53,7 @@ class ChangeParamOrderTest extends TestHelper with TestRefactoring {
   } applyRefactoring(changeParamOrder(List(1::0::2::Nil, 1::0::2::Nil)))
 
   @Test
-  def methodCall = new FileSet {
+  def methodCall() = new FileSet {
     """
       package changeParamOrder.methodCall
       class Defining {
@@ -77,7 +77,7 @@ class ChangeParamOrderTest extends TestHelper with TestRefactoring {
   } applyRefactoring(changeParamOrder(List(1::0::2::Nil)))
 
   @Test
-  def methodCallMultipleParamLists = new FileSet {
+  def methodCallMultipleParamLists() = new FileSet {
     """
       package changeParamOrder.methodCallMultipleParamLists
       class Defining {
@@ -101,7 +101,7 @@ class ChangeParamOrderTest extends TestHelper with TestRefactoring {
   } applyRefactoring(changeParamOrder(List(1::0::2::Nil, 1::2::0::3::Nil)))
 
   @Test
-  def partialMethod = new FileSet {
+  def partialMethod() = new FileSet {
     """
       package changeParamOrder.partialMethod
       class A {
@@ -121,7 +121,7 @@ class ChangeParamOrderTest extends TestHelper with TestRefactoring {
   } applyRefactoring(changeParamOrder(List(1::0::Nil)))
 
   @Test
-  def curriedPartialMethod = new FileSet {
+  def curriedPartialMethod() = new FileSet {
     """
       package changeParamOrder.curriedPartialMethod
       class A {
@@ -141,7 +141,7 @@ class ChangeParamOrderTest extends TestHelper with TestRefactoring {
   } applyRefactoring(changeParamOrder(List(1::0::Nil, 0::2::1::Nil)))
 
   @Test
-  def partialsWithBody = new FileSet {
+  def partialsWithBody() = new FileSet {
     """
     package changeParamOrder.partialsWithBody
     class A {
@@ -183,7 +183,7 @@ class ChangeParamOrderTest extends TestHelper with TestRefactoring {
   } applyRefactoring(changeParamOrder(List(1::0::Nil, 1::2::0::Nil, 1::2::0::Nil, 1::0::Nil)))
 
   @Test
-  def partialValsWithBody = new FileSet {
+  def partialValsWithBody() = new FileSet {
     """
     package changeParamOrder.partialValsWithBody
     class A {
@@ -225,7 +225,7 @@ class ChangeParamOrderTest extends TestHelper with TestRefactoring {
   } applyRefactoring(changeParamOrder(List(1::0::Nil, 1::2::0::Nil, 1::2::0::Nil, 1::0::Nil)))
 
   @Test
-  def curriedMethodCall = new FileSet {
+  def curriedMethodCall() = new FileSet {
     """
       package changeParamOrder.curriedMethodCall
       class Defining {
@@ -253,7 +253,7 @@ class ChangeParamOrderTest extends TestHelper with TestRefactoring {
   } applyRefactoring(changeParamOrder(List(1::0::2::Nil, 1::2::0::3::Nil)))
 
   @Test
-  def repeatedlyPartiallyApplied = new FileSet {
+  def repeatedlyPartiallyApplied() = new FileSet {
     """
       package changeParamOrder.repeatedlyPartiallyApplied
       class A {
@@ -275,7 +275,7 @@ class ChangeParamOrderTest extends TestHelper with TestRefactoring {
   } applyRefactoring(changeParamOrder(List(1::0::Nil, 0::2::1::Nil, 2::1::0::Nil)))
 
   @Test
-  def aliasToVal = new FileSet {
+  def aliasToVal() = new FileSet {
     """
       package changeParamOrder.aliasToVal
       class A {
@@ -295,7 +295,7 @@ class ChangeParamOrderTest extends TestHelper with TestRefactoring {
   } applyRefactoring(changeParamOrder(List(1::0::Nil, 0::2::1::Nil)))
 
   @Test
-  def partiallyAppliedVal = new FileSet {
+  def partiallyAppliedVal() = new FileSet {
     """
       package changeParamOrder.partiallyAppliedVal
       class A {
@@ -315,7 +315,7 @@ class ChangeParamOrderTest extends TestHelper with TestRefactoring {
   } applyRefactoring(changeParamOrder(List(1::0::Nil, 0::2::1::Nil, 2::1::0::Nil)))
 
   @Test
-  def repeatedlyPartiallyAppliedVal = new FileSet {
+  def repeatedlyPartiallyAppliedVal() = new FileSet {
     """
       package changeParamOrder.repeatedlyPartiallyAppliedVal
       class A {
@@ -337,7 +337,7 @@ class ChangeParamOrderTest extends TestHelper with TestRefactoring {
   } applyRefactoring(changeParamOrder(List(1::0::Nil, 0::2::1::Nil, 2::1::0::Nil)))
 
   @Test
-  def changeParamOrderSubclass = new FileSet {
+  def changeParamOrderSubclass() = new FileSet {
     """
       package changeParamOrder.subclass
       class Parent {
@@ -361,7 +361,7 @@ class ChangeParamOrderTest extends TestHelper with TestRefactoring {
   } applyRefactoring(changeParamOrder(List(1::0::2::Nil)))
 
   @Test
-  def changeParamOrderSuperclass = new FileSet {
+  def changeParamOrderSuperclass() = new FileSet {
     """
       package changeParamOrder.superclass
       class Parent {
@@ -385,7 +385,7 @@ class ChangeParamOrderTest extends TestHelper with TestRefactoring {
   } applyRefactoring(changeParamOrder(List(1::0::2::Nil)))
 
   @Test
-  def changeParamOrderSuperClassCall = new FileSet {
+  def changeParamOrderSuperClassCall() = new FileSet {
     """
       package changeParamOrder.superClassCall
       class Parent {
@@ -409,7 +409,7 @@ class ChangeParamOrderTest extends TestHelper with TestRefactoring {
   } applyRefactoring(changeParamOrder(List(1::0::2::Nil)))
 
   @Test(expected=classOf[RefactoringException])
-  def invalidPermutation = new FileSet {
+  def invalidPermutation() = new FileSet {
     """
     package changeParamOrder.invalidPermutation
     class Foo {
@@ -422,7 +422,7 @@ class ChangeParamOrderTest extends TestHelper with TestRefactoring {
   } applyRefactoring(changeParamOrder(List(1::0::Nil, 1::0::3::Nil, 0::1::Nil)))
 
   @Test
-  def partiallyAppliedMethodUsage = new FileSet {
+  def partiallyAppliedMethodUsage() = new FileSet {
     """
       package splitParameterLists.partiallyAppliedMethodUsage
       class A {
@@ -442,7 +442,7 @@ class ChangeParamOrderTest extends TestHelper with TestRefactoring {
   } applyRefactoring(changeParamOrder(List(1::0::Nil, 0::2::1::Nil)))
 
   @Test
-  def partiallyAppliedMethodUsage2 = new FileSet {
+  def partiallyAppliedMethodUsage2() = new FileSet {
     """
       package splitParameterLists.partiallyAppliedMethodUsage2
       class A {

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/EliminateMatchTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/EliminateMatchTest.scala
@@ -26,7 +26,7 @@ class EliminateMatchTest extends TestHelper with TestRefactoring {
   val none = None: Option[String]
 
   @Test
-  def eliminateOptionMap {
+  def eliminateOptionMap() {
 
     def f1(x: Option[String]) = x match {
       case Some(s) => Some(s * 2)
@@ -40,7 +40,7 @@ class EliminateMatchTest extends TestHelper with TestRefactoring {
   }
 
   @Test
-  def eliminateOptionExists {
+  def eliminateOptionExists() {
 
     def f1(x: Option[String]) = x match {
       case Some(s) => s contains "a"
@@ -54,7 +54,7 @@ class EliminateMatchTest extends TestHelper with TestRefactoring {
   }
 
   @Test
-  def eliminateOptionIsDefined {
+  def eliminateOptionIsDefined() {
 
     def f1(x: Option[String]) = x match {
       case Some(_) => true
@@ -68,7 +68,7 @@ class EliminateMatchTest extends TestHelper with TestRefactoring {
   }
 
   @Test
-  def eliminateOptionForeach {
+  def eliminateOptionForeach() {
 
     var x1 = 0
     var x2 = 0
@@ -87,7 +87,7 @@ class EliminateMatchTest extends TestHelper with TestRefactoring {
   }
 
   @Test
-  def eliminateIsDefined = new FileSet {
+  def eliminateIsDefined() = new FileSet {
     """
     object EliminiateWithoutSelection {
       def f1(x: Option[String]) = x /*(*/ match /*)*/ {
@@ -104,7 +104,7 @@ class EliminateMatchTest extends TestHelper with TestRefactoring {
   } applyRefactoring(elim)
 
   @Test
-  def flatMapElimination = new FileSet {
+  def flatMapElimination() = new FileSet {
     """
       package elimination
       object EliminateMap {
@@ -125,7 +125,7 @@ class EliminateMatchTest extends TestHelper with TestRefactoring {
   } applyRefactoring(elim)
 
   @Test
-  def flatMapElimination2 = new FileSet {
+  def flatMapElimination2() = new FileSet {
     """
       package elimination
       object EliminateMap {
@@ -146,7 +146,7 @@ class EliminateMatchTest extends TestHelper with TestRefactoring {
   } applyRefactoring(elim)
 
   @Test
-  def simpleExistsElimination = new FileSet {
+  def simpleExistsElimination() = new FileSet {
     """
       package elimination
       object EliminateMap {
@@ -165,7 +165,7 @@ class EliminateMatchTest extends TestHelper with TestRefactoring {
   } applyRefactoring(elim)
 
   @Test
-  def isDefinedElimination = new FileSet {
+  def isDefinedElimination() = new FileSet {
     """
       package elimination
       object EliminateMap {
@@ -184,7 +184,7 @@ class EliminateMatchTest extends TestHelper with TestRefactoring {
   } applyRefactoring(elim)
 
   @Test
-  def existsEliminationDifferentOrder = new FileSet {
+  def existsEliminationDifferentOrder() = new FileSet {
     """
       package elimination
       object EliminateMap {
@@ -203,7 +203,7 @@ class EliminateMatchTest extends TestHelper with TestRefactoring {
   } applyRefactoring(elim)
 
   @Test // TODO: could be more beautiful
-  def existsEliminationWithBody = new FileSet {
+  def existsEliminationWithBody() = new FileSet {
     """
       package elimination
       object EliminateMap {
@@ -237,7 +237,7 @@ class EliminateMatchTest extends TestHelper with TestRefactoring {
   } applyRefactoring(elim)
 
   @Test
-  def mapEliminationSimple = new FileSet {
+  def mapEliminationSimple() = new FileSet {
     """
       package elimination
       object EliminateMap {
@@ -256,7 +256,7 @@ class EliminateMatchTest extends TestHelper with TestRefactoring {
   } applyRefactoring(elim)
 
   @Test
-  def mapEliminationNoneSome = new FileSet {
+  def mapEliminationNoneSome() = new FileSet {
     """
       package elimination
       object EliminateMap {
@@ -275,7 +275,7 @@ class EliminateMatchTest extends TestHelper with TestRefactoring {
   } applyRefactoring(elim)
 
   @Test
-  def mapEliminationNoCapture = new FileSet {
+  def mapEliminationNoCapture() = new FileSet {
     """
       package elimination
       object EliminateMap {
@@ -294,7 +294,7 @@ class EliminateMatchTest extends TestHelper with TestRefactoring {
   } applyRefactoring(elim)
 
   @Test
-  def mapEliminationNoNone = new FileSet {
+  def mapEliminationNoNone() = new FileSet {
     """
       package elimination
       object EliminateMap {
@@ -313,7 +313,7 @@ class EliminateMatchTest extends TestHelper with TestRefactoring {
   } applyRefactoring(elim)
 
   @Test
-  def mapEliminationWithChainedCall = new FileSet {
+  def mapEliminationWithChainedCall() = new FileSet {
     """
       package elimination
       object EliminateMap {
@@ -332,7 +332,7 @@ class EliminateMatchTest extends TestHelper with TestRefactoring {
   } applyRefactoring(elim)
 
   @Test
-  def mapEliminationWithBlock = new FileSet {
+  def mapEliminationWithBlock() = new FileSet {
     """
       package elimination
       object EliminateMap {
@@ -359,7 +359,7 @@ class EliminateMatchTest extends TestHelper with TestRefactoring {
   } applyRefactoring(elim)
 
   @Test
-  def foreachEliminationWithExplicitUnit = new FileSet {
+  def foreachEliminationWithExplicitUnit() = new FileSet {
     """
       package elimination
       object EliminateMap {
@@ -380,7 +380,7 @@ class EliminateMatchTest extends TestHelper with TestRefactoring {
   } applyRefactoring(elim)
 
   @Test
-  def foreachEliminationWithUnit = new FileSet {
+  def foreachEliminationWithUnit() = new FileSet {
     """
       package elimination
       object EliminateMap {
@@ -401,7 +401,7 @@ class EliminateMatchTest extends TestHelper with TestRefactoring {
   } applyRefactoring(elim)
 
   @Test
-  def flattenElimination = new FileSet {
+  def flattenElimination() = new FileSet {
     """
       package elimination
       object EliminateMap {
@@ -422,7 +422,7 @@ class EliminateMatchTest extends TestHelper with TestRefactoring {
   } applyRefactoring(elim)
 
   @Test
-  def isEmptyElimination = new FileSet {
+  def isEmptyElimination() = new FileSet {
     """
       package elimination
       object EliminateMap {
@@ -443,7 +443,7 @@ class EliminateMatchTest extends TestHelper with TestRefactoring {
   } applyRefactoring(elim)
 
   @Test
-  def forallElimination = new FileSet {
+  def forallElimination() = new FileSet {
     """
       package elimination
       object EliminateMap {
@@ -464,7 +464,7 @@ class EliminateMatchTest extends TestHelper with TestRefactoring {
   } applyRefactoring(elim)
 
   @Test
-  def orElseElimination = new FileSet {
+  def orElseElimination() = new FileSet {
     """
       package elimination
       object EliminateMap {
@@ -485,7 +485,7 @@ class EliminateMatchTest extends TestHelper with TestRefactoring {
   } applyRefactoring(elim)
 
   @Test
-  def orElseEliminationAlt = new FileSet {
+  def orElseEliminationAlt() = new FileSet {
     """
       package elimination
       object EliminateMap {
@@ -508,7 +508,7 @@ class EliminateMatchTest extends TestHelper with TestRefactoring {
   } applyRefactoring(elim)
 
   @Test
-  def getOrElseElimination = new FileSet {
+  def getOrElseElimination() = new FileSet {
     """
       package elimination
       object EliminateMap {
@@ -529,7 +529,7 @@ class EliminateMatchTest extends TestHelper with TestRefactoring {
   } applyRefactoring(elim)
 
   @Test
-  def toListElimination = new FileSet {
+  def toListElimination() = new FileSet {
     """
       package elimination
       object EliminateMap {
@@ -550,7 +550,7 @@ class EliminateMatchTest extends TestHelper with TestRefactoring {
   } applyRefactoring(elim)
 
   @Test
-  def toListEliminationAlt = new FileSet {
+  def toListEliminationAlt() = new FileSet {
     """
       package elimination
       object EliminateMap {
@@ -571,7 +571,7 @@ class EliminateMatchTest extends TestHelper with TestRefactoring {
   } applyRefactoring(elim)
 
   @Test
-  def foreachInBlock = new FileSet {
+  def foreachInBlock() = new FileSet {
     """
       package elimination
       object EliminateMap {
@@ -614,7 +614,7 @@ class EliminateMatchTest extends TestHelper with TestRefactoring {
   } applyRefactoring(elim)
 
   @Test(expected=classOf[PreparationException])
-  def cannotEliminateWithBinding = new FileSet {
+  def cannotEliminateWithBinding() = new FileSet {
     """
       package elimination
       object EliminateMap {

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/ExpandCaseClassBindingTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/ExpandCaseClassBindingTest.scala
@@ -21,7 +21,7 @@ class ExpandCaseClassBindingTest extends TestHelper with TestRefactoring {
   }.changes
 
   @Test
-  def expandSome = new FileSet {
+  def expandSome() = new FileSet {
     """
       package extractLocal
       object Demo {
@@ -41,7 +41,7 @@ class ExpandCaseClassBindingTest extends TestHelper with TestRefactoring {
   } applyRefactoring(expand)
 
   @Test
-  def expandSomeWithReference = new FileSet {
+  def expandSomeWithReference() = new FileSet {
     """
       package extractLocal
       object Demo {
@@ -61,7 +61,7 @@ class ExpandCaseClassBindingTest extends TestHelper with TestRefactoring {
   } applyRefactoring(expand)
 
   @Test
-  def expandWithMultipleParams = new FileSet {
+  def expandWithMultipleParams() = new FileSet {
     """
       package expandWithMultipleParams
       case class Abc(a: String, b: Int, c: Double)
@@ -83,7 +83,7 @@ class ExpandCaseClassBindingTest extends TestHelper with TestRefactoring {
   } applyRefactoring(expand)
 
   @Test
-  def expandTuple = new FileSet {
+  def expandTuple() = new FileSet {
     """
       object Demo {
         ("", 5, 5.0) match {
@@ -101,7 +101,7 @@ class ExpandCaseClassBindingTest extends TestHelper with TestRefactoring {
   } applyRefactoring(expand)
 
   @Test
-  def expandNested = new FileSet {
+  def expandNested() = new FileSet {
     """
       case class Pair[T, U](first: T, second: U)
       object Demo {
@@ -121,7 +121,7 @@ class ExpandCaseClassBindingTest extends TestHelper with TestRefactoring {
   } applyRefactoring(expand)
 
   @Test
-  def expandInnerNested = new FileSet {
+  def expandInnerNested() = new FileSet {
     """
       case class Pair[T, U](first: T, second: U)
       object Demo {
@@ -141,7 +141,7 @@ class ExpandCaseClassBindingTest extends TestHelper with TestRefactoring {
   } applyRefactoring(expand)
 
   @Test(expected=classOf[PreparationException])
-  def illegalExpansion = new FileSet {
+  def illegalExpansion() = new FileSet {
     """
       package illegalExpansion
       object /*(*/Xy/*)*/ {

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/ExplicitGettersSettersTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/ExplicitGettersSettersTest.scala
@@ -23,7 +23,7 @@ class ExplicitGettersSettersTest extends TestHelper with TestRefactoring {
   }.changes
 
   @Test
-  def oneVarFromMany = new FileSet {
+  def oneVarFromMany() = new FileSet {
     """
       package oneFromMany
       class Demo(val a: String,  /*(*/var i: Int/*)*/  ) {
@@ -46,7 +46,7 @@ class ExplicitGettersSettersTest extends TestHelper with TestRefactoring {
   } applyRefactoring(explicitGettersSetters)
 
   @Test
-  def oneValFromMany = new FileSet {
+  def oneValFromMany() = new FileSet {
     """
       package oneFromMany
       class Demo(val a: String,  /*(*/val i: Int/*)*/  ) {
@@ -66,7 +66,7 @@ class ExplicitGettersSettersTest extends TestHelper with TestRefactoring {
   } applyRefactoring(explicitGettersSetters)
 
   @Test
-  def singleVal = new FileSet {
+  def singleVal() = new FileSet {
     """
       package oneFromMany
       class Demo(  /*(*/val i: Int/*)*/  )
@@ -82,7 +82,7 @@ class ExplicitGettersSettersTest extends TestHelper with TestRefactoring {
   } applyRefactoring(explicitGettersSetters)
 
   @Test
-  def singleValWithEmptyBody = new FileSet {
+  def singleValWithEmptyBody() = new FileSet {
     """
       package oneFromMany
       class Demo(  /*(*/val i: Int/*)*/  ) {

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/ExtractLocalTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/ExtractLocalTest.scala
@@ -23,7 +23,7 @@ class ExtractLocalTest extends TestHelper with TestRefactoring {
   }
 
   @Test
-  def extracPartOfChainedCalls = new FileSet {
+  def extracPartOfChainedCalls() = new FileSet {
     """
       package extractLocal
       object Demo {
@@ -46,7 +46,7 @@ class ExtractLocalTest extends TestHelper with TestRefactoring {
   } applyRefactoring(extract("asList"))
 
   @Test
-  def extractIfCond = new FileSet {
+  def extractIfCond() = new FileSet {
     """
       package extractLocal
       object Demo {
@@ -73,7 +73,7 @@ class ExtractLocalTest extends TestHelper with TestRefactoring {
   } applyRefactoring(extract("isMacOs"))
 
   @Test
-  def extractLocal = new FileSet {
+  def extractLocal() = new FileSet {
     """
       package extractLocal
       object Demo {
@@ -100,7 +100,7 @@ class ExtractLocalTest extends TestHelper with TestRefactoring {
   } applyRefactoring(extract("gr"))
 
   @Test
-  def extractFromElseWithoutParens = new FileSet {
+  def extractFromElseWithoutParens() = new FileSet {
     """
       package extractLocal
       object Demo {
@@ -138,7 +138,7 @@ class ExtractLocalTest extends TestHelper with TestRefactoring {
   } applyRefactoring(extract("sum"))
 
   @Test
-  def extractValRhs = new FileSet {
+  def extractValRhs() = new FileSet {
     """
       object Demo {
         def update(platform: String) {
@@ -157,7 +157,7 @@ class ExtractLocalTest extends TestHelper with TestRefactoring {
   } applyRefactoring(extract("plt"))
 
   @Test
-  def extractValRhs2 = new FileSet {
+  def extractValRhs2() = new FileSet {
     """
       class Extr {
         def update(platform: String) {
@@ -176,7 +176,7 @@ class ExtractLocalTest extends TestHelper with TestRefactoring {
   } applyRefactoring(extract("six"))
 
   @Test
-  def extractFilter = new FileSet {
+  def extractFilter() = new FileSet {
     """
       class Extr2 {
         def m {
@@ -199,7 +199,7 @@ class ExtractLocalTest extends TestHelper with TestRefactoring {
   } applyRefactoring(extract("largerThree"))
 
   @Test
-  def extractPartOfACondition = new FileSet {
+  def extractPartOfACondition() = new FileSet {
     """
       class Extr2 {
         def m {
@@ -224,7 +224,7 @@ class ExtractLocalTest extends TestHelper with TestRefactoring {
   } applyRefactoring(extract("part2"))
 
   @Test
-  def extractFromCaseWithMultipleStatements = new FileSet {
+  def extractFromCaseWithMultipleStatements() = new FileSet {
     """
       class Extr2 {
         Nil match {
@@ -249,7 +249,7 @@ class ExtractLocalTest extends TestHelper with TestRefactoring {
   } applyRefactoring(extract("six"))
 
   @Test
-  def extractFromCaseWithSingleStatement = new FileSet {
+  def extractFromCaseWithSingleStatement() = new FileSet {
     """
       class Extr2 {
         Nil match {
@@ -270,7 +270,7 @@ class ExtractLocalTest extends TestHelper with TestRefactoring {
   } applyRefactoring(extract("six"))
 
   @Test
-  def extractFromCaseWithTwoStatements = new FileSet {
+  def extractFromCaseWithTwoStatements() = new FileSet {
     """
       class Extr2 {
         /*(*/5 + 1/*)*/toString
@@ -286,7 +286,7 @@ class ExtractLocalTest extends TestHelper with TestRefactoring {
   } applyRefactoring(extract("six"))
 
   @Test
-  def extractFromTry = new FileSet {
+  def extractFromTry() = new FileSet {
     """
       class Extr2 {
         try {
@@ -307,7 +307,7 @@ class ExtractLocalTest extends TestHelper with TestRefactoring {
   } applyRefactoring(extract("largerThanTwo"))
 
   @Test
-  def extractFromTrySingleStatement = new FileSet {
+  def extractFromTrySingleStatement() = new FileSet {
     """
       class Extr2 {
         try {
@@ -326,7 +326,7 @@ class ExtractLocalTest extends TestHelper with TestRefactoring {
   } applyRefactoring(extract("largerThanTwo"))
 
   @Test
-  def extractMethod = new FileSet {
+  def extractMethod() = new FileSet {
     """
       class Extr2 {
         /*(*/List(1,2,3) filter/*)*/ (_> 2) mkString ", "
@@ -342,7 +342,7 @@ class ExtractLocalTest extends TestHelper with TestRefactoring {
   } applyRefactoring(extract("filterList"))
 
   @Test
-  def extractFromFunctionWithCurlyBraces = new FileSet {
+  def extractFromFunctionWithCurlyBraces() = new FileSet {
     """
       class Extr2 {
         List(1,2,3) filter { it =>
@@ -361,7 +361,7 @@ class ExtractLocalTest extends TestHelper with TestRefactoring {
   } applyRefactoring(extract("isOdd"))
 
   @Test
-  def extractFromFunction = new FileSet {
+  def extractFromFunction() = new FileSet {
     """
       class Extr2 {
         List(1,2,3) filter (i => /*(*/i + 1 % 2/*)*/ == 0)
@@ -378,7 +378,7 @@ class ExtractLocalTest extends TestHelper with TestRefactoring {
   } applyRefactoring(extract("isOdd"))
 
   @Test
-  def extractFromValBlock = new FileSet {
+  def extractFromValBlock() = new FileSet {
       """
       class Extr2 {
         val a = {
@@ -398,7 +398,7 @@ class ExtractLocalTest extends TestHelper with TestRefactoring {
   } applyRefactoring extract("addTwo")
 
   @Test
-  def extractFromThen = new FileSet {
+  def extractFromThen() = new FileSet {
     """
       class Extr2 {
         if(true) {
@@ -417,7 +417,7 @@ class ExtractLocalTest extends TestHelper with TestRefactoring {
   } applyRefactoring(extract("ab"))
 
   @Test
-  def extractFromThenWithoutParent = new FileSet {
+  def extractFromThenWithoutParent() = new FileSet {
     """
       class Extr2 {
         if(true)
@@ -435,7 +435,7 @@ class ExtractLocalTest extends TestHelper with TestRefactoring {
   } applyRefactoring(extract("ab"))
 
   @Test
-  def extractFromElse = new FileSet {
+  def extractFromElse() = new FileSet {
     """
 
     object ExtractLocal1 {
@@ -476,7 +476,7 @@ class ExtractLocalTest extends TestHelper with TestRefactoring {
   } applyRefactoring(extract("msg"))
 
   @Test
-  def extractFromSimpleMethod = new FileSet {
+  def extractFromSimpleMethod() = new FileSet {
     """
       class Extr2 {
         def method {
@@ -495,7 +495,7 @@ class ExtractLocalTest extends TestHelper with TestRefactoring {
   } applyRefactoring(extract("ab"))
 
   @Test
-  def extractFromMethod = new FileSet {
+  def extractFromMethod() = new FileSet {
     """
       class Extr2 {
         def method {
@@ -516,7 +516,7 @@ class ExtractLocalTest extends TestHelper with TestRefactoring {
   } applyRefactoring(extract("ab"))
 
   @Test
-  def extractFromMethod2 = new FileSet {
+  def extractFromMethod2() = new FileSet {
     """
 object ExtractMethod2 {
 
@@ -548,7 +548,7 @@ object ExtractMethod2 {
 
   @Test
   @Ignore
-  def extractFromFunction2 = new FileSet {
+  def extractFromFunction2() = new FileSet {
     """
       class Extr2 {
         List(1,2,3) filter (/*(*/_ + 1 % 2/*)*/ == 0)
@@ -558,7 +558,7 @@ object ExtractMethod2 {
   } applyRefactoring(extract("isOdd"))
 
   @Test
-  def extractFromCaseClause = new FileSet {
+  def extractFromCaseClause() = new FileSet {
     """
       class Extr2 {
         List() match {
@@ -578,7 +578,7 @@ object ExtractMethod2 {
   } applyRefactoring(extract("isFalse"))
 
   @Test
-  def extractFromMatch = new FileSet {
+  def extractFromMatch() = new FileSet {
     """
       class Extr2 {
         /*(*/List(1,2,3)/*)*/ match {
@@ -598,7 +598,7 @@ object ExtractMethod2 {
   } applyRefactoring(extract("l"))
 
   @Test
-  def extractFunctionFromMethodCall = new FileSet {
+  def extractFunctionFromMethodCall() = new FileSet {
     """
       class Extr2 {
         def main(args : Array[String]) {
@@ -621,7 +621,7 @@ object ExtractMethod2 {
   } applyRefactoring(extract("cc"))
 
   @Test
-  def extractLastExpressionInUnitMethod = new FileSet {
+  def extractLastExpressionInUnitMethod() = new FileSet {
     """
     object Bar {
       def foo {
@@ -638,7 +638,7 @@ object ExtractMethod2 {
   } applyRefactoring(extract("t"))
 
   @Test
-  def extractFromUpdateMethod = new FileSet {
+  def extractFromUpdateMethod() = new FileSet {
     """
     object ExtractLocalBugTest extends App{
       val List(one, three, eight) = List(1,3,8);
@@ -664,7 +664,7 @@ object ExtractMethod2 {
   } applyRefactoring(extract("two"))
 
   @Test
-  def extractWithoutSelection = new FileSet {
+  def extractWithoutSelection() = new FileSet {
     """
     object ExtractLocal {
       def x() {
@@ -685,7 +685,7 @@ object ExtractMethod2 {
   } applyRefactoring(extract("one"))
 
   @Test
-  def extractFromFor = new FileSet {
+  def extractFromFor() = new FileSet {
     """
     object ExtractFromFor {
 
@@ -707,7 +707,7 @@ object ExtractMethod2 {
   } applyRefactoring(extract("len"))
 
   @Test
-  def extractFromForFilter = new FileSet {
+  def extractFromForFilter() = new FileSet {
     """
     object ExtractFromFor {
 
@@ -729,7 +729,7 @@ object ExtractMethod2 {
   } applyRefactoring(extract("len"))
 
   @Test
-  def extractFromForFilterYieldWithBody = new FileSet {
+  def extractFromForFilterYieldWithBody() = new FileSet {
     """
     object ExtractFromFor {
 
@@ -755,7 +755,7 @@ object ExtractMethod2 {
   } applyRefactoring(extract("len"))
 
   @Test
-  def extractFromForFilterYieldWithSameLineBody = new FileSet {
+  def extractFromForFilterYieldWithSameLineBody() = new FileSet {
     """
     object ExtractFromFor {
 
@@ -777,7 +777,7 @@ object ExtractMethod2 {
   } applyRefactoring(extract("len"))
 
   @Test
-  def extractFromForFilterYieldWithBlockBody = new FileSet {
+  def extractFromForFilterYieldWithBlockBody() = new FileSet {
     """
     object ExtractFromFor {
 
@@ -805,7 +805,7 @@ object ExtractMethod2 {
   } applyRefactoring(extract("len"))
 
   @Test
-  def extractAnonFunction = new FileSet {
+  def extractAnonFunction() = new FileSet {
     """
     object ExtractFromFor {
       val inc = /*(*/(_:Int)+1/*)*/
@@ -821,7 +821,7 @@ object ExtractMethod2 {
   } applyRefactoring(extract("plusOne"))
 
  @Test
- def extractList = new FileSet {
+ def extractList() = new FileSet {
    """
    class ExtractList {
      val list = /*(*/1::Nil/*)*/
@@ -837,7 +837,7 @@ object ExtractMethod2 {
  } applyRefactoring(extract("extracted"))
 
  @Test
- def extractFromConstructor = new FileSet {
+ def extractFromConstructor() = new FileSet {
    """
    object ExtractFromHere {
      import java.net.URL
@@ -861,7 +861,7 @@ object ExtractMethod2 {
  } applyRefactoring(extract("url"))
 
   @Test
-  def plusAssignRhs = new FileSet {
+  def plusAssignRhs() = new FileSet {
    """
     class ExtractLocalVariable {
       def f() {
@@ -884,7 +884,7 @@ object ExtractMethod2 {
   } applyRefactoring(extract("result_of_g"))
 
   @Test
-  def fromForExpressionReturningUnit = new FileSet {
+  def fromForExpressionReturningUnit() = new FileSet {
    """
     class ExtractfromForExpression {
       def f() {
@@ -903,7 +903,7 @@ object ExtractMethod2 {
   } applyRefactoring(extract("lst"))
 
   @Test
-  def fromForExpression = new FileSet {
+  def fromForExpression() = new FileSet {
    """
     class ExtractfromForExpression {
       def f() {
@@ -922,7 +922,7 @@ object ExtractMethod2 {
   } applyRefactoring(extract("lst"))
 
   @Test
-  def fromForExpressionNoEnclosingBlock = new FileSet {
+  def fromForExpressionNoEnclosingBlock() = new FileSet {
    """
     class ExtractfromForExpression {
       def f() = for (x <- /*(*/List(1,2,3,4)/*)*/) yield x
@@ -939,7 +939,7 @@ object ExtractMethod2 {
   } applyRefactoring(extract("lst"))
 
   @Test
-  def fromForExpressionCurlyOneLiner = new FileSet {
+  def fromForExpressionCurlyOneLiner() = new FileSet {
    """
     class ExtractfromForExpression {
       def f() = {
@@ -958,7 +958,7 @@ object ExtractMethod2 {
   } applyRefactoring(extract("lst"))
 
   @Test
-  def fromForExpressionWithFilter = new FileSet {
+  def fromForExpressionWithFilter() = new FileSet {
    """
     class ExtractfromForExpression {
       def f() {
@@ -981,7 +981,7 @@ object ExtractMethod2 {
   } applyRefactoring(extract("lst"))
 
   @Test
-  def fromForExpressionCurly = new FileSet {
+  def fromForExpressionCurly() = new FileSet {
    """
     class ExtractfromForExpression {
       def f() {
@@ -1012,7 +1012,7 @@ object ExtractMethod2 {
    * going to be very difficult. */
   @Test
   @Ignore
-  def fromForExpressionMultiple = new FileSet {
+  def fromForExpressionMultiple() = new FileSet {
    """
     class ExtractfromForExpression {
       def f() {
@@ -1029,7 +1029,7 @@ object ExtractMethod2 {
   } applyRefactoring(extract("lst"))
 
   @Test
-  def fromForBlockBody = new FileSet {
+  def fromForBlockBody() = new FileSet {
    """
     class ExtractfromForExpression {
       def f() {
@@ -1058,7 +1058,7 @@ object ExtractMethod2 {
   } applyRefactoring(extract("lst"))
 
   @Test
-  def extractFromForEntireRhs = new FileSet {
+  def extractFromForEntireRhs() = new FileSet {
     """
     object ExtractFromFor {
       def foo {
@@ -1077,7 +1077,7 @@ object ExtractMethod2 {
   } applyRefactoring(extract("extractedValue"))
 
   @Test
-  def extractFromForEntireRhsYield = new FileSet {
+  def extractFromForEntireRhsYield() = new FileSet {
     """
     object ExtractFromFor {
       def foo {
@@ -1096,7 +1096,7 @@ object ExtractMethod2 {
   } applyRefactoring(extract("extractedValue"))
 
   @Test
-  def missingTypeNeedsAnnotation = new FileSet {
+  def missingTypeNeedsAnnotation() = new FileSet {
     """
     object ExtractmissingTypeNeedsAnnotation {
       def foo {
@@ -1115,7 +1115,7 @@ object ExtractMethod2 {
   } applyRefactoring(extract("pred"))
 
   @Test
-  def extractAnonFunctionWithoutTypeAscriptions = new FileSet {
+  def extractAnonFunctionWithoutTypeAscriptions() = new FileSet {
     """
     object ExtractFromFor {
       def foo {
@@ -1134,7 +1134,7 @@ object ExtractMethod2 {
   } applyRefactoring(extract("sum"))
 
   @Test
-  def extractAnonFunctionWithoutTypeAscription = new FileSet {
+  def extractAnonFunctionWithoutTypeAscription() = new FileSet {
     """
     object ExtractFromFor {
       def foo {
@@ -1153,7 +1153,7 @@ object ExtractMethod2 {
   } applyRefactoring(extract("addOne"))
 
   @Test
-  def extractMatchBodyOperatorMap = new FileSet {
+  def extractMatchBodyOperatorMap() = new FileSet {
     """
     object ExtractFromFor {
       def foo {
@@ -1176,7 +1176,7 @@ object ExtractMethod2 {
   } applyRefactoring(extract("toOne"))
 
   @Test
-  def extractMatchBody = new FileSet {
+  def extractMatchBody() = new FileSet {
     """
     object ExtractFromFor {
       def foo {

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/ExtractMethodTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/ExtractMethodTest.scala
@@ -19,7 +19,7 @@ class ExtractMethodTest extends TestHelper with TestRefactoring {
   }.changes
 
   @Test
-  def extractBlock = new FileSet {
+  def extractBlock() = new FileSet {
     """
     package extractBlock
     class A {
@@ -52,7 +52,7 @@ class ExtractMethodTest extends TestHelper with TestRefactoring {
   } applyRefactoring extract("prntln")
 
   @Test
-  def simpleExtract = new FileSet {
+  def simpleExtract() = new FileSet {
     """
     package simpleExtract
     class A {
@@ -78,7 +78,7 @@ class ExtractMethodTest extends TestHelper with TestRefactoring {
   } applyRefactoring extract("myOwnPrint")
 
   @Test
-  def ignoreOtherClass = new FileSet {
+  def ignoreOtherClass() = new FileSet {
     """
     package ignoreOtherClass
     class A {
@@ -110,7 +110,7 @@ class ExtractMethodTest extends TestHelper with TestRefactoring {
   } applyRefactoring extract("prntln")
 
   @Test
-  def simpleExtractOneParameter = new FileSet {
+  def simpleExtractOneParameter() = new FileSet {
     """
     package simpleExtractOneParameter
     class A {
@@ -138,7 +138,7 @@ class ExtractMethodTest extends TestHelper with TestRefactoring {
   } applyRefactoring extract("prntln")
 
   @Test
-  def extractRangeParameter = new FileSet {
+  def extractRangeParameter() = new FileSet {
       """
       object ExtractMethod3 {
 
@@ -175,7 +175,7 @@ class ExtractMethodTest extends TestHelper with TestRefactoring {
   } applyRefactoring extract("prntln")
 
   @Test
-  def simpleExtractSeveralParameters = new FileSet {
+  def simpleExtractSeveralParameters() = new FileSet {
     """
     package simpleExtractSeveralParameters
     class A {
@@ -207,7 +207,7 @@ class ExtractMethodTest extends TestHelper with TestRefactoring {
   } applyRefactoring extract("prntln")
 
   @Test
-  def simpleExtractReturn = new FileSet {
+  def simpleExtractReturn() = new FileSet {
     """
     package simpleExtractReturn
     class A {
@@ -234,7 +234,7 @@ class ExtractMethodTest extends TestHelper with TestRefactoring {
   } applyRefactoring extract("prntln")
 
   @Test
-  def simpleExtractMultipleReturns = new FileSet {
+  def simpleExtractMultipleReturns() = new FileSet {
     """
     package simpleExtractMultipleReturns
     class A {
@@ -263,7 +263,7 @@ class ExtractMethodTest extends TestHelper with TestRefactoring {
   } applyRefactoring extract("prntln")
 
   @Test
-  def simpleExtractParametersAndReturns = new FileSet {
+  def simpleExtractParametersAndReturns() = new FileSet {
     """
     package simpleExtractParametersAndReturns
     class A {
@@ -298,7 +298,7 @@ class ExtractMethodTest extends TestHelper with TestRefactoring {
   } applyRefactoring extract("prntln")
 
   @Test
-  def extractBlockExpression = new FileSet {
+  def extractBlockExpression() = new FileSet {
       """
     package extractBlockExpression
     class A {
@@ -323,7 +323,7 @@ class ExtractMethodTest extends TestHelper with TestRefactoring {
   } applyRefactoring extract("inc")
 
   @Test
-  def replaceWholeMethod = new FileSet {
+  def replaceWholeMethod() = new FileSet {
     """
     package replaceWholeMethod
     class A {
@@ -348,7 +348,7 @@ class ExtractMethodTest extends TestHelper with TestRefactoring {
   } applyRefactoring extract("inc")
 
   @Test
-  def extractIfCond = new FileSet {
+  def extractIfCond() = new FileSet {
     """
     package extractIfCond
     class A {
@@ -378,7 +378,7 @@ class ExtractMethodTest extends TestHelper with TestRefactoring {
   } applyRefactoring extract("test")
 
   @Test
-  def extractAnonFunction = new FileSet {
+  def extractAnonFunction() = new FileSet {
     """
 object ExtractMethod3 {
 
@@ -409,7 +409,7 @@ object ExtractMethod3 {
   } applyRefactoring extract("test")
 
   @Test
-  def extractAnonFunction2 = new FileSet {
+  def extractAnonFunction2() = new FileSet {
     """
 object ExtractMethod3 {
 
@@ -440,7 +440,7 @@ object ExtractMethod3 {
   } applyRefactoring extract("test")
 
   @Test
-  def extractAnonFunction3 = new FileSet {
+  def extractAnonFunction3() = new FileSet {
     """
 object ExtractMethod3 {
 
@@ -471,7 +471,7 @@ object ExtractMethod3 {
   } applyRefactoring extract("test")
 
   @Test
-  def extractIfThen = new FileSet {
+  def extractIfThen() = new FileSet {
     """
     package extractIfThen
     class A {
@@ -500,7 +500,7 @@ object ExtractMethod3 {
   } applyRefactoring extract("test")
 
   @Test
-  def extractIfElse = new FileSet {
+  def extractIfElse() = new FileSet {
     """
     package extractIfElse
     class A {
@@ -532,7 +532,7 @@ object ExtractMethod3 {
   } applyRefactoring extract("test")
 
   @Test
-  def extractIfSingleLineElse = new FileSet {
+  def extractIfSingleLineElse() = new FileSet {
     """
     package extractIfSingleLineElse
     class A {
@@ -556,7 +556,7 @@ object ExtractMethod3 {
   } applyRefactoring extract("test")
 
   @Test
-  def extractIfElseTry = new FileSet {
+  def extractIfElseTry() = new FileSet {
     """
     package extractIfElseTry
     class A {
@@ -598,7 +598,7 @@ object ExtractMethod3 {
   } applyRefactoring extract("test")
 
   @Test
-  def extractCheckForFalse = new FileSet {
+  def extractCheckForFalse() = new FileSet {
     """
           package extractCheckForFalse
       trait Check {
@@ -628,7 +628,7 @@ object ExtractMethod3 {
   } applyRefactoring extract("isFalse")
 
   @Test
-  def extractWithMethod = new FileSet {
+  def extractWithMethod() = new FileSet {
     """
     package extractWithMethod
     class A {
@@ -659,7 +659,7 @@ object ExtractMethod3 {
   } applyRefactoring extract("certainlyTrue")
 
   @Test
-  def extractAllAtOnce = new FileSet {
+  def extractAllAtOnce() = new FileSet {
     """
     package extractAllAtOnce
     object C {
@@ -696,7 +696,7 @@ object ExtractMethod3 {
   } applyRefactoring extract("magic")
 
   @Test
-  def extractLarger = new FileSet {
+  def extractLarger() = new FileSet {
     """
     package extractLarger
     object C {
@@ -762,7 +762,7 @@ object ExtractMethod3 {
   } applyRefactoring extract("isFalse")
 
   @Test
-  def singleIfInMethod = new FileSet {
+  def singleIfInMethod() = new FileSet {
     """
 object ExtractMethod2 {
   def method {
@@ -788,7 +788,7 @@ object ExtractMethod2 {
   } applyRefactoring extract("certainlyTrue")
 
   @Test
-  def localFunctionAsParameter = new FileSet {
+  def localFunctionAsParameter() = new FileSet {
     """
 object ExtractWithLocalFunction {
   def method {
@@ -816,7 +816,7 @@ object ExtractWithLocalFunction {
   } applyRefactoring extract("call")
 
   @Test
-  def localFunctionAsParameter2 = new FileSet {
+  def localFunctionAsParameter2() = new FileSet {
     """
 object ExtractWithLocalFunction2 {
   def method {
@@ -846,7 +846,7 @@ object ExtractWithLocalFunction2 {
   } applyRefactoring extract("call")
 
   @Test
-  def localFunctionAsParameter3 = new FileSet {
+  def localFunctionAsParameter3() = new FileSet {
     """
 object ExtractWithLocalFunction3 {
   def method {
@@ -872,7 +872,7 @@ object ExtractWithLocalFunction3 {
   } applyRefactoring extract("call")
 
   @Test
-  def bug18 = new FileSet {
+  def bug18() = new FileSet {
     """
 object Bar {
   def foo {
@@ -898,7 +898,7 @@ object Bar {
   } applyRefactoring extract("calc")
 
   @Test
-  def simpleYield = new FileSet {
+  def simpleYield() = new FileSet {
     """
 package simpleExtract
 class A {
@@ -928,7 +928,7 @@ class A {
   } applyRefactoring extract("call")
 
   @Test
-  def extractFromMethodWithObject = new FileSet {
+  def extractFromMethodWithObject() = new FileSet {
     """
 package simpleExtract
 class PathSeparator {
@@ -965,7 +965,7 @@ class PathSeparator {
   } applyRefactoring extract("mkTuple")
 
   @Test
-  def extractFromMethodWithMultipleAssignment = new FileSet {
+  def extractFromMethodWithMultipleAssignment() = new FileSet {
     """
 package simpleExtract
 class PathSeparator {
@@ -995,7 +995,7 @@ class PathSeparator {
   } applyRefactoring extract("sayHello")
 
   @Test
-  def extractFromWithinAnonymousClass = new FileSet {
+  def extractFromWithinAnonymousClass() = new FileSet {
     """
     class ExtractFromAnonClass {
       def method {
@@ -1025,7 +1025,7 @@ class PathSeparator {
   } applyRefactoring extract("three")
 
   @Test
-  def extractFromWithinForExpr = new FileSet {
+  def extractFromWithinForExpr() = new FileSet {
     """
     class ExtractFromAnonClass {
       def method {
@@ -1047,7 +1047,7 @@ class PathSeparator {
   } applyRefactoring extract("lst")
 
   @Test
-  def extractFromWithinForExprFilter = new FileSet {
+  def extractFromWithinForExprFilter() = new FileSet {
     """
     class ExtractFromAnonClass {
       def method {
@@ -1069,7 +1069,7 @@ class PathSeparator {
   } applyRefactoring extract("test")
 
   @Test
-  def extractFromWithinForExprBody = new FileSet {
+  def extractFromWithinForExprBody() = new FileSet {
     """
     class ExtractFromAnonClass {
       def method {
@@ -1091,7 +1091,7 @@ class PathSeparator {
   } applyRefactoring extract("addTwo")
 
   @Test(expected=classOf[PreparationException])
-  def extractionNeedsSelection = new FileSet {
+  def extractionNeedsSelection() = new FileSet {
     """
     class Foo {
       def bar = {

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/ExtractTraitTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/ExtractTraitTest.scala
@@ -18,7 +18,7 @@ class ExtractTraitTest extends TestRefactoring {
   override val global = (new CompilerInstance).compiler
 
   @After
-  def shutdownCompiler {
+  def shutdownCompiler() {
     global.askShutdown
   }
 
@@ -38,7 +38,7 @@ class ExtractTraitTest extends TestRefactoring {
   }.changes
 
   @Test
-  def extractNothing = new FileSet {
+  def extractNothing() = new FileSet {
     """
     package extractTrait.extractNothing
     class /*(*/Foo/*)*/
@@ -56,7 +56,7 @@ class ExtractTraitTest extends TestRefactoring {
   } applyRefactoring(extractTrait(("Extracted", (name) => false)))
 
   @Test
-  def extractNothingNestedPackages = new FileSet {
+  def extractNothingNestedPackages() = new FileSet {
     """
     package a {
       package b.c {
@@ -88,7 +88,7 @@ class ExtractTraitTest extends TestRefactoring {
   } applyRefactoring(extractTrait(("Extracted", (name) => false)))
 
   @Test
-  def extractSingleDefDef = new FileSet {
+  def extractSingleDefDef() = new FileSet {
     """
     package extractTrait.extractSingleDefDef
 
@@ -117,7 +117,7 @@ class ExtractTraitTest extends TestRefactoring {
   } applyRefactoring(extractTrait(("Squarify", (name) => name == "square")))
 
   @Test
-  def extractSingleValDef = new FileSet {
+  def extractSingleValDef() = new FileSet {
     """
     package extractTrait.extractSingleValDef
 
@@ -144,7 +144,7 @@ class ExtractTraitTest extends TestRefactoring {
   } applyRefactoring(extractTrait(("Extracted", (name) => name == "immutable")))
 
   @Test
-  def extractSingleVarDef = new FileSet {
+  def extractSingleVarDef() = new FileSet {
     """
     package extractTrait.extractSingleVarDef
 
@@ -171,7 +171,7 @@ class ExtractTraitTest extends TestRefactoring {
   } applyRefactoring(extractTrait(("Extracted", (name) => name == "mutable")))
 
   @Test
-  def dontExtractClassParameters = new FileSet {
+  def dontExtractClassParameters() = new FileSet {
     """
     package extractTrait.dontExtractClassParameters
 
@@ -195,7 +195,7 @@ class ExtractTraitTest extends TestRefactoring {
   } applyRefactoring(extractTrait(("EmptyTrait"), (name) => "a"::"b"::"c"::Nil contains name))
 
   @Test(expected=classOf[RefactoringException])
-  def failWhenTraitAccessesPrivateClassMembers = new FileSet {
+  def failWhenTraitAccessesPrivateClassMembers() = new FileSet {
     """
     package extractTrait.failWhenTraitAccessesPrivateClassMembers
 
@@ -221,7 +221,7 @@ class ExtractTraitTest extends TestRefactoring {
   } applyRefactoring(extractTrait(("Squarify"), (name) => name == "square"))
 
   @Test(expected=classOf[RefactoringException])
-  def failWhenClassAccessesPrivateTraitMembers = new FileSet {
+  def failWhenClassAccessesPrivateTraitMembers() = new FileSet {
     """
     package extractTrait.failWhenClassAccessesPrivateTraitMembers
 
@@ -247,7 +247,7 @@ class ExtractTraitTest extends TestRefactoring {
   } applyRefactoring(extractTrait(("Squarify"), (name) => name == "number"))
 
   @Test
-  def addSelfTypeForClassMemberAccess = new FileSet {
+  def addSelfTypeForClassMemberAccess() = new FileSet {
     """
     package extractTrait.addSelfTypeForClassMemberAccess
 
@@ -273,7 +273,7 @@ class ExtractTraitTest extends TestRefactoring {
   } applyRefactoring(extractTrait(("Squarify"), (name) => name == "square"))
 
   @Test
-  def addSelfTypeForClassMethodAccess = new FileSet {
+  def addSelfTypeForClassMethodAccess() = new FileSet {
     """
     package extractTrait.addSelfTypeForClassMethodAccess
 
@@ -301,7 +301,7 @@ class ExtractTraitTest extends TestRefactoring {
   } applyRefactoring(extractTrait(("Squarify"), (name) => name == "square"))
 
   @Test
-  def withTypeParameters = new FileSet {
+  def withTypeParameters() = new FileSet {
     """
     package extractTrait.withTypeParameters
 
@@ -330,7 +330,7 @@ class ExtractTraitTest extends TestRefactoring {
   } applyRefactoring(extractTrait(("Empty"), (name) => name == "empty"))
 
   @Test
-  def withTypeParametersAndSelfType = new FileSet {
+  def withTypeParametersAndSelfType() = new FileSet {
     """
     package extractTrait.withTypeParametersAndSelfType
 
@@ -358,7 +358,7 @@ class ExtractTraitTest extends TestRefactoring {
   } applyRefactoring(extractTrait(("FirstReverser"), (name) => name == "reverseFirst"))
 
   @Test
-  def withImportsMovedToTrait = new FileSet {
+  def withImportsMovedToTrait() = new FileSet {
     """
     package extractTrait.withImportsMovedToTrait
     import scala.math.abs
@@ -390,7 +390,7 @@ class ExtractTraitTest extends TestRefactoring {
   } applyRefactoring(extractTrait(("Preparator"), (name) => name == "prepare"))
 
   @Test
-  def withImportsOnlyInClass = new FileSet {
+  def withImportsOnlyInClass() = new FileSet {
     """
     package extractTrait.withImportsOnlyInClass
 
@@ -424,7 +424,7 @@ class ExtractTraitTest extends TestRefactoring {
   } applyRefactoring(extractTrait(("LpNorms"), (name) => name.startsWith("l")))
 
   @Test
-  def fromTrait = new FileSet {
+  def fromTrait() = new FileSet {
     """
     package extractTrait.fromTrait
 
@@ -453,7 +453,7 @@ class ExtractTraitTest extends TestRefactoring {
   } applyRefactoring(extractTrait(("Squarify"), (name) => name == "square"))
 
   @Test
-  def overloadedMethods = new FileSet {
+  def overloadedMethods() = new FileSet {
     """
     package extractTrait.overloadedMethods
 
@@ -480,7 +480,7 @@ class ExtractTraitTest extends TestRefactoring {
   } applyRefactoring(extractTraitByParamListLength("OverloadedTrait", (nrParams) => nrParams == 2))
 
   @Test
-  def inDefaultPackage = new FileSet {
+  def inDefaultPackage() = new FileSet {
     """
     class /*(*/OriginalClassInDefaultPackage/*)*/ {
       def foo() {}
@@ -499,7 +499,7 @@ class ExtractTraitTest extends TestRefactoring {
   } applyRefactoring(extractTrait("Foo", (s) => s == "foo"))
 
   @Test
-  def withExistingSuperclass = new FileSet {
+  def withExistingSuperclass() = new FileSet {
     """
     package withExistingSuperclass
     trait A {
@@ -528,7 +528,7 @@ class ExtractTraitTest extends TestRefactoring {
   } applyRefactoring(extractTrait("Extracted", _ == "foo"))
 
   @Test
-  def removeOverride = new FileSet {
+  def removeOverride() = new FileSet {
     """
     package extractTrait.removeOverride
 

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/GenerateHashcodeAndEqualsTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/GenerateHashcodeAndEqualsTest.scala
@@ -20,7 +20,7 @@ class GenerateHashcodeAndEqualsTest extends TestHelper with TestRefactoring {
   override val global = (new CompilerInstance).compiler
 
   @After
-  def shutdownCompiler {
+  def shutdownCompiler() {
     global.askShutdown
   }
 
@@ -34,7 +34,7 @@ class GenerateHashcodeAndEqualsTest extends TestHelper with TestRefactoring {
   }.changes
 
   @Test
-  def singleValParam = new FileSet {
+  def singleValParam() = new FileSet {
     """
       package generateHashcodeAndEquals.singleValParam
 
@@ -64,7 +64,7 @@ class GenerateHashcodeAndEqualsTest extends TestHelper with TestRefactoring {
   } applyRefactoring (generateHashcodeAndEquals((false, p => true, false)))
 
   @Test
-  def twoValParams = new FileSet {
+  def twoValParams() = new FileSet {
     """
       package generateHashcodeAndEquals.twoValParams
 
@@ -94,7 +94,7 @@ class GenerateHashcodeAndEqualsTest extends TestHelper with TestRefactoring {
   } applyRefactoring (generateHashcodeAndEquals((false, p => true, false)))
 
   @Test
-  def excludeNonPublicParams = new FileSet {
+  def excludeNonPublicParams() = new FileSet {
     """
       package generateHashcodeAndEquals.excludeNonPublicParams
 
@@ -124,7 +124,7 @@ class GenerateHashcodeAndEqualsTest extends TestHelper with TestRefactoring {
   } applyRefactoring (generateHashcodeAndEquals((false, _ => true, false)))
 
   @Test
-  def keepExistingEquals = new FileSet {
+  def keepExistingEquals() = new FileSet {
     """
       package generateHashcodeAndEquals.keepExistingEquals
 
@@ -151,7 +151,7 @@ class GenerateHashcodeAndEqualsTest extends TestHelper with TestRefactoring {
   } applyRefactoring (generateHashcodeAndEquals((false, _ => true, true)))
 
   @Test
-  def dropExistingHashCode = new FileSet {
+  def dropExistingHashCode() = new FileSet {
     """
       package generateHashcodeAndEquals.dropExistingHashCode
 
@@ -183,7 +183,7 @@ class GenerateHashcodeAndEqualsTest extends TestHelper with TestRefactoring {
   } applyRefactoring (generateHashcodeAndEquals((false, _ => true, false)))
 
   @Test
-  def keepExistingCanEqual = new FileSet {
+  def keepExistingCanEqual() = new FileSet {
     """
       package generateHashcodeAndEquals.keepExistingCanEqual
 
@@ -213,7 +213,7 @@ class GenerateHashcodeAndEqualsTest extends TestHelper with TestRefactoring {
   } applyRefactoring (generateHashcodeAndEquals((false, _ => true, true)))
 
   @Test
-  def selectByName = new FileSet {
+  def selectByName() = new FileSet {
     """
     package generateHashcodeAndEquals.selectByName
 
@@ -248,7 +248,7 @@ class GenerateHashcodeAndEqualsTest extends TestHelper with TestRefactoring {
   , false))
 
   @Test
-  def callSuper = new FileSet {
+  def callSuper() = new FileSet {
     """
       package generateHashcodeAndEquals.callSuper
 
@@ -278,7 +278,7 @@ class GenerateHashcodeAndEqualsTest extends TestHelper with TestRefactoring {
   } applyRefactoring (generateHashcodeAndEquals((true, _ => true, false)))
 
   @Test
-  def emptyClassBody = new FileSet {
+  def emptyClassBody() = new FileSet {
     """
       package generateHashcodeAndEquals.emptyClassBody
 
@@ -310,7 +310,7 @@ class GenerateHashcodeAndEqualsTest extends TestHelper with TestRefactoring {
   } applyRefactoring (generateHashcodeAndEquals((true, _ => true, true)))
 
   @Test
-  def noParams = new FileSet {
+  def noParams() = new FileSet {
     """
     package generateHashcodeAndEquals.noParams
     class /*(*/Foo/*)*/ {
@@ -339,7 +339,7 @@ class GenerateHashcodeAndEqualsTest extends TestHelper with TestRefactoring {
   } applyRefactoring(generateHashcodeAndEquals((false, _ => false, false)))
 
   @Test(expected = classOf[PreparationException])
-  def traitFails = new FileSet {
+  def traitFails() = new FileSet {
     """
     package generateHashcodeAndEquals.traitFails
     trait NotAClass
@@ -348,7 +348,7 @@ class GenerateHashcodeAndEqualsTest extends TestHelper with TestRefactoring {
   } applyRefactoring(generateHashcodeAndEquals((false, _ => false, false)))
 
   @Test
-  def replaceHashcodeVal = new FileSet {
+  def replaceHashcodeVal() = new FileSet {
     """
     package generateHashcodeAndEquals.replaceHashcodeVal
     class /*(*/Foo/*)*/ {
@@ -378,7 +378,7 @@ class GenerateHashcodeAndEqualsTest extends TestHelper with TestRefactoring {
   } applyRefactoring(generateHashcodeAndEquals((false, _ => false, false)))
 
   @Test
-  def dontExtendEqualsTwice = new FileSet {
+  def dontExtendEqualsTwice() = new FileSet {
     """
     class /*(*/Foo/*)*/ extends Equals {
       def canEqual(that: Any) = false
@@ -404,7 +404,7 @@ class GenerateHashcodeAndEqualsTest extends TestHelper with TestRefactoring {
   } applyRefactoring(generateHashcodeAndEquals((false, _ => false, true)))
 
   @Test
-  def traitWithExistingSuperConstructorCall = new FileSet {
+  def traitWithExistingSuperConstructorCall() = new FileSet {
     """
     package traitWithExistingSuperConstructorCall
 

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/InlineLocalTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/InlineLocalTest.scala
@@ -21,7 +21,7 @@ class InlineLocalTest extends TestHelper with TestRefactoring {
   }.changes
 
   @Test
-  def inlineIfCond = new FileSet {
+  def inlineIfCond() = new FileSet {
     """
       package extractLocal
       object Demo {
@@ -48,7 +48,7 @@ class InlineLocalTest extends TestHelper with TestRefactoring {
   } applyRefactoring(inline)
 
   @Test
-  def inlineInMatch = new FileSet {
+  def inlineInMatch() = new FileSet {
     """
   object ExtractLocal1 {
 
@@ -79,7 +79,7 @@ class InlineLocalTest extends TestHelper with TestRefactoring {
   } applyRefactoring(inline)
 
   @Test
-  def inlineLocal = new FileSet {
+  def inlineLocal() = new FileSet {
     """
       package extractLocal
       object Demo {
@@ -106,7 +106,7 @@ class InlineLocalTest extends TestHelper with TestRefactoring {
   } applyRefactoring(inline)
 
   @Test
-  def inlineFromElseWithoutParens = new FileSet {
+  def inlineFromElseWithoutParens() = new FileSet {
     """
       package extractLocal
       object Demo {
@@ -145,7 +145,7 @@ class InlineLocalTest extends TestHelper with TestRefactoring {
   } applyRefactoring(inline)
 
   @Test
-  def inlineValRhs = new FileSet {
+  def inlineValRhs() = new FileSet {
     """
       object Demo {
         def update(platform: String) {
@@ -170,7 +170,7 @@ class InlineLocalTest extends TestHelper with TestRefactoring {
   } applyRefactoring(inline)
 
   @Test
-  def inlineFilter = new FileSet {
+  def inlineFilter() = new FileSet {
     """
       class Extr2 {
         def m {
@@ -192,7 +192,7 @@ class InlineLocalTest extends TestHelper with TestRefactoring {
   } applyRefactoring(inline)
 
   @Test
-  def inlineFilterFunction = new FileSet {
+  def inlineFilterFunction() = new FileSet {
     """
       class Extr2 {
         def m {
@@ -214,7 +214,7 @@ class InlineLocalTest extends TestHelper with TestRefactoring {
   } applyRefactoring(inline)
 
   @Test
-  def inlinePartOfACondition = new FileSet {
+  def inlinePartOfACondition() = new FileSet {
     """
       class Extr2 {
         def m {
@@ -239,7 +239,7 @@ class InlineLocalTest extends TestHelper with TestRefactoring {
   } applyRefactoring(inline)
 
   @Test
-  def inlineFromCaseWithMultipleStatements = new FileSet {
+  def inlineFromCaseWithMultipleStatements() = new FileSet {
     """
       class Extr2 { def m {
         Nil match {
@@ -264,7 +264,7 @@ class InlineLocalTest extends TestHelper with TestRefactoring {
   } applyRefactoring(inline)
 
   @Test
-  def inlineFromCaseWithSingleStatement = new FileSet {
+  def inlineFromCaseWithSingleStatement() = new FileSet {
     """
       class Extr2 { def m {
         Nil match {
@@ -287,7 +287,7 @@ class InlineLocalTest extends TestHelper with TestRefactoring {
   } applyRefactoring(inline)
 
   @Test
-  def inlineFromCaseWithTwoStatements = new FileSet {
+  def inlineFromCaseWithTwoStatements() = new FileSet {
     """
       class Extr2 { def m {
         /*(*/val six = 5 + 1/*)*/
@@ -302,7 +302,7 @@ class InlineLocalTest extends TestHelper with TestRefactoring {
   } applyRefactoring(inline)
 
   @Test
-  def inliningNeedsParens = new FileSet {
+  def inliningNeedsParens() = new FileSet {
     """
       class Extr2 {
         def m {
@@ -323,7 +323,7 @@ class InlineLocalTest extends TestHelper with TestRefactoring {
   } applyRefactoring(inline)
 
   @Test
-  def inliningNeedsParens2 = new FileSet {
+  def inliningNeedsParens2() = new FileSet {
     """
       class Extr2 {
         def m {
@@ -344,7 +344,7 @@ class InlineLocalTest extends TestHelper with TestRefactoring {
   } applyRefactoring(inline)
 
   @Test
-  def inliningNeedsNoParens = new FileSet {
+  def inliningNeedsNoParens() = new FileSet {
     """
       class Extr2 {
         def m {
@@ -365,7 +365,7 @@ class InlineLocalTest extends TestHelper with TestRefactoring {
   } applyRefactoring(inline)
 
   @Test
-  def inlineFromTry = new FileSet {
+  def inlineFromTry() = new FileSet {
     """
       class Extr2 { def m {
         try {
@@ -386,7 +386,7 @@ class InlineLocalTest extends TestHelper with TestRefactoring {
   } applyRefactoring(inline)
 
   @Test
-  def inlineFromFunctionWithCurlyBraces = new FileSet {
+  def inlineFromFunctionWithCurlyBraces() = new FileSet {
     """
       class Extr2 { def m {
         List(1,2,3) filter { it =>
@@ -406,7 +406,7 @@ class InlineLocalTest extends TestHelper with TestRefactoring {
   } applyRefactoring(inline)
 
   @Test
-  def inlineFromValBlock = new FileSet {
+  def inlineFromValBlock() = new FileSet {
     """
       class Extr2 { def m {
         val a = {
@@ -427,7 +427,7 @@ class InlineLocalTest extends TestHelper with TestRefactoring {
   } applyRefactoring(inline)
 
   @Test
-  def inlineFromThen = new FileSet {
+  def inlineFromThen() = new FileSet {
     """
       class Extr2 { def m {
         if(true) {
@@ -446,7 +446,7 @@ class InlineLocalTest extends TestHelper with TestRefactoring {
   } applyRefactoring(inline)
 
   @Test
-  def inlineFromElse = new FileSet {
+  def inlineFromElse() = new FileSet {
     """
 
     object ExtractLocal1 {
@@ -487,7 +487,7 @@ class InlineLocalTest extends TestHelper with TestRefactoring {
   } applyRefactoring(inline)
 
   @Test
-  def inlineFromSeveralVals = new FileSet {
+  def inlineFromSeveralVals() = new FileSet {
     """
     class InlineTest {
       def m {
@@ -508,7 +508,7 @@ class InlineLocalTest extends TestHelper with TestRefactoring {
   } applyRefactoring(inline)
 
   @Test
-  def inlineFromVal = new FileSet {
+  def inlineFromVal() = new FileSet {
     """
     class InlineTest {
       def m {
@@ -529,7 +529,7 @@ class InlineLocalTest extends TestHelper with TestRefactoring {
   } applyRefactoring(inline)
 
   @Test
-  def inlineInListConcatenation = new FileSet {
+  def inlineInListConcatenation() = new FileSet {
     """
      class InlineTest {
        def m {
@@ -548,7 +548,7 @@ class InlineLocalTest extends TestHelper with TestRefactoring {
   } applyRefactoring(inline)
 
   @Test
-  def preserveSomeWhitespace = new FileSet {
+  def preserveSomeWhitespace() = new FileSet {
     """
 object Test extends App {
   def f() {
@@ -567,7 +567,7 @@ object Test extends App {
   } applyRefactoring(inline)
 
   @Test(expected=classOf[RefactoringException])
-  def dontStartInlineFromRhs = new FileSet {
+  def dontStartInlineFromRhs() = new FileSet {
     """
     object Test extends App {
       def f() {

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/IntroduceProductNTraitTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/IntroduceProductNTraitTest.scala
@@ -19,7 +19,7 @@ class IntroduceProductNTraitTest extends TestHelper with TestRefactoring {
   override val global = (new CompilerInstance).compiler
 
   @After
-  def shutdownCompiler {
+  def shutdownCompiler() {
     global.askShutdown
   }
 
@@ -33,7 +33,7 @@ class IntroduceProductNTraitTest extends TestHelper with TestRefactoring {
   }.changes
 
   @Test
-  def product1Simple = new FileSet {
+  def product1Simple() = new FileSet {
     """
     package introduceProductNTrait.product1Simple
 
@@ -67,7 +67,7 @@ class IntroduceProductNTraitTest extends TestHelper with TestRefactoring {
   } applyRefactoring(introduceProductNTrait(false, _ => true, false))
 
   @Test
-  def product2Simple = new FileSet {
+  def product2Simple() = new FileSet {
     """
     package introduceProductNTrait.product2Simple
 
@@ -105,7 +105,7 @@ class IntroduceProductNTraitTest extends TestHelper with TestRefactoring {
   } applyRefactoring(introduceProductNTrait(false, _ => true, false))
 
   @Test
-  def multipleTraits = new FileSet {
+  def multipleTraits() = new FileSet {
     """
     package introduceProductNTrait.multipleTraits
 
@@ -139,7 +139,7 @@ class IntroduceProductNTraitTest extends TestHelper with TestRefactoring {
   } applyRefactoring(introduceProductNTrait(true, s => s == "p", false))
 
   @Test
-  def nonPublicClassParams = new FileSet {
+  def nonPublicClassParams() = new FileSet {
     """
     package introduceProductNTrait.nonPublicClassParams
 

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/MarkOccurrencesTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/MarkOccurrencesTest.scala
@@ -45,7 +45,7 @@ class MarkOccurrencesTest extends TestHelper {
   }
 
   @Test
-  def methodCall = markOccurrences("""
+  def methodCall() = markOccurrences("""
       package renameRecursive
       class A {
         def length[T](l: List[T]): Int = l match {
@@ -65,7 +65,7 @@ class MarkOccurrencesTest extends TestHelper {
     """)
 
   @Test
-  def fullySelected = markOccurrences("""
+  def fullySelected() = markOccurrences("""
       class Abc {
           new /*(*/Abc/*)*/
       }
@@ -77,7 +77,7 @@ class MarkOccurrencesTest extends TestHelper {
     """)
 
   @Test
-  def typeParameter = markOccurrences("""
+  def typeParameter() = markOccurrences("""
       class Abc {
           val xs: List[String] = "" :: Nil
           val x: /*(*/String/*)*/ = xs.head
@@ -91,7 +91,7 @@ class MarkOccurrencesTest extends TestHelper {
     """)
 
   @Test
-  def invalidSelection = markOccurrences("""
+  def invalidSelection() = markOccurrences("""
       class Abc {
           val xs: List[String] = "" :: Nil
           /*(*/val/*)*/ x: String = xs.head
@@ -105,7 +105,7 @@ class MarkOccurrencesTest extends TestHelper {
     """)
 
   @Test
-  def appliedTypeTreeParameter = markOccurrences("""
+  def appliedTypeTreeParameter() = markOccurrences("""
       class Abc {
           val xs: List[/*(*/String/*)*/] = "" :: Nil
           val x: String = xs.head
@@ -119,7 +119,7 @@ class MarkOccurrencesTest extends TestHelper {
     """)
 
   @Test
-  def superConstructorArguments = markOccurrences("""
+  def superConstructorArguments() = markOccurrences("""
       class Base(s: String)
       class Sub(a: String) extends Base(/*(*/a/*)*/)
     """,
@@ -129,7 +129,7 @@ class MarkOccurrencesTest extends TestHelper {
     """)
 
   @Test
-  def importValInInnerObject = markOccurrences("""
+  def importValInInnerObject() = markOccurrences("""
     object Outer {
       object Inner {
         val /*(*/c/*)*/ = 2
@@ -151,7 +151,7 @@ class MarkOccurrencesTest extends TestHelper {
     """)
 
   @Test
-  def markImportedOccurrences = markOccurrences("""
+  def markImportedOccurrences() = markOccurrences("""
     import java.io./*(*/File/*)*/
     object Whatever {
       val sep = File.pathSeparator
@@ -165,7 +165,7 @@ class MarkOccurrencesTest extends TestHelper {
     """)
 
   @Test
-  def markImportedAndRenamedOccurrences = markOccurrences("""
+  def markImportedAndRenamedOccurrences() = markOccurrences("""
     import java.io./*(*/File/*)*/
     import java.io.{File => F}
     object Whatever {
@@ -183,7 +183,7 @@ class MarkOccurrencesTest extends TestHelper {
     """)
 
   @Test
-  def markImportedAndRenamedOccurrencesRenamedSelected = markOccurrences("""
+  def markImportedAndRenamedOccurrencesRenamedSelected() = markOccurrences("""
     import java.io.File
     import java.io.{File => F}
     object Whatever {
@@ -201,7 +201,7 @@ class MarkOccurrencesTest extends TestHelper {
     """)
 
   @Test
-  def backtickedIdentifiers = markOccurrences("""
+  def backtickedIdentifiers() = markOccurrences("""
     trait StrangeIdentifiers {
       val /*(*/`my strange identifier`/*)*/ = "foo"
       val `my strange identifier 2` = `my strange identifier`
@@ -215,7 +215,7 @@ class MarkOccurrencesTest extends TestHelper {
     """)
 
   @Test
-  def annotatedType = markOccurrences("""
+  def annotatedType() = markOccurrences("""
       object U {
         def go(t: List[ /*(*/String/*)*/ ]) = {
           val s: String = ""
@@ -233,7 +233,7 @@ class MarkOccurrencesTest extends TestHelper {
     """)
 
   @Test
-  def filterInForComprehension1 = markOccurrences("""
+  def filterInForComprehension1() = markOccurrences("""
       object U {
         for (/*(*/foo/*)*/ <- List("santa", "claus") if foo.startsWith("s")) yield foo
       }
@@ -245,7 +245,7 @@ class MarkOccurrencesTest extends TestHelper {
     """)
 
   @Test
-  def filterInForComprehension2 = markOccurrences("""
+  def filterInForComprehension2() = markOccurrences("""
       object U {
         for (foo <- List("santa", "claus") if /*(*/foo/*)*/.startsWith("s")) yield foo
       }
@@ -257,7 +257,7 @@ class MarkOccurrencesTest extends TestHelper {
     """)
 
   @Test
-  def filterInForComprehension3 = markOccurrences("""
+  def filterInForComprehension3() = markOccurrences("""
       object U {
         for (foo <- List("santa", "claus") if foo.startsWith("s")) yield /*(*/foo/*)*/
       }
@@ -269,7 +269,7 @@ class MarkOccurrencesTest extends TestHelper {
     """)
 
   @Test
-  def filterInForComprehension4 = markOccurrences("""
+  def filterInForComprehension4() = markOccurrences("""
       object U {
         for (foo <- List("santa", "claus") if "".startsWith(/*(*/foo/*)*/)) yield foo
       }
@@ -281,7 +281,7 @@ class MarkOccurrencesTest extends TestHelper {
     """)
 
   @Test
-  def filterInForComprehensions = markOccurrences("""
+  def filterInForComprehensions() = markOccurrences("""
       object U {
         for (/*(*/foo/*)*/ <- List("santa", "2claus"); bar <- List(1,2) if foo.startsWith(""+ bar)) yield foo
       }
@@ -293,7 +293,7 @@ class MarkOccurrencesTest extends TestHelper {
     """)
 
   @Test
-  def filterInForComprehensions2 = markOccurrences("""
+  def filterInForComprehensions2() = markOccurrences("""
       object U {
         for (foo <- List("santa", "2claus"); /*(*/bar/*)*/ <- List(1,2) if foo.startsWith(""+ bar)) yield foo
       }
@@ -305,7 +305,7 @@ class MarkOccurrencesTest extends TestHelper {
     """)
 
   @Test
-  def referenceFromInside = markOccurrences("""
+  def referenceFromInside() = markOccurrences("""
     package referenceFromInside
     class /*(*/Foo/*)*/ {
       class Bar {
@@ -323,7 +323,7 @@ class MarkOccurrencesTest extends TestHelper {
     """)
 
   @Test
-  def referenceToOverridenTypesInSubclasses = markOccurrences("""
+  def referenceToOverridenTypesInSubclasses() = markOccurrences("""
     abstract class A {
 
       type /*(*/Foo/*)*/
@@ -359,7 +359,7 @@ class MarkOccurrencesTest extends TestHelper {
     """)
 
   @Test
-  def typeAscriptionTraitMember = markOccurrences("""
+  def typeAscriptionTraitMember() = markOccurrences("""
     trait ScalaIdeRefactoring {
       trait /*(*/Refactoring/*)*/
       val refactoring: Refactoring
@@ -373,7 +373,7 @@ class MarkOccurrencesTest extends TestHelper {
     """)
 
   @Test
-  def typeAliasRhs = markOccurrences("""
+  def typeAliasRhs() = markOccurrences("""
     class Foo2 {
       type T = /*(*/Int/*)*/
       val x: T = 10
@@ -389,7 +389,7 @@ class MarkOccurrencesTest extends TestHelper {
     """)
 
   @Test
-  def typeAliasLhs = markOccurrences("""
+  def typeAliasLhs() = markOccurrences("""
     class Foo2 {
       type /*(*/T/*)*/ = Int
       val x: T = 10
@@ -406,7 +406,7 @@ class MarkOccurrencesTest extends TestHelper {
 
   @Ignore
   @Test
-  def namedArg = markOccurrences("""
+  def namedArg() = markOccurrences("""
     class Updateable { def update(/*(*/what/*)*/: Int, rest: Int) = 0 }
 
     class NamedParameter {
@@ -424,7 +424,7 @@ class MarkOccurrencesTest extends TestHelper {
     """)
 
   @Test
-  def constructorInForComprehension = markOccurrences("""
+  def constructorInForComprehension() = markOccurrences("""
     package constructorInForComprehension
     case class /*(*/A/*)*/(val x: Int)
 

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/MergeParameterListsTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/MergeParameterListsTest.scala
@@ -21,7 +21,7 @@ class MergeParameterListsTest extends TestHelper with TestRefactoring {
 
 
   @Test(expected=classOf[RefactoringException])
-  def tooSmallMergePosition = new FileSet {
+  def tooSmallMergePosition() = new FileSet {
     """
     package mergeParameterLists.tooSmallMergePosition
     class A {
@@ -37,7 +37,7 @@ class MergeParameterListsTest extends TestHelper with TestRefactoring {
   } applyRefactoring(mergeParameterLists(0::1::Nil))
 
   @Test(expected=classOf[RefactoringException])
-  def tooBigMergePosition = new FileSet {
+  def tooBigMergePosition() = new FileSet {
     """
     package mergeParameterLists.tooBigMergePosition
     class A {
@@ -53,7 +53,7 @@ class MergeParameterListsTest extends TestHelper with TestRefactoring {
   } applyRefactoring(mergeParameterLists(1::3::Nil))
 
   @Test(expected=classOf[RefactoringException])
-  def unsortedMergePositions = new FileSet {
+  def unsortedMergePositions() = new FileSet {
     """
     package mergeParameterLists.unsortedMergePositions
     class A {
@@ -69,7 +69,7 @@ class MergeParameterListsTest extends TestHelper with TestRefactoring {
   } applyRefactoring(mergeParameterLists(2::1::Nil))
 
   @Test(expected=classOf[RefactoringException])
-  def repeatedMergePosition = new FileSet {
+  def repeatedMergePosition() = new FileSet {
     """
     package mergeParameterLists.repeatedMergePosition
     class A {
@@ -86,7 +86,7 @@ class MergeParameterListsTest extends TestHelper with TestRefactoring {
 
 
   @Test
-  def mergeAllLists = new FileSet {
+  def mergeAllLists() = new FileSet {
     """
     package mergeParameterLists.mergeAllLists
     class A {
@@ -102,7 +102,7 @@ class MergeParameterListsTest extends TestHelper with TestRefactoring {
   } applyRefactoring(mergeParameterLists(1::2::3::Nil))
 
   @Test
-  def mergeSomeLists = new FileSet {
+  def mergeSomeLists() = new FileSet {
     """
     package mergeParameterLists.mergeSomeLists
     class A {
@@ -118,7 +118,7 @@ class MergeParameterListsTest extends TestHelper with TestRefactoring {
   } applyRefactoring(mergeParameterLists(1::3::Nil))
 
   @Test
-  def mergeWithCall = new FileSet {
+  def mergeWithCall() = new FileSet {
     """
     package mergeParameterLists.mergeWithCall
     class A {
@@ -136,7 +136,7 @@ class MergeParameterListsTest extends TestHelper with TestRefactoring {
   } applyRefactoring(mergeParameterLists(1::3::Nil))
 
   @Test
-  def mergeMethodSubclass = new FileSet {
+  def mergeMethodSubclass() = new FileSet {
     """
     package mergeParameterLists.mergeMethodSubclass
     class Parent {
@@ -158,7 +158,7 @@ class MergeParameterListsTest extends TestHelper with TestRefactoring {
   } applyRefactoring(mergeParameterLists(1::3::Nil))
 
   @Test
-  def mergeMethodSuperclass = new FileSet {
+  def mergeMethodSuperclass() = new FileSet {
     """
     package mergeParameterLists.mergeMethodSuperclass
     class Parent {
@@ -180,7 +180,7 @@ class MergeParameterListsTest extends TestHelper with TestRefactoring {
   } applyRefactoring(mergeParameterLists(1::3::Nil))
 
   @Test
-  def mergeMethodAliased = new FileSet {
+  def mergeMethodAliased() = new FileSet {
     """
     package mergeParameterLists.mergeMethodAliased
     class A {
@@ -200,7 +200,7 @@ class MergeParameterListsTest extends TestHelper with TestRefactoring {
   } applyRefactoring(mergeParameterLists(1::2::Nil))
 
   @Test
-  def mergePartiallyApplied= new FileSet {
+  def mergePartiallyApplied() = new FileSet {
     """
     package mergeParameterLists.mergePartiallyApplied
     class A {
@@ -220,7 +220,7 @@ class MergeParameterListsTest extends TestHelper with TestRefactoring {
   } applyRefactoring(mergeParameterLists(1::3::Nil))
 
   @Test
-  def repeatedlyPartiallyApplied = new FileSet {
+  def repeatedlyPartiallyApplied() = new FileSet {
     """
     package mergeParameterLists.repeatedlyPartiallyApplied
     class A {
@@ -244,7 +244,7 @@ class MergeParameterListsTest extends TestHelper with TestRefactoring {
   } applyRefactoring(mergeParameterLists(1::3::5::7::Nil))
 
   @Test
-  def aliasToVal = new FileSet {
+  def aliasToVal() = new FileSet {
     """
       package mergeParameterLists.aliasToVal
       class A {
@@ -264,7 +264,7 @@ class MergeParameterListsTest extends TestHelper with TestRefactoring {
   } applyRefactoring(mergeParameterLists(1::3::Nil))
 
   @Test
-  def repeatedlyPartiallyAppliedVal = new FileSet {
+  def repeatedlyPartiallyAppliedVal() = new FileSet {
     """
       package mergeParameterLists.repeatedlyPartiallyAppliedVal
       class A {
@@ -286,7 +286,7 @@ class MergeParameterListsTest extends TestHelper with TestRefactoring {
   } applyRefactoring(mergeParameterLists(1::3::5::Nil))
 
   @Test
-  def partialsWithBody = new FileSet {
+  def partialsWithBody() = new FileSet {
     """
     package mergeParameterLists.partialsWithBody
     class A {
@@ -328,7 +328,7 @@ class MergeParameterListsTest extends TestHelper with TestRefactoring {
   } applyRefactoring(mergeParameterLists(List(1, 3, 5, 6, 8)))
 
   @Test
-  def partialValsWithBody = new FileSet {
+  def partialValsWithBody() = new FileSet {
     """
     package mergeParameterLists.partialValsWithBody
     class A {
@@ -370,7 +370,7 @@ class MergeParameterListsTest extends TestHelper with TestRefactoring {
   } applyRefactoring(mergeParameterLists(List(1, 3, 5, 6, 8)))
 
   @Test(expected=classOf[RefactoringException])
-  def mergePointUsedForCurrying = new FileSet {
+  def mergePointUsedForCurrying() = new FileSet {
     """
     package mergeParameterLists.mergePointUsedForCurrying
     class A {
@@ -388,7 +388,7 @@ class MergeParameterListsTest extends TestHelper with TestRefactoring {
   } applyRefactoring(mergeParameterLists(1::2::Nil))
 
   @Test
-  def partiallyAppliedMethodUsage = new FileSet {
+  def partiallyAppliedMethodUsage() = new FileSet {
     """
       package splitParameterLists.partiallyAppliedMethodUsage
       class A {
@@ -408,7 +408,7 @@ class MergeParameterListsTest extends TestHelper with TestRefactoring {
   } applyRefactoring(mergeParameterLists(1::3::Nil))
 
   @Test
-  def partiallyAppliedMethodUsage2 = new FileSet {
+  def partiallyAppliedMethodUsage2() = new FileSet {
     """
       package splitParameterLists.partiallyAppliedMethodUsage2
       class A {

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/MoveClassTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/MoveClassTest.scala
@@ -24,7 +24,7 @@ class MoveClassTest extends TestHelper with TestRefactoring {
   }
 
   @Test
-  def moveBetweenPackages = new FileSet {
+  def moveBetweenPackages() = new FileSet {
     """
       package a.b.c
       class ToMove
@@ -36,7 +36,7 @@ class MoveClassTest extends TestHelper with TestRefactoring {
   } applyRefactoring(moveTo("x.y"))
 
   @Test
-  def moveWithoutEmptyLineAtEOF = new FileSet {
+  def moveWithoutEmptyLineAtEOF() = new FileSet {
     """
       package a.b.c
 
@@ -56,7 +56,7 @@ class MoveClassTest extends TestHelper with TestRefactoring {
   } applyRefactoring(moveTo("hehe"))
 
   @Test
-  def moveFromDefaultPackage = new FileSet {
+  def moveFromDefaultPackage() = new FileSet {
     """
       import java.util.ArrayList
 
@@ -70,7 +70,7 @@ class MoveClassTest extends TestHelper with TestRefactoring {
   } applyRefactoring(moveTo("a.b"))
 
   @Test
-  def moveToParent = new FileSet {
+  def moveToParent() = new FileSet {
     """
       package a.b.c
 
@@ -86,7 +86,7 @@ class MoveClassTest extends TestHelper with TestRefactoring {
   } applyRefactoring(moveTo("a.b"))
 
   @Test
-  def moveToSubpackage = new FileSet {
+  def moveToSubpackage() = new FileSet {
     """
       package a
 
@@ -100,7 +100,7 @@ class MoveClassTest extends TestHelper with TestRefactoring {
   } applyRefactoring(moveTo("a.b.c"))
 
   @Test
-  def moveObjectBetweenPackages = new FileSet {
+  def moveObjectBetweenPackages() = new FileSet {
     """
       package a.b.c
       import java.util.ArrayList
@@ -113,7 +113,7 @@ class MoveClassTest extends TestHelper with TestRefactoring {
   } applyRefactoring(moveTo("x.y"))
 
   @Test
-  def moveBetweenNestedPackages = new FileSet {
+  def moveBetweenNestedPackages() = new FileSet {
     """
       package a
       package b
@@ -127,7 +127,7 @@ class MoveClassTest extends TestHelper with TestRefactoring {
   } applyRefactoring(moveTo("x.y"))
 
   @Test
-  def moveBetweenSubPackage = new FileSet {
+  def moveBetweenSubPackage() = new FileSet {
     """
       package org.com
       package pkg
@@ -141,7 +141,7 @@ class MoveClassTest extends TestHelper with TestRefactoring {
   } applyRefactoring(moveTo("org.com.other"))
 
   @Test
-  def moveToSuperPackage = new FileSet {
+  def moveToSuperPackage() = new FileSet {
     """
       package org.com
       package pkg
@@ -154,7 +154,7 @@ class MoveClassTest extends TestHelper with TestRefactoring {
   } applyRefactoring(moveTo("org.com"))
 
   @Test
-  def moveOneFromManyWithSelfReference = new FileSet {
+  def moveOneFromManyWithSelfReference() = new FileSet {
     """
       package org.com
       package pkg
@@ -182,7 +182,7 @@ class MoveClassTest extends TestHelper with TestRefactoring {
   } applyRefactoring(moveTo("org.com"))
 
   @Test
-  def moveOneFromMany = new FileSet {
+  def moveOneFromMany() = new FileSet {
     """
       package org.com
       package pkg
@@ -206,7 +206,7 @@ class MoveClassTest extends TestHelper with TestRefactoring {
   } applyRefactoring(moveTo("org.com"))
 
   @Test
-  def moveOneFromManyWithDoc = new FileSet {
+  def moveOneFromManyWithDoc() = new FileSet {
     """
       package org.com
       package pkg
@@ -243,7 +243,7 @@ class MoveClassTest extends TestHelper with TestRefactoring {
   } applyRefactoring(moveTo("org.com.whatever"))
 
   @Test
-  def moveClassWithImplementation = new FileSet {
+  def moveClassWithImplementation() = new FileSet {
     """
       package org.com
       package pkg
@@ -280,7 +280,7 @@ class MoveClassTest extends TestHelper with TestRefactoring {
   } applyRefactoring(moveTo("ch.misto"))
 
   @Test
-  def moveClassesWithImports = new FileSet {
+  def moveClassesWithImports() = new FileSet {
     """
       package org.com
       package pkg
@@ -311,7 +311,7 @@ class MoveClassTest extends TestHelper with TestRefactoring {
   } applyRefactoring(moveTo("ch.misto"))
 
   @Test
-  def wildcardsNotExpanded = new FileSet {
+  def wildcardsNotExpanded() = new FileSet {
     """
       package org.com
       package pkg
@@ -334,7 +334,7 @@ class MoveClassTest extends TestHelper with TestRefactoring {
   } applyRefactoring(moveTo("ch.misto"))
 
   @Test
-  def moveClassWithImports = new FileSet {
+  def moveClassWithImports() = new FileSet {
     """
       package org.com
       package pkg
@@ -372,7 +372,7 @@ class MoveClassTest extends TestHelper with TestRefactoring {
   } applyRefactoring(moveTo("ch.misto"))
 
   @Test
-  def moveClassThatExtendsFromRequiredImport = new FileSet {
+  def moveClassThatExtendsFromRequiredImport() = new FileSet {
     """
       package org.com
       package pkg
@@ -412,7 +412,7 @@ class MoveClassTest extends TestHelper with TestRefactoring {
   } applyRefactoring(moveTo("ch.misto"))
 
   @Test
-  def moveClassWithDepOnCurrentPackage = new FileSet {
+  def moveClassWithDepOnCurrentPackage() = new FileSet {
     """
       package org.com
       package pkg
@@ -439,7 +439,7 @@ class MoveClassTest extends TestHelper with TestRefactoring {
   } applyRefactoring(moveTo("org.com.other"))
 
   @Test
-  def copyrightHeaderIsMovedAlong = new FileSet {
+  def copyrightHeaderIsMovedAlong() = new FileSet {
     """
       // Copyright 2012 ..
       package org.com
@@ -468,7 +468,7 @@ class MoveClassTest extends TestHelper with TestRefactoring {
   } applyRefactoring(moveTo("ch.hsr"))
 
   @Test
-  def moveWithAdaptedImport = new FileSet {
+  def moveWithAdaptedImport() = new FileSet {
     """
       package a.b.c
 
@@ -497,7 +497,7 @@ class MoveClassTest extends TestHelper with TestRefactoring {
   } applyRefactoring(moveTo("x.y"))
 
   @Test
-  def moveMulipleClassesWithAdaptedImport = new FileSet {
+  def moveMulipleClassesWithAdaptedImport() = new FileSet {
     """
       package a.b.c
 
@@ -530,7 +530,7 @@ class MoveClassTest extends TestHelper with TestRefactoring {
   } applyRefactoring(moveTo("x.y"))
 
   @Test
-  def needImportToOriginatingPackage = new FileSet {
+  def needImportToOriginatingPackage() = new FileSet {
     addToCompiler("X", """
       package a.b.c
 
@@ -556,7 +556,7 @@ class MoveClassTest extends TestHelper with TestRefactoring {
   } applyRefactoring(moveTo("x.y"))
 
   @Test
-  def moveWithAdaptedImportWithManySelectors = new FileSet {
+  def moveWithAdaptedImportWithManySelectors() = new FileSet {
     addToCompiler("X", """
       package a.b.c
 
@@ -592,7 +592,7 @@ class MoveClassTest extends TestHelper with TestRefactoring {
   } applyRefactoring(moveTo("x.y"))
 
   @Test
-  def moveClassWithMultipleDependenciesOnCurrentFile = new FileSet {
+  def moveClassWithMultipleDependenciesOnCurrentFile() = new FileSet {
     """
     package arith
 
@@ -626,7 +626,7 @@ class MoveClassTest extends TestHelper with TestRefactoring {
   } applyRefactoring(moveTo("a.b.c.d"))
 
   @Test
-  def adaptFQN = new FileSet {
+  def adaptFQN() = new FileSet {
     """
       package a.b.c
       class /*(*/ToMove/*)*/
@@ -647,7 +647,7 @@ class MoveClassTest extends TestHelper with TestRefactoring {
   } applyRefactoring(moveTo("x.y"))
 
   @Test
-  def adaptReferenceFromSamePackage = new FileSet {
+  def adaptReferenceFromSamePackage() = new FileSet {
     """
       package a.b.c
       class /*(*/ToMove/*)*/
@@ -672,7 +672,7 @@ class MoveClassTest extends TestHelper with TestRefactoring {
   } applyRefactoring(moveTo("x.y"))
 
   @Test
-  def adaptReferenceInValDefWithoutImport = new FileSet {
+  def adaptReferenceInValDefWithoutImport() = new FileSet {
     """
       package a.b.c
       class /*(*/ToMove/*)*/
@@ -700,7 +700,7 @@ class MoveClassTest extends TestHelper with TestRefactoring {
   } applyRefactoring(moveTo("x.y"))
 
   @Test
-  def adaptReferenceInValDefWithImport = new FileSet {
+  def adaptReferenceInValDefWithImport() = new FileSet {
     """
       package a.b.c
       class /*(*/ToMove/*)*/
@@ -723,7 +723,7 @@ class MoveClassTest extends TestHelper with TestRefactoring {
   } applyRefactoring(moveTo("x.y"))
 
   @Test
-  def adaptReferenceFromSubPackage = new FileSet {
+  def adaptReferenceFromSubPackage() = new FileSet {
     """
       package a.b
       package c
@@ -747,7 +747,7 @@ class MoveClassTest extends TestHelper with TestRefactoring {
   } applyRefactoring(moveTo("x.y"))
 
   @Test
-  def moveMultipleClassesWithInterdependencies = new FileSet {
+  def moveMultipleClassesWithInterdependencies() = new FileSet {
     """
     package org.scala-refactoring-library
 
@@ -783,7 +783,7 @@ class MoveClassTest extends TestHelper with TestRefactoring {
   } applyRefactoring(moveTo("org.scala-refactoring"))
 
   @Test
-  def moveToDefaultPackage = new FileSet {
+  def moveToDefaultPackage() = new FileSet {
     """
     package ctes
 
@@ -803,7 +803,7 @@ class MoveClassTest extends TestHelper with TestRefactoring {
   } applyRefactoring(moveTo(""))
 
   @Test
-  def moveCompanionObjectAlongNoOtherImpls = new FileSet {
+  def moveCompanionObjectAlongNoOtherImpls() = new FileSet {
     """
     object /*(*/BFF/*)*/
     class BFF
@@ -818,7 +818,7 @@ class MoveClassTest extends TestHelper with TestRefactoring {
 
   @Ignore
   @Test
-  def moveCompanionObjectAlong = new FileSet {
+  def moveCompanionObjectAlong() = new FileSet {
     """
     object /*(*/BFF/*)*/
     class BFF
@@ -831,7 +831,7 @@ class MoveClassTest extends TestHelper with TestRefactoring {
   } applyRefactoring(moveTo("bff"))
 
   @Test
-  def moveFromDefaultPackageNoImports = new FileSet {
+  def moveFromDefaultPackageNoImports() = new FileSet {
     """
     object Ctes {
       val A = 2
@@ -849,7 +849,7 @@ class MoveClassTest extends TestHelper with TestRefactoring {
   } applyRefactoring(moveTo("ctes"))
 
   @Test
-  def updateReferencesToMovedObject = new FileSet {
+  def updateReferencesToMovedObject() = new FileSet {
     """
     object Bar64 {
       val instance = new Bar64
@@ -886,7 +886,7 @@ class MoveClassTest extends TestHelper with TestRefactoring {
   } applyRefactoring(moveTo("bar"))
 
   @Test
-  def nestedPackageAndImports = new FileSet {
+  def nestedPackageAndImports() = new FileSet {
     """
     package x
     package y
@@ -917,7 +917,7 @@ class MoveClassTest extends TestHelper with TestRefactoring {
   } applyRefactoring(moveTo("x.z"))
 
   @Test
-  def adaptLotsOfReferences = new FileSet {
+  def adaptLotsOfReferences() = new FileSet {
     """
       package a.b
       package c
@@ -966,7 +966,7 @@ class MoveClassTest extends TestHelper with TestRefactoring {
   } applyRefactoring(moveTo("x.y"))
 
   @Test
-  def moveManyClassesAdaptReferences = new FileSet {
+  def moveManyClassesAdaptReferences() = new FileSet {
     """
       package a.b.c
       trait Aa
@@ -1014,7 +1014,7 @@ class MoveClassTest extends TestHelper with TestRefactoring {
   } applyRefactoring(moveTo("x.y"))
 
   @Test
-  def moveObject = new FileSet {
+  def moveObject() = new FileSet {
     """package arith
 
 sealed abstract class Term

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/MoveConstructorToCompanionObjectTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/MoveConstructorToCompanionObjectTest.scala
@@ -15,7 +15,7 @@ class MoveConstructorToCompanionObjectTest extends TestHelper with TestRefactori
   }.changes
 
   @Test
-  def moveConstructorToExistingCompanion = new FileSet {
+  def moveConstructorToExistingCompanion() = new FileSet {
     """
       package moveConstructorToCompanion.existingCompanion
 
@@ -39,7 +39,7 @@ class MoveConstructorToCompanionObjectTest extends TestHelper with TestRefactori
   } applyRefactoring(moveConstructorToCompanion)
 
   @Test
-  def existingCompanionWithMethods = new FileSet {
+  def existingCompanionWithMethods() = new FileSet {
     """
       package moveConstructorToCompanion.existingCompanionWithMethods
 
@@ -69,7 +69,7 @@ class MoveConstructorToCompanionObjectTest extends TestHelper with TestRefactori
   } applyRefactoring(moveConstructorToCompanion)
 
   @Test
-  def withoutExistingCompanion = new FileSet {
+  def withoutExistingCompanion() = new FileSet {
     """
       package moveConstructorToCompanion.withoutExistingCompanion
 
@@ -89,7 +89,7 @@ class MoveConstructorToCompanionObjectTest extends TestHelper with TestRefactori
   } applyRefactoring(moveConstructorToCompanion)
 
   @Test
-  def withoutExistingCompanionWithEnclosingClass = new FileSet {
+  def withoutExistingCompanionWithEnclosingClass() = new FileSet {
     """
       package moveConstructorToCompanion.withoutExistingCompanionWithEnclosingClass
 
@@ -117,7 +117,7 @@ class MoveConstructorToCompanionObjectTest extends TestHelper with TestRefactori
   } applyRefactoring(moveConstructorToCompanion)
 
   @Test
-  def withoutExistingCompanionWithEnclosingObject = new FileSet {
+  def withoutExistingCompanionWithEnclosingObject() = new FileSet {
     """
       package moveConstructorToCompanion.withoutExistingCompanionWithEnclosingObject
 
@@ -145,7 +145,7 @@ class MoveConstructorToCompanionObjectTest extends TestHelper with TestRefactori
   } applyRefactoring(moveConstructorToCompanion)
 
   @Test
-  def withoutExistingCompanionWithEnclosingMethod = new FileSet {
+  def withoutExistingCompanionWithEnclosingMethod() = new FileSet {
     """
       package moveConstructorToCompanion.withoutExistingCompanionWithEnclosingMethod
 
@@ -174,7 +174,7 @@ class MoveConstructorToCompanionObjectTest extends TestHelper with TestRefactori
   } applyRefactoring(moveConstructorToCompanion)
 
   @Test
-  def withoutExistingCompanionWithEnclosingVal = new FileSet {
+  def withoutExistingCompanionWithEnclosingVal() = new FileSet {
     """
       package moveConstructorToCompanion.withoutExistingCompanionWithEnclosingVal
 
@@ -203,7 +203,7 @@ class MoveConstructorToCompanionObjectTest extends TestHelper with TestRefactori
   } applyRefactoring(moveConstructorToCompanion)
 
   @Test
-  def withTypeParams = new FileSet {
+  def withTypeParams() = new FileSet {
     """
       package moveConstructorToCompanion.withTypeParams
 
@@ -225,7 +225,7 @@ class MoveConstructorToCompanionObjectTest extends TestHelper with TestRefactori
   } applyRefactoring(moveConstructorToCompanion)
 
   @Test
-  def curriedConstructor = new FileSet {
+  def curriedConstructor() = new FileSet {
     """
       package moveConstructorToCompanion.curriedConstructor
 
@@ -247,7 +247,7 @@ class MoveConstructorToCompanionObjectTest extends TestHelper with TestRefactori
   } applyRefactoring(moveConstructorToCompanion)
 
   @Test
-  def constructorWithoutParameters = new FileSet {
+  def constructorWithoutParameters() = new FileSet {
     """
       package moveConstructorToCompanion.emptyConstructor
 
@@ -269,7 +269,7 @@ class MoveConstructorToCompanionObjectTest extends TestHelper with TestRefactori
   } applyRefactoring(moveConstructorToCompanion)
 
   @Test
-  def replaceConstructorCallsWithoutExistingCompanion = new FileSet {
+  def replaceConstructorCallsWithoutExistingCompanion() = new FileSet {
     """
       package moveConstructorToCompanion.replaceConstructorCallsWithoutExistingCompanion
 
@@ -298,7 +298,7 @@ class MoveConstructorToCompanionObjectTest extends TestHelper with TestRefactori
 
 
   @Test
-  def replaceConstructorCallsInObject = new FileSet {
+  def replaceConstructorCallsInObject() = new FileSet {
     """
       package moveConstructorToCompanion.replaceConstructorCallsInObject
 

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
@@ -22,7 +22,7 @@ class RenameTest extends TestHelper with TestRefactoring {
   }.changes
 
   @Test
-  def renameOverlapping = new FileSet {
+  def renameOverlapping() = new FileSet {
     """
       package renameOverlapping
 
@@ -52,7 +52,7 @@ class RenameTest extends TestHelper with TestRefactoring {
   } applyRefactoring(renameTo("Dice"))
 
   @Test
-  def renameRecursive = new FileSet {
+  def renameRecursive() = new FileSet {
     """
       package renameRecursive
       class A {
@@ -74,7 +74,7 @@ class RenameTest extends TestHelper with TestRefactoring {
   } applyRefactoring(renameTo("recursiveLength"))
 
   @Test
-  def renameLocalValue = new FileSet {
+  def renameLocalValue() = new FileSet {
     """
       package renameLocal1
       class A {
@@ -100,7 +100,7 @@ class RenameTest extends TestHelper with TestRefactoring {
   } applyRefactoring(renameTo("b"))
 
   @Test
-  def renameLazyVal = new FileSet {
+  def renameLazyVal() = new FileSet {
     """
     package renameLazyVal
     class A {
@@ -122,7 +122,7 @@ class RenameTest extends TestHelper with TestRefactoring {
   } applyRefactoring(renameTo("b"))
 
   @Test
-  def renameLazyValFromDefinition = new FileSet {
+  def renameLazyValFromDefinition() = new FileSet {
     """
     package renameLazyVals
     class A {
@@ -144,7 +144,7 @@ class RenameTest extends TestHelper with TestRefactoring {
   } applyRefactoring(renameTo("c"))
 
   @Test
-  def renameParameterWithoutSelection = new FileSet {
+  def renameParameterWithoutSelection() = new FileSet {
     """
     package renameParameter
     class A {
@@ -164,7 +164,7 @@ class RenameTest extends TestHelper with TestRefactoring {
   } applyRefactoring(renameTo("b"))
 
   @Test
-  def renameParameter = new FileSet {
+  def renameParameter() = new FileSet {
     """
     package renameParameter
     class A {
@@ -184,7 +184,7 @@ class RenameTest extends TestHelper with TestRefactoring {
   } applyRefactoring(renameTo("b"))
 
   @Test
-  def renameWithType = new FileSet {
+  def renameWithType() = new FileSet {
     """
     package renameWithType
     class A {
@@ -208,7 +208,7 @@ class RenameTest extends TestHelper with TestRefactoring {
   } applyRefactoring(renameTo("c"))
 
   @Test
-  def renameMultiAssignment = new FileSet {
+  def renameMultiAssignment() = new FileSet {
     """
     package renameMultiAssignment
     class A {
@@ -230,7 +230,7 @@ class RenameTest extends TestHelper with TestRefactoring {
   } applyRefactoring(renameTo("c"))
 
   @Test
-  def renameMultiAssignmentWithTA = new FileSet {
+  def renameMultiAssignmentWithTA() = new FileSet {
     """
     package renameMultiAssignment
     class A {
@@ -252,7 +252,7 @@ class RenameTest extends TestHelper with TestRefactoring {
   } applyRefactoring(renameTo("c"))
 
   @Test
-  def renameClassWithTypeParameters = new FileSet {
+  def renameClassWithTypeParameters() = new FileSet {
     """
     case class /*(*/Test/*)*/[A, B](a:A,b:B)
     """ becomes
@@ -262,7 +262,7 @@ class RenameTest extends TestHelper with TestRefactoring {
   } applyRefactoring(renameTo("Test1"))
 
   @Test
-  def renameAbstractType = new FileSet {
+  def renameAbstractType() = new FileSet {
     """
     trait O {
       trait Property[+T]
@@ -280,7 +280,7 @@ class RenameTest extends TestHelper with TestRefactoring {
   } applyRefactoring(renameTo("Prop_Tpe"))
 
   @Test
-  def renameReferenceToOuterclass = new FileSet {
+  def renameReferenceToOuterclass() = new FileSet {
     """
     package renameReferenceToOuterclass
     class /*(*/Foo/*)*/ {
@@ -300,7 +300,7 @@ class RenameTest extends TestHelper with TestRefactoring {
   } applyRefactoring(renameTo("Blubb"))
 
   @Test
-  def renameDeconstructingAssignment = new FileSet {
+  def renameDeconstructingAssignment() = new FileSet {
     """
     package renameMultiAssignment
     class A {
@@ -322,7 +322,7 @@ class RenameTest extends TestHelper with TestRefactoring {
   } applyRefactoring(renameTo("c"))
 
   @Test
-  def renameBinding = new FileSet {
+  def renameBinding() = new FileSet {
     """
     package renameBinding
     class A {
@@ -342,7 +342,7 @@ class RenameTest extends TestHelper with TestRefactoring {
   } applyRefactoring(renameTo("integer"))
 
   @Test
-  def renameNewVal = new FileSet {
+  def renameNewVal() = new FileSet {
     """
     package renameNewVal
     class A(i: Int) {
@@ -362,7 +362,7 @@ class RenameTest extends TestHelper with TestRefactoring {
   } applyRefactoring(renameTo("ls"))
 
   @Test
-  def renameLazyArg = new FileSet {
+  def renameLazyArg() = new FileSet {
     """
     package renameLazyArg
     class A(i: Int) {
@@ -382,7 +382,7 @@ class RenameTest extends TestHelper with TestRefactoring {
   } applyRefactoring(renameTo("s"))
 
   @Test
-  def forComprehension = new FileSet {
+  def forComprehension() = new FileSet {
     """
     package forComprehension
     class A {
@@ -402,7 +402,7 @@ class RenameTest extends TestHelper with TestRefactoring {
   } applyRefactoring(renameTo("index"))
 
   @Test
-  def inConstructor = new FileSet {
+  def inConstructor() = new FileSet {
     """
     package inConstructor
     class A(i: Int) {
@@ -418,7 +418,7 @@ class RenameTest extends TestHelper with TestRefactoring {
   } applyRefactoring(renameTo("iTimesTwo"))
 
   @Test
-  def renameMethod = new FileSet {
+  def renameMethod() = new FileSet {
     """
     package renameMethod
     class A {
@@ -448,7 +448,7 @@ class RenameTest extends TestHelper with TestRefactoring {
   } applyRefactoring(renameTo("x"))
 
   @Test
-  def renameMethodInMultipleFiles = new FileSet {
+  def renameMethodInMultipleFiles() = new FileSet {
     """
     package rename
     class A {
@@ -479,7 +479,7 @@ class RenameTest extends TestHelper with TestRefactoring {
   } applyRefactoring(renameTo("x"))
 
   @Test
-  def renameClass = new FileSet {
+  def renameClass() = new FileSet {
     """
     package renameClass
     /*(*/  class A  /*)*/
@@ -512,7 +512,7 @@ class RenameTest extends TestHelper with TestRefactoring {
   } applyRefactoring(renameTo("X"))
 
   @Test
-  def renameTypeParameter = new FileSet {
+  def renameTypeParameter() = new FileSet {
     """
     package ex
 
@@ -532,7 +532,7 @@ class RenameTest extends TestHelper with TestRefactoring {
   } applyRefactoring(renameTo("Md"))
 
   @Test
-  def renameSuperClass = new FileSet {
+  def renameSuperClass() = new FileSet {
     """
     package ex
 
@@ -552,7 +552,7 @@ class RenameTest extends TestHelper with TestRefactoring {
   } applyRefactoring(renameTo("Expr"))
 
   @Test
-  def renameType = new FileSet {
+  def renameType() = new FileSet {
     """
 
     class Person(name: String)
@@ -582,7 +582,7 @@ class RenameTest extends TestHelper with TestRefactoring {
   } applyRefactoring(renameTo("P"))
 
   @Test
-  def renameCaseClass = new FileSet {
+  def renameCaseClass() = new FileSet {
     """
     case class /*(*/Person/*)*/(name: String)
 
@@ -598,7 +598,7 @@ class RenameTest extends TestHelper with TestRefactoring {
   } applyRefactoring(renameTo("P"))
 
   @Test
-  def renameSelfType = new FileSet {
+  def renameSelfType() = new FileSet {
     """
     trait /*(*/T1/*)*/
 
@@ -616,7 +616,7 @@ class RenameTest extends TestHelper with TestRefactoring {
   } applyRefactoring renameTo("Trait")
 
   @Test
-  def renameSelfType2 = new FileSet {
+  def renameSelfType2() = new FileSet {
     """
     trait /*(*/T1/*)*/
     trait T2
@@ -636,7 +636,7 @@ class RenameTest extends TestHelper with TestRefactoring {
   } applyRefactoring(renameTo("Trait"))
 
   @Test
-  def renameClassWithImport = new FileSet {
+  def renameClassWithImport() = new FileSet {
     """
     package withTrait
     trait /*(*/T/*)*/
@@ -659,7 +659,7 @@ class RenameTest extends TestHelper with TestRefactoring {
   } applyRefactoring(renameTo("Trait"))
 
   @Test
-  def renamePackages = new FileSet {
+  def renamePackages() = new FileSet {
     """
     package /*(*/p1/*)*/
     """ becomes
@@ -678,7 +678,7 @@ class RenameTest extends TestHelper with TestRefactoring {
   } applyRefactoring(renameTo("refactoring"))
 
   @Test
-  def renameInnerPackages = new FileSet {
+  def renameInnerPackages() = new FileSet {
     """
     package p1
     package /*(*/   p2  /*)*/ {
@@ -707,14 +707,14 @@ class RenameTest extends TestHelper with TestRefactoring {
   } applyRefactoring(renameTo("refactoring"))
 
   @Test
-  def renameUnderWindows = new FileSet {
+  def renameUnderWindows() = new FileSet {
     "package com.test\r\nobject Hello {\r\n  def test = {\r\n    val /*(*/loc/*)*/ = 42\r\n    loc * loc\r\n  }\r\n}" becomes
     "package com.test\r\nobject Hello {\r\n  def test = {\r\n    val /*(*/fourtytwo/*)*/ = 42\r\n    fourtytwo * fourtytwo\r\n  }\r\n}"
   } applyRefactoring(renameTo("fourtytwo"))
 
 
   @Test
-  def renameCaseClassAndObject = new FileSet {
+  def renameCaseClassAndObject() = new FileSet {
     """
       object /*(*/TestIde/*)*/ {}
 
@@ -728,7 +728,7 @@ class RenameTest extends TestHelper with TestRefactoring {
   } applyRefactoring(renameTo("TestIde1"))
 
   @Test
-  def renameNestedType = new FileSet {
+  def renameNestedType() = new FileSet {
     """
     trait /*(*/Thing/*)*/ {
       val otherThings: Set[Thing] = Set()
@@ -744,7 +744,7 @@ class RenameTest extends TestHelper with TestRefactoring {
   } applyRefactoring(renameTo("X"))
 
   @Test
-  def renameIdentifierWithBackticks = new FileSet {
+  def renameIdentifierWithBackticks() = new FileSet {
     """
     trait StrangeIdentifiers {
       val /*(*/`my strange identifier`/*)*/ = "foo"
@@ -760,7 +760,7 @@ class RenameTest extends TestHelper with TestRefactoring {
   } applyRefactoring(renameTo("`my strange identifier again`"))
 
   @Test
-  def renameClassWithBackTicks = new FileSet {
+  def renameClassWithBackTicks() = new FileSet {
     """
     package renameClassWithBackTicks
     /*(*/
@@ -778,7 +778,7 @@ class RenameTest extends TestHelper with TestRefactoring {
   } applyRefactoring(renameTo("`X Y`"))
 
   @Test
-  def renameTypeParamInSecondConstructor = new FileSet {
+  def renameTypeParamInSecondConstructor() = new FileSet {
     """
     trait /*(*/X/*)*/
 
@@ -800,7 +800,7 @@ class RenameTest extends TestHelper with TestRefactoring {
   } applyRefactoring(renameTo("Comp"))
 
   @Test
-  def renameSingleVariableDeconstructingAssignment = new FileSet {
+  def renameSingleVariableDeconstructingAssignment() = new FileSet {
     """
     package renameSingleVariableDeconstructingAssignment
     class A {
@@ -822,7 +822,7 @@ class RenameTest extends TestHelper with TestRefactoring {
   } applyRefactoring(renameTo("c"))
 
   @Test
-  def renameSingleVariableDeconstructingAssignment2 = new FileSet {
+  def renameSingleVariableDeconstructingAssignment2() = new FileSet {
     """
     package renameSingleVariableDeconstructingAssignment2
     class A {
@@ -844,7 +844,7 @@ class RenameTest extends TestHelper with TestRefactoring {
   } applyRefactoring(renameTo("c"))
 
   @Test
-  def renameSingleVariableDeconstructingAssignment3 = new FileSet {
+  def renameSingleVariableDeconstructingAssignment3() = new FileSet {
     """
     package renameSingleVariableDeconstructingAssignment2
     class A {
@@ -868,7 +868,7 @@ class RenameTest extends TestHelper with TestRefactoring {
   } applyRefactoring(renameTo("c"))
 
   @Test
-  def renameSingleVariableDeconstructingAssignment4 = new FileSet {
+  def renameSingleVariableDeconstructingAssignment4() = new FileSet {
     """
     package renameSingleVariableDeconstructingAssignment4
     class A {
@@ -890,7 +890,7 @@ class RenameTest extends TestHelper with TestRefactoring {
   } applyRefactoring(renameTo("c"))
 
   @Test
-  def renameSingleVariableDeconstructingAssignment5 = new FileSet {
+  def renameSingleVariableDeconstructingAssignment5() = new FileSet {
     """
     package renameSingleVariableDeconstructingAssignment5
     class A {
@@ -912,7 +912,7 @@ class RenameTest extends TestHelper with TestRefactoring {
   } applyRefactoring(renameTo("c"))
 
   @Test
-  def renameSingleVariableDeconstructingAssignment6 = new FileSet {
+  def renameSingleVariableDeconstructingAssignment6() = new FileSet {
     """
     package renameSingleVariableDeconstructingAssignment6
     class A {
@@ -935,7 +935,7 @@ class RenameTest extends TestHelper with TestRefactoring {
 
 
   @Test
-  def renameClassParameterPassedIntoSuperClassWithExpression = new FileSet {
+  def renameClassParameterPassedIntoSuperClassWithExpression() = new FileSet {
     """
     class Class(/*(*/a/*)*/: String) extends RuntimeException(a + "")
     """ becomes
@@ -945,7 +945,7 @@ class RenameTest extends TestHelper with TestRefactoring {
   } applyRefactoring(renameTo("b"))
 
   @Test
-  def renameClassParameterPassedIntoSuperClassWithExpression2 = new FileSet {
+  def renameClassParameterPassedIntoSuperClassWithExpression2() = new FileSet {
     """
     package renameClassParameterPassedIntoSuperClassWithExpression2
     class Class(val /*(*/a/*)*/: String) extends RuntimeException(a + "")
@@ -957,7 +957,7 @@ class RenameTest extends TestHelper with TestRefactoring {
   } applyRefactoring(renameTo("b"))
 
   @Test
-  def renameSuperclassAtEndOfFile = new FileSet {
+  def renameSuperclassAtEndOfFile() = new FileSet {
     """
     package renameSuperclassAtEndOfFile
     class /*(*/Bar/*)*/
@@ -969,7 +969,7 @@ class RenameTest extends TestHelper with TestRefactoring {
   } applyRefactoring(renameTo("Baz"))
 
   @Test
-  def renameSuperclassAtEndOfFile2 = new FileSet {
+  def renameSuperclassAtEndOfFile2() = new FileSet {
     """
     package renameSuperclassAtEndOfFile
     class B
@@ -981,7 +981,7 @@ class RenameTest extends TestHelper with TestRefactoring {
   } applyRefactoring(renameTo("Bazadudud"))
 
   @Test
-  def renameMethodInCaseObject = new FileSet {
+  def renameMethodInCaseObject() = new FileSet {
     """
   abstract class Base {
     def /*(*/foo/*)*/ = false
@@ -1009,7 +1009,7 @@ class RenameTest extends TestHelper with TestRefactoring {
   } applyRefactoring(renameTo("babar"))
 
   @Test
-  def renameClassWithClassOfUsage = new FileSet {
+  def renameClassWithClassOfUsage() = new FileSet {
     """
     package renameClassWithClassOfUsage
     class /*(*/Foo/*)*/ {
@@ -1025,7 +1025,7 @@ class RenameTest extends TestHelper with TestRefactoring {
   } applyRefactoring(renameTo("Bar"))
 
   @Test
-  def renameClassExplicitSelfTypeAnnotation= new FileSet {
+  def renameClassExplicitSelfTypeAnnotation() = new FileSet {
     """
     package renameClassExplicitSelfTypeAnnotation
     trait A
@@ -1043,7 +1043,7 @@ class RenameTest extends TestHelper with TestRefactoring {
   } applyRefactoring(renameTo("Babar"))
 
   @Test
-  def renameWithMultipleContextBounds = new FileSet {
+  def renameWithMultipleContextBounds() = new FileSet {
     """
     package test
     class Foo[T] {
@@ -1059,7 +1059,7 @@ class RenameTest extends TestHelper with TestRefactoring {
   } applyRefactoring(renameTo("babar"))
 
   @Test
-  def renameClassWithThisConstuctorCall = new FileSet {
+  def renameClassWithThisConstuctorCall() = new FileSet {
     """
     package renameClassWithThisConstuctorCall
 
@@ -1077,7 +1077,7 @@ class RenameTest extends TestHelper with TestRefactoring {
   } applyRefactoring(renameTo("ConfigX"))
 
   @Test
-  def renameAbstractTypesInHierarchy = new FileSet {
+  def renameAbstractTypesInHierarchy() = new FileSet {
     """
     abstract class A {
       type /*(*/Foo/*)*/
@@ -1103,7 +1103,7 @@ class RenameTest extends TestHelper with TestRefactoring {
   } applyRefactoring(renameTo("ConfigX"))
 
   @Test
-  def renameClassSelfTypeAnnotation = new FileSet {
+  def renameClassSelfTypeAnnotation() = new FileSet {
     """
     package renameClassWithSelfTypeAnnotation
     class /*(*/Foo/*)*/ {
@@ -1119,7 +1119,7 @@ class RenameTest extends TestHelper with TestRefactoring {
   } applyRefactoring(renameTo("Bar"))
 
   @Test
-  def renameClassSelfTypeAnnotation2 = new FileSet {
+  def renameClassSelfTypeAnnotation2() = new FileSet {
     """
     package renameClassWithSelfTypeAnnotation
     class /*(*/Foo/*)*/ {
@@ -1135,7 +1135,7 @@ class RenameTest extends TestHelper with TestRefactoring {
   } applyRefactoring(renameTo("Babar"))
 
   @Test
-  def renameMethodWithContextBound = new FileSet {
+  def renameMethodWithContextBound() = new FileSet {
     """
 object RenameWithContextBound {
   val blubb = new Blubb
@@ -1169,7 +1169,7 @@ class Blubb
   } applyRefactoring(renameTo("abc"))
 
   @Test
-  def coloncolon = new FileSet {
+  def coloncolon() = new FileSet {
     """
     object Problem07 {
       def /*(*/flatten/*)*/(list: List[Any]): List[Any] = list match {
@@ -1193,7 +1193,7 @@ class Blubb
   } applyRefactoring(renameTo("fltn"))
 
   @Test
-  def typeProjection = new FileSet {
+  def typeProjection() = new FileSet {
     """
     class A {
       trait /*(*/B/*)*/
@@ -1209,7 +1209,7 @@ class Blubb
   } applyRefactoring(renameTo("C"))
 
   @Test
-  def overriddenMethod = new FileSet {
+  def overriddenMethod() = new FileSet {
     """
     package overriddenMethod.bar
 
@@ -1248,7 +1248,7 @@ class Blubb
 
   @Ignore
   @Test
-  def namedParameter = new FileSet {
+  def namedParameter() = new FileSet {
     """
     class NamedParameter {
       def foo(/*(*/b/*)*/: Int, c: String) {
@@ -1269,7 +1269,7 @@ class Blubb
 
   @Ignore
   @Test
-  def namedParameterAndDefault = new FileSet {
+  def namedParameterAndDefault() = new FileSet {
     """
     class NamedParameter {
       def foo(/*(*/b/*)*/: Int, c: String = "") {
@@ -1290,7 +1290,7 @@ class Blubb
 
   @Ignore
   @Test
-  def namedParameterInDeclaredOrder = new FileSet {
+  def namedParameterInDeclaredOrder() = new FileSet {
     """
     class NamedParameter {
       def foo(/*(*/b/*)*/: Int, c: String) {
@@ -1311,7 +1311,7 @@ class Blubb
 
   @Ignore
   @Test
-  def namedParameterInSecondArgsList = new FileSet {
+  def namedParameterInSecondArgsList() = new FileSet {
     """
     class NamedParameter {
       def foo(x: Int)(/*(*/b/*)*/: Int, c: String) {
@@ -1332,7 +1332,7 @@ class Blubb
 
   @Ignore
   @Test
-  def updateMethodAndNamedArgument = new FileSet {
+  def updateMethodAndNamedArgument() = new FileSet {
     """
     class Updateable { def update(/*(*/what/*)*/: Int, rest: Int) = 0 }
 
@@ -1352,7 +1352,7 @@ class Blubb
   } applyRefactoring(renameTo("xys"))
 
   @Test
-  def privatePrimaryConstructor = new FileSet {
+  def privatePrimaryConstructor() = new FileSet {
     """
     class /*(*/SomeClass/*)*/ private () extends AnyRef {
       def meta = SomeClass
@@ -1368,7 +1368,7 @@ class Blubb
   } applyRefactoring(renameTo("RenamedClass"))
 
   @Test
-  def constructionInforComprehension = new FileSet {
+  def constructionInforComprehension() = new FileSet {
     """
     package constructorInForComprehension
     case class /*(*/A/*)*/(val x: Int)
@@ -1388,7 +1388,7 @@ class Blubb
   } applyRefactoring(renameTo("BBB"))
 
   @Test
-  def privateMembersTupleNotation = new FileSet {
+  def privateMembersTupleNotation() = new FileSet {
     """
     package privateMembersTupleNotation
     class /*(*/Test/*)*/ {
@@ -1406,7 +1406,7 @@ class Blubb
   } applyRefactoring(renameTo("MyTest"))
 
   @Test
-  def renameMethodForComprehensionBody = new FileSet {
+  def renameMethodForComprehensionBody() = new FileSet {
     """
     package renameMethodForComprehensionBody
     class Testing {
@@ -1440,7 +1440,7 @@ class Blubb
   } applyRefactoring(renameTo("getContent"))
 
   @Test
-  def renameApplyCall = new FileSet {
+  def renameApplyCall() = new FileSet {
     """
     package renameApplyCall
     object Foo {
@@ -1466,7 +1466,7 @@ class Blubb
   } applyRefactoring(renameTo("list"))
 
   @Test
-  def renameFinalVal = new FileSet {
+  def renameFinalVal() = new FileSet {
     """
     package renameFinalVal
 

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/SplitParameterListsTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/SplitParameterListsTest.scala
@@ -17,7 +17,7 @@ class SplitParameterListsTest extends TestHelper with TestRefactoring {
   }.changes
 
   @Test
-  def simpleSplitting = new FileSet {
+  def simpleSplitting() = new FileSet {
     """
       package splitParameterLists.simpleSplitting
     class A {
@@ -33,7 +33,7 @@ class SplitParameterListsTest extends TestHelper with TestRefactoring {
   } applyRefactoring (splitParameterLists(List(1 :: Nil)))
 
   @Test
-  def multipleParamListSplitting = new FileSet {
+  def multipleParamListSplitting() = new FileSet {
     """
       package splitParameterLists.multipleParamListSplitting
     class A {
@@ -49,7 +49,7 @@ class SplitParameterListsTest extends TestHelper with TestRefactoring {
   } applyRefactoring (splitParameterLists(List(1 :: Nil, 1 :: 2 :: Nil)))
 
   @Test
-  def splittingWithMethodCall = new FileSet {
+  def splittingWithMethodCall() = new FileSet {
     """
       package splitParameterLists.splittingWithMethodCall
     class A {
@@ -73,7 +73,7 @@ class SplitParameterListsTest extends TestHelper with TestRefactoring {
   } applyRefactoring (splitParameterLists(List(1 :: Nil, 2 :: Nil)))
 
   @Test
-  def splittingMethodSubclass = new FileSet {
+  def splittingMethodSubclass() = new FileSet {
     """
       package splitParameterLists.splittingMethodSubclass
       class Parent {
@@ -97,7 +97,7 @@ class SplitParameterListsTest extends TestHelper with TestRefactoring {
   } applyRefactoring (splitParameterLists(List(1 :: Nil, 2 :: Nil)))
 
   @Test
-  def splittingMethodSuperclass = new FileSet {
+  def splittingMethodSuperclass() = new FileSet {
     """
       package splitParameterLists.splittingMethodSuperclass
       class Parent {
@@ -121,7 +121,7 @@ class SplitParameterListsTest extends TestHelper with TestRefactoring {
   } applyRefactoring (splitParameterLists(List(1 :: Nil, 2 :: Nil)))
 
   @Test
-  def curriedMethodAliased = new FileSet {
+  def curriedMethodAliased() = new FileSet {
     """
       package splitParameterLists.curriedMethodAliased
       class A {
@@ -141,7 +141,7 @@ class SplitParameterListsTest extends TestHelper with TestRefactoring {
   } applyRefactoring (splitParameterLists(List(1 :: 2 :: Nil)))
 
   @Test
-  def curriedMethodAliasedTwoParamLists = new FileSet {
+  def curriedMethodAliasedTwoParamLists() = new FileSet {
     """
       package splitParameterLists.curriedMethodAliasedTwoParamLists
       class A {
@@ -161,7 +161,7 @@ class SplitParameterListsTest extends TestHelper with TestRefactoring {
   } applyRefactoring (splitParameterLists(List(1 :: Nil, 1 :: Nil)))
 
   @Test
-  def curriedMethodPartiallyApplied = new FileSet {
+  def curriedMethodPartiallyApplied() = new FileSet {
     """
       package splitParameterLists.curriedMethodPartiallyApplied
       class A {
@@ -181,7 +181,7 @@ class SplitParameterListsTest extends TestHelper with TestRefactoring {
   } applyRefactoring (splitParameterLists(List(1 :: Nil, 2 :: Nil)))
 
   @Test
-  def partiallyCurried = new FileSet {
+  def partiallyCurried() = new FileSet {
     """
       package splitParameterLists.partiallyCurried
       class A {
@@ -201,7 +201,7 @@ class SplitParameterListsTest extends TestHelper with TestRefactoring {
   } applyRefactoring (splitParameterLists(List(1 :: Nil, 2 :: Nil, 1 :: Nil)))
 
   @Test
-  def twoPartiallyCurriedMethods = new FileSet {
+  def twoPartiallyCurriedMethods() = new FileSet {
     """
       package splitParameterLists.twoPartiallyCurriedMethods
       class A {
@@ -225,7 +225,7 @@ class SplitParameterListsTest extends TestHelper with TestRefactoring {
   } applyRefactoring (splitParameterLists(List(1 :: Nil, 2 :: Nil, 1 :: Nil)))
 
   @Test
-  def repeatedlyPartiallyApplied = new FileSet {
+  def repeatedlyPartiallyApplied() = new FileSet {
     """
       package splitParameterLists.repeatedlyPartiallyApplied
       class A {
@@ -249,7 +249,7 @@ class SplitParameterListsTest extends TestHelper with TestRefactoring {
   } applyRefactoring (splitParameterLists(List(1 :: Nil, 2 :: Nil, 1 :: Nil, 1 :: Nil)))
 
   @Test
-  def aliasToVal = new FileSet {
+  def aliasToVal() = new FileSet {
     """
       package splitParameterLists.aliasToVal
       class A {
@@ -269,7 +269,7 @@ class SplitParameterListsTest extends TestHelper with TestRefactoring {
   } applyRefactoring (splitParameterLists(List(1 :: Nil, 2 :: Nil)))
 
   @Test
-  def repeatedlyPartiallyAppliedVal = new FileSet {
+  def repeatedlyPartiallyAppliedVal() = new FileSet {
     """
       package splitParameterLists.repeatedlyPartiallyAppliedVal
       class A {
@@ -291,7 +291,7 @@ class SplitParameterListsTest extends TestHelper with TestRefactoring {
   } applyRefactoring (splitParameterLists(List(1 :: Nil, 2 :: Nil, 1 :: Nil)))
 
   @Test
-  def partialsWithBody = new FileSet {
+  def partialsWithBody() = new FileSet {
     """
     package splitParameterLists.partialsWithBody
     class A {
@@ -333,7 +333,7 @@ class SplitParameterListsTest extends TestHelper with TestRefactoring {
   } applyRefactoring (splitParameterLists(List(1 :: Nil, 2 :: Nil, 1 :: 2 :: Nil, 1 :: Nil)))
 
   @Test
-  def partialValsWithBody = new FileSet {
+  def partialValsWithBody() = new FileSet {
     """
     package splitParameterLists.partialsWithBody
     class A {
@@ -376,7 +376,7 @@ class SplitParameterListsTest extends TestHelper with TestRefactoring {
 
   @Test
   @Ignore // TODO: implement
-  def partialOverride = new FileSet {
+  def partialOverride() = new FileSet {
     """
       package splitParameterLists.partialOverride
       class Parent {
@@ -400,7 +400,7 @@ class SplitParameterListsTest extends TestHelper with TestRefactoring {
   } applyRefactoring (splitParameterLists(List(1 :: Nil, 1 :: Nil)))
 
   @Test(expected = classOf[RefactoringException])
-  def unorderedSplitPositions = new FileSet {
+  def unorderedSplitPositions() = new FileSet {
     """
       package splitParameterLists.unorderedSplitPositions
       class Foo {
@@ -416,7 +416,7 @@ class SplitParameterListsTest extends TestHelper with TestRefactoring {
   } applyRefactoring (splitParameterLists(List(2 :: 1 :: Nil)))
 
   @Test(expected = classOf[RefactoringException])
-  def aboveBoundsSplitPosition = new FileSet {
+  def aboveBoundsSplitPosition() = new FileSet {
     """
       package splitParameterLists.aboveBoundsSplitPosition
       class Foo {
@@ -432,7 +432,7 @@ class SplitParameterListsTest extends TestHelper with TestRefactoring {
   } applyRefactoring (splitParameterLists(List(3 :: Nil)))
 
   @Test(expected = classOf[RefactoringException])
-  def belowBoundsSplitPosition = new FileSet {
+  def belowBoundsSplitPosition() = new FileSet {
     """
       package splitParameterLists.belowBoundsSplitPosition
       class Foo {
@@ -448,7 +448,7 @@ class SplitParameterListsTest extends TestHelper with TestRefactoring {
   } applyRefactoring (splitParameterLists(List(0 :: Nil)))
 
   @Test(expected = classOf[RefactoringException])
-  def duplicatedSplitPosition = new FileSet {
+  def duplicatedSplitPosition() = new FileSet {
     """
       package splitParameterLists.duplicatedSplitPosition
       class Foo {
@@ -464,7 +464,7 @@ class SplitParameterListsTest extends TestHelper with TestRefactoring {
   } applyRefactoring (splitParameterLists(List(1 :: 1 :: Nil)))
 
   @Test(expected = classOf[RefactoringException])
-  def tooManySplitPositions = new FileSet {
+  def tooManySplitPositions() = new FileSet {
     """
       package splitParameterLists.tooManySplitPositions
       class Foo {
@@ -480,7 +480,7 @@ class SplitParameterListsTest extends TestHelper with TestRefactoring {
   } applyRefactoring (splitParameterLists(List(1 :: Nil, 1 :: Nil)))
 
   @Test
-  def partiallyAppliedMethodUsage = new FileSet {
+  def partiallyAppliedMethodUsage() = new FileSet {
     """
       package splitParameterLists.partiallyAppliedMethodUsage
       class A {
@@ -500,7 +500,7 @@ class SplitParameterListsTest extends TestHelper with TestRefactoring {
   } applyRefactoring (splitParameterLists(List(1 :: Nil, 1 :: Nil)))
 
   @Test
-  def partiallyAppliedMethodUsage2 = new FileSet {
+  def partiallyAppliedMethodUsage2() = new FileSet {
     """
       package splitParameterLists.partiallyAppliedMethodUsage2
       class A {
@@ -522,7 +522,7 @@ class SplitParameterListsTest extends TestHelper with TestRefactoring {
   } applyRefactoring (splitParameterLists(List(1 :: Nil, 1 :: Nil, 1 :: Nil)))
 
   @Test
-  def partiallyAppliedMethodUsageOutsideClass = new FileSet {
+  def partiallyAppliedMethodUsageOutsideClass() = new FileSet {
     """
     package splitParameterLists.partiallyAppliedMethodUsageOutsideClass
     class A {
@@ -552,7 +552,7 @@ class SplitParameterListsTest extends TestHelper with TestRefactoring {
   } applyRefactoring (splitParameterLists(List(Nil, 1 :: Nil)))
 
   @Test(expected = classOf[PreparationException])
-  def splitConstructor = new FileSet {
+  def splitConstructor() = new FileSet {
     """
     package splitParameterLists.splitConstructor
     class /*SplitMe*/(a: Int, b: Int)

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/extraction/ExtractCodeTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/extraction/ExtractCodeTest.scala
@@ -16,7 +16,7 @@ class ExtractCodeTest extends TestHelper with TestRefactoring {
   }
 
   @Test
-  def extractCodeWithoutUnknownDependencies = new FileSet {
+  def extractCodeWithoutUnknownDependencies() = new FileSet {
     """
       object Demo {
         val a = 1
@@ -33,7 +33,7 @@ class ExtractCodeTest extends TestHelper with TestRefactoring {
   }.performRefactoring(extract("extracted", 1)).assertEqualTree
 
   @Test
-  def extractCodeWithUnknownDependencies = new FileSet {
+  def extractCodeWithUnknownDependencies() = new FileSet {
     """
       object Demo {
         val a = 1
@@ -46,7 +46,7 @@ class ExtractCodeTest extends TestHelper with TestRefactoring {
       """
       object Demo {
         val a = 1
-    
+
         val b = {
           val c = 2
           extracted(c)
@@ -60,7 +60,7 @@ class ExtractCodeTest extends TestHelper with TestRefactoring {
   }.performRefactoring(extract("extracted", 1)).assertEqualTree
 
   @Test
-  def extractMultipleExpressions = new FileSet {
+  def extractMultipleExpressions() = new FileSet {
     """
       object Demo {
         val a = 1
@@ -87,7 +87,7 @@ class ExtractCodeTest extends TestHelper with TestRefactoring {
   }.performRefactoring(extract("extracted", 0)).assertEqualTree
 
   @Test
-  def extractUnitExpressionToDef = new FileSet {
+  def extractUnitExpressionToDef() = new FileSet {
     """
       object Demo {
         /*(*/println("hello world")/*)*/
@@ -96,7 +96,7 @@ class ExtractCodeTest extends TestHelper with TestRefactoring {
       """
       object Demo {
         extracted
-    
+
         def extracted(): Unit = {
           println("hello world")
         }
@@ -105,7 +105,7 @@ class ExtractCodeTest extends TestHelper with TestRefactoring {
   }.performRefactoring(extract("extracted", 0)).assertEqualTree
 
   @Test
-  def extractCodeInCase = new FileSet {
+  def extractCodeInCase() = new FileSet {
     """
       object Demo {
         val p = (1, 1) match {
@@ -116,7 +116,7 @@ class ExtractCodeTest extends TestHelper with TestRefactoring {
       """
       object Demo {
         val p = (1, 1) match {
-          case (x: Int, y: Int) => 
+          case (x: Int, y: Int) =>
             val extracted = x * y
             extracted
         }
@@ -125,7 +125,7 @@ class ExtractCodeTest extends TestHelper with TestRefactoring {
   }.performRefactoring(extract("extracted", 0)).assertEqualTree
 
   @Test
-  def extractCodeWithPotentialSideEffects = new FileSet {
+  def extractCodeWithPotentialSideEffects() = new FileSet {
     """
       object Demo {
         val a = {
@@ -137,7 +137,7 @@ class ExtractCodeTest extends TestHelper with TestRefactoring {
       """
       object Demo {
         val a = extracted
-    
+
         def extracted(): Int = {
           println("calculate answer...")
           6 * 7
@@ -147,7 +147,7 @@ class ExtractCodeTest extends TestHelper with TestRefactoring {
   }.performRefactoring(extract("extracted", 1)).assertEqualTree
 
   @Test
-  def extractCodeWithPotentialSideEffectsOnVar = new FileSet {
+  def extractCodeWithPotentialSideEffectsOnVar() = new FileSet {
     """
       object Demo {
         var c = 1
@@ -160,9 +160,9 @@ class ExtractCodeTest extends TestHelper with TestRefactoring {
       """
       object Demo {
         var c = 1
-    
+
         val a = extracted
-    
+
         def extracted(): Int = {
           c += 1
           6 * 7
@@ -172,7 +172,7 @@ class ExtractCodeTest extends TestHelper with TestRefactoring {
   }.performRefactoring(extract("extracted", 1)).assertEqualTree
 
   @Test
-  def extractForEnumerator = new FileSet {
+  def extractForEnumerator() = new FileSet {
     """
       object Demo {
         for{
@@ -185,14 +185,14 @@ class ExtractCodeTest extends TestHelper with TestRefactoring {
         for{
           i <- extracted
         } println(i)
-    
+
         val extracted = 1 to 100
       }
     """
   }.performRefactoring(extract("extracted", 0)).assertEqualTree
 
   @Test
-  def extractFromForBody = new FileSet {
+  def extractFromForBody() = new FileSet {
     """
       object Demo {
         for{
@@ -205,7 +205,7 @@ class ExtractCodeTest extends TestHelper with TestRefactoring {
         for{
           i <- 1 to 100
         } extracted(i)
-    
+
         def extracted(i: Int): Unit = {
           println(i)
         }
@@ -214,7 +214,7 @@ class ExtractCodeTest extends TestHelper with TestRefactoring {
   }.performRefactoring(extract("extracted", 0)).assertEqualTree
 
   @Test
-  def extractCase = {
+  def extractCase() = {
     new FileSet {
       """
       object Demo {
@@ -225,7 +225,7 @@ class ExtractCodeTest extends TestHelper with TestRefactoring {
     """ becomes """
       object Demo {
         extracted
-    
+
     	def extracted(): Unit = {
     	  1 match {
 	        /*(*/case _ => println(1)/*)*/
@@ -237,7 +237,7 @@ class ExtractCodeTest extends TestHelper with TestRefactoring {
   }
 
   @Test
-  def extractConstructorCall = new FileSet {
+  def extractConstructorCall() = new FileSet {
     """
       object Demo {
         /*(*/List(1, 2, 3)/*)*/
@@ -246,14 +246,14 @@ class ExtractCodeTest extends TestHelper with TestRefactoring {
       """
       object Demo {
         extracted
-    
+
     	val extracted = List(1, 2, 3)
       }
     """
   }.performRefactoring(extract("extracted", 0)).assertEqualTree
 
   @Test
-  def extractExtractor = new FileSet {
+  def extractExtractor() = new FileSet {
     """
       object Demo {
         1 match {
@@ -266,7 +266,7 @@ class ExtractCodeTest extends TestHelper with TestRefactoring {
         1 match {
 	  	  case Extracted(i) => println(i)
         }
-    
+
         object Extracted {
           def unapply(x: Int) = x match {
     		case i => Some(i)
@@ -278,7 +278,7 @@ class ExtractCodeTest extends TestHelper with TestRefactoring {
   }.performRefactoring(extract("Extracted", 0)).assertEqualTree
 
   @Test
-  def extractWithNothingSelected = new FileSet {
+  def extractWithNothingSelected() = new FileSet {
     """
       object Demo {
         def fn = {

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/extraction/ExtractExtractorTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/extraction/ExtractExtractorTest.scala
@@ -14,7 +14,7 @@ class ExtractExtractorTest extends TestHelper with TestRefactoring {
   }
 
   @Test
-  def extractSimpleExtractor = new FileSet {
+  def extractSimpleExtractor() = new FileSet {
     """
       object Demo {
         1 match {
@@ -39,7 +39,7 @@ class ExtractExtractorTest extends TestHelper with TestRefactoring {
   }.performRefactoring(extract(0)).assertEqualTree
 
   @Test
-  def extractWithBodyOnNewLine = new FileSet {
+  def extractWithBodyOnNewLine() = new FileSet {
     """
       object Demo {
         List(1) match {
@@ -66,7 +66,7 @@ class ExtractExtractorTest extends TestHelper with TestRefactoring {
   }.performRefactoring(extract(0)).assertEqualTree
   
   @Test
-  def extractorWithMultipleBindings = new FileSet{
+  def extractorWithMultipleBindings() = new FileSet{
     """
       object Demo {
         (1, 2) match {
@@ -91,7 +91,7 @@ class ExtractExtractorTest extends TestHelper with TestRefactoring {
   }.performRefactoring(extract(0)).assertEqualTree
   
   @Test
-  def extractorWithoutBindings = new FileSet{
+  def extractorWithoutBindings() = new FileSet{
     """
       object Demo {
         1 match {
@@ -116,7 +116,7 @@ class ExtractExtractorTest extends TestHelper with TestRefactoring {
   }.performRefactoring(extract(0)).assertEqualTree
   
   @Test
-  def extractSubPattern = new FileSet{
+  def extractSubPattern() = new FileSet{
     """
       object Demo {
         1 match {
@@ -141,7 +141,7 @@ class ExtractExtractorTest extends TestHelper with TestRefactoring {
   }.performRefactoring(extract(0)).assertEqualTree
   
   @Test
-  def extractPatternWithGuard = new FileSet{
+  def extractPatternWithGuard() = new FileSet{
     """
       object Demo {
         1 match {
@@ -166,7 +166,7 @@ class ExtractExtractorTest extends TestHelper with TestRefactoring {
   }.performRefactoring(extract(0)).assertEqualTree
   
   @Test
-  def extractWithoutGuard = new FileSet{
+  def extractWithoutGuard() = new FileSet{
     """
       object Demo {
         "abc" match {
@@ -191,7 +191,7 @@ class ExtractExtractorTest extends TestHelper with TestRefactoring {
   }.performRefactoring(extract(0)).assertEqualTree
   
   @Test
-  def extractListPattern = new FileSet{
+  def extractListPattern() = new FileSet{
     """
       object Demo {
         List(1, 2, 3) match {
@@ -216,7 +216,7 @@ class ExtractExtractorTest extends TestHelper with TestRefactoring {
   }.performRefactoring(extract(0)).assertEqualTree
   
   @Test
-  def extractConstructorPatternWithoutGuard = new FileSet{
+  def extractConstructorPatternWithoutGuard() = new FileSet{
     """
       case class TwoInts(a: Int, b: Int)
       object Demo {

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/extraction/ExtractMethodTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/extraction/ExtractMethodTest.scala
@@ -16,7 +16,7 @@ class ExtractMethodTest extends TestHelper with TestRefactoring {
   }
 
   @Test
-  def extractSimpleMethod = new FileSet {
+  def extractSimpleMethod() = new FileSet {
     """
       object Demo {
         def fn(a: Int) = {
@@ -39,7 +39,7 @@ class ExtractMethodTest extends TestHelper with TestRefactoring {
   }.performRefactoring(extract("extracted", 0)).assertEqualTree
 
   @Test
-  def extractComplexMethod = new FileSet {
+  def extractComplexMethod() = new FileSet {
     """
       object Demo {
         val na = 1
@@ -80,9 +80,9 @@ class ExtractMethodTest extends TestHelper with TestRefactoring {
       }
     """
   }.performRefactoring(extract("extracted", 2)).assertEqualTree
-  
+
   @Test
-  def extractMethodWithoutParametersAndCreateEmptyParameterList = new FileSet {
+  def extractMethodWithoutParametersAndCreateEmptyParameterList() = new FileSet {
     """
       object Demo {
         /*(*/println(123)/*)*/
@@ -99,7 +99,7 @@ class ExtractMethodTest extends TestHelper with TestRefactoring {
   }.performRefactoring(extract("extracted", 0)).assertEqualSource
 
   @Test
-  def extractImportedDependency = new FileSet {
+  def extractImportedDependency() = new FileSet {
     """
       object Demo {
         def fn = {
@@ -114,7 +114,7 @@ class ExtractMethodTest extends TestHelper with TestRefactoring {
           import scala.math.Pi
 	  	  extracted()
         }
-    
+
     	def extracted() = {
     	  import scala.math.Pi
     	  Pi
@@ -122,9 +122,9 @@ class ExtractMethodTest extends TestHelper with TestRefactoring {
       }
     """
   }.performRefactoring(extract("extracted", 1)).assertEqualTree
-  
+
   @Test
-  def extractFromNestedClass = new FileSet {
+  def extractFromNestedClass() = new FileSet {
     """
       object Demo {
         trait T{
@@ -146,7 +146,7 @@ class ExtractMethodTest extends TestHelper with TestRefactoring {
 
   @Test
   @Ignore("Has to be handled in pretty printer")
-  def hideImportedQualifiersOfParameter = new FileSet {
+  def hideImportedQualifiersOfParameter() = new FileSet {
     """
       import scala.collection.mutable.LinkedList
       object Demo {
@@ -170,9 +170,9 @@ class ExtractMethodTest extends TestHelper with TestRefactoring {
       }
     """
   }.performRefactoring(extract("extracted", 1)).assertEqualSource
-  
+
   @Test(expected=classOf[IndexOutOfBoundsException])
-  def extractWithSideEffects = new FileSet {
+  def extractWithSideEffects() = new FileSet {
     """
       object Demo {
         def fn = {
@@ -184,9 +184,9 @@ class ExtractMethodTest extends TestHelper with TestRefactoring {
     """ becomes
       """"""
   }.performRefactoring(extract("extracted", 1)).assertEqualSource
-  
+
   @Test
-  def extractFunction = new FileSet {
+  def extractFunction() = new FileSet {
     """
       object Demo {
 	  	def fn(a: Int) = {

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/extraction/ExtractParameterTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/extraction/ExtractParameterTest.scala
@@ -16,7 +16,7 @@ class ExtractParameterTest extends TestHelper with TestRefactoring {
   }
 
   @Test
-  def extractSimpleParam = new FileSet {
+  def extractSimpleParam() = new FileSet {
     """
       object Demo {
         def fn(a: Int) = {
@@ -34,7 +34,7 @@ class ExtractParameterTest extends TestHelper with TestRefactoring {
   }.performRefactoring(extract("extracted", 0)).assertEqualTree
 
   @Test
-  def extractParamToParameterlessMethod = new FileSet {
+  def extractParamToParameterlessMethod() = new FileSet {
     """
       object Demo {
         def fn() = {
@@ -52,7 +52,7 @@ class ExtractParameterTest extends TestHelper with TestRefactoring {
   }.performRefactoring(extract("extracted", 0)).assertEqualTree
 
   @Test(expected=classOf[IndexOutOfBoundsException])
-  def dontExtractParamToMethodWithouParamList = new FileSet {
+  def dontExtractParamToMethodWithouParamList() = new FileSet {
     """
       object Demo {
         def fn = {
@@ -64,7 +64,7 @@ class ExtractParameterTest extends TestHelper with TestRefactoring {
   }.performRefactoring(extract("extracted", 0)).assertEqualTree
 
   @Test
-  def extractParamToMethodWithMultipleParamLists = new FileSet {
+  def extractParamToMethodWithMultipleParamLists() = new FileSet {
     """
       object Demo {
         def fn(a: Int)(b: Int) = {
@@ -82,13 +82,13 @@ class ExtractParameterTest extends TestHelper with TestRefactoring {
   }.performRefactoring(extract("extracted", 0)).assertEqualTree
 
   @Test
-  def extractParamToReferencedMethod = new FileSet {
+  def extractParamToReferencedMethod() = new FileSet {
     """
       object Demo {
         def fn(a: Int) = {
           /*(*/100/*)*/
         }
-    
+
 	  	fn(1)
       }
     """ becomes
@@ -97,21 +97,21 @@ class ExtractParameterTest extends TestHelper with TestRefactoring {
         def fn(a: Int, extracted: Int = 100) = {
           extracted
         }
-    
+
         fn(1)
       }
     """
   }.performRefactoring(extract("extracted", 0)).assertEqualTree
 
   @Test(expected = classOf[IndexOutOfBoundsException])
-  def dontExtractWithInaccessibleDependencies = new FileSet {
+  def dontExtractWithInaccessibleDependencies() = new FileSet {
     """
       object Demo {
         def fn(a: Int) = {
 	      val b = 100
           /*(*/b/*)*/
         }
-    
+
 	  	fn(1)
       }
     """ becomes
@@ -120,7 +120,7 @@ class ExtractParameterTest extends TestHelper with TestRefactoring {
 
   @Test
   @Ignore
-  def expandSelection = new FileSet {
+  def expandSelection() = new FileSet {
     """
       object Demo {
         def fn(a: Int) = {

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/extraction/ExtractValueTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/extraction/ExtractValueTest.scala
@@ -18,7 +18,7 @@ class ExtractValueTest extends TestHelper with TestRefactoring {
   }
 
   @Test
-  def extractSimpleValue = new FileSet {
+  def extractSimpleValue() = new FileSet {
     """
       object Demo {
         def fn(a: Int) = {
@@ -39,7 +39,7 @@ class ExtractValueTest extends TestHelper with TestRefactoring {
   }.performRefactoring(extract("c", 0)).assertEqualTree
 
   @Test
-  def extractSimpleSequence = new FileSet {
+  def extractSimpleSequence() = new FileSet {
     """
       object Demo {
         def fn(a: Int) = {
@@ -64,7 +64,7 @@ class ExtractValueTest extends TestHelper with TestRefactoring {
   }.performRefactoring(extract("c", 0)).assertEqualTree
 
   @Test
-  def extractWithOutboundDependency = new FileSet {
+  def extractWithOutboundDependency() = new FileSet {
     """
       object Demo {
         def fn(a: Int) = {
@@ -88,7 +88,7 @@ class ExtractValueTest extends TestHelper with TestRefactoring {
   }.performRefactoring(extract("c", 0)).assertEqualTree
 
   @Test
-  def extractWithOutboundDependencies = new FileSet {
+  def extractWithOutboundDependencies() = new FileSet {
     """
       object Demo {
         def fn(a: Int) = {
@@ -118,7 +118,7 @@ class ExtractValueTest extends TestHelper with TestRefactoring {
   }.performRefactoring(extract("e", 0)).assertEqualTree
 
   @Test
-  def extractToTemplateScope = new FileSet {
+  def extractToTemplateScope() = new FileSet {
     """
       object Demo {
         def fn(a: Int) = {
@@ -142,7 +142,7 @@ class ExtractValueTest extends TestHelper with TestRefactoring {
   }.performRefactoring(extract("c", 2)).assertEqualTree
 
   @Test
-  def extractImportedDependency = new FileSet {
+  def extractImportedDependency() = new FileSet {
     """
       object Demo {
         def fn = {
@@ -157,7 +157,7 @@ class ExtractValueTest extends TestHelper with TestRefactoring {
           import scala.math.Pi
 	  	  extracted
         }
-    
+
     	val extracted = {
     	  import scala.math.Pi
           Pi
@@ -167,7 +167,7 @@ class ExtractValueTest extends TestHelper with TestRefactoring {
   }.performRefactoring(extract("extracted", 1)).assertEqualTree
 
   @Test
-  def extractImportedDependencyInSubtree = new FileSet {
+  def extractImportedDependencyInSubtree() = new FileSet {
     """
       object Demo {
         def fn = {
@@ -182,7 +182,7 @@ class ExtractValueTest extends TestHelper with TestRefactoring {
           import scala.math.Pi
 	  	  extracted
         }
-    
+
     	val extracted = {
           import scala.math.Pi
           100 * Pi
@@ -192,7 +192,7 @@ class ExtractValueTest extends TestHelper with TestRefactoring {
   }.performRefactoring(extract("extracted", 1)).assertEqualTree
 
   @Test
-  def extractImportedCtor = new FileSet {
+  def extractImportedCtor() = new FileSet {
     """
       object Demo {
         def fn = {
@@ -207,7 +207,7 @@ class ExtractValueTest extends TestHelper with TestRefactoring {
           import scala.collection.mutable.LinkedList
     	  extracted
         }
-    
+
     	val extracted = {
           import scala.collection.mutable.LinkedList
           scala.collection.mutable.LinkedList(1)
@@ -217,7 +217,7 @@ class ExtractValueTest extends TestHelper with TestRefactoring {
   }.performRefactoring(extract("extracted", 1)).assertEqualTree
 
   @Test
-  def extractImportedCtorWithImportedQualifiers = new FileSet {
+  def extractImportedCtorWithImportedQualifiers() = new FileSet {
     """
       import scala.collection.mutable.LinkedList
       object Demo {
@@ -237,10 +237,10 @@ class ExtractValueTest extends TestHelper with TestRefactoring {
       }
     """
   }.performRefactoring(extract("extracted", 1)).assertEqualSource
-  
+
   @Test
   @Ignore
-  def extractInFunctionWithSingleExprBody = new FileSet{
+  def extractInFunctionWithSingleExprBody() = new FileSet{
     """
     object Demo {
       List(1, 2, 3).map(i => /*(*/i + 1/*)*/)
@@ -254,9 +254,9 @@ class ExtractValueTest extends TestHelper with TestRefactoring {
     }
     """
   }.performRefactoring(extract("extracted", 0)).assertEqualSource
-  
+
   @Test
-  def extractFunction = new FileSet{
+  def extractFunction() = new FileSet{
     """
     object Demo {
       List(1, 2, 3).map(i /*(*/=> i + /*)*/1)
@@ -269,9 +269,9 @@ class ExtractValueTest extends TestHelper with TestRefactoring {
     }
     """
   }.performRefactoring(extract("extracted", 0)).assertEqualTree
-  
+
   @Test
-  def extractFunctionWithBlockBody = new FileSet{
+  def extractFunctionWithBlockBody() = new FileSet{
     """
     object Demo {
       List(1, 2, 3).map{/*(*/i =>
@@ -290,9 +290,9 @@ class ExtractValueTest extends TestHelper with TestRefactoring {
     }
     """
   }.performRefactoring(extract("extracted", 0)).assertEqualTree
-  
+
   @Test
-  def extractFunctionWithWildcardParam = new FileSet{
+  def extractFunctionWithWildcardParam() = new FileSet{
     """
     object Demo {
       List(1, 2, 3).map(/*(*/_ + 1/*)*/)
@@ -300,14 +300,14 @@ class ExtractValueTest extends TestHelper with TestRefactoring {
     """ becomes """
     object Demo {
       List(1, 2, 3).map(extracted)
-    
+
       val extracted: Int => Int = _ + 1
     }
     """
   }.performRefactoring(extract("extracted", 0)).assertEqualTree
-  
+
   @Test
-  def extractConstantPattern = new FileSet{
+  def extractConstantPattern() = new FileSet{
     """
     object Demo {
 	  List(1) match {
@@ -319,14 +319,14 @@ class ExtractValueTest extends TestHelper with TestRefactoring {
 	  List(1) match {
 	    case List(extracted) => ()
       }
-    
+
       val extracted = 1
     }
     """
   }.performRefactoring(extract("extracted", 0)).assertEqualTree
-  
+
   @Test
-  def dontExtractPatternsWithBindings = new FileSet{
+  def dontExtractPatternsWithBindings() = new FileSet{
     """
     case class Intish(i: Int)
     object Demo {
@@ -345,9 +345,9 @@ class ExtractValueTest extends TestHelper with TestRefactoring {
     }
     """
   }.performRefactoring(extract("extracted", 0)).assertEqualTree
-  
+
   @Test
-  def dontExtractWildcardPatterns = new FileSet{
+  def dontExtractWildcardPatterns() = new FileSet{
     """
     case class Intish(i: Int)
     object Demo {
@@ -366,9 +366,9 @@ class ExtractValueTest extends TestHelper with TestRefactoring {
     }
     """
   }.performRefactoring(extract("extracted", 0)).assertEqualTree
-  
+
   @Test
-  def extractIntoNewValBlock = new FileSet{
+  def extractIntoNewValBlock() = new FileSet{
     """
     object Demo {
 	  val a = /*(*/"hello"/*)*/.toUpperCase
@@ -382,9 +382,9 @@ class ExtractValueTest extends TestHelper with TestRefactoring {
     }
     """
   }.performRefactoring(extract("extracted", 0)).assertEqualTree
-  
+
   @Test
-  def extractMutable = new FileSet{
+  def extractMutable() = new FileSet{
     """
     object Demo {
 	  def fn = {

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/extraction/ExtractionsTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/extraction/ExtractionsTest.scala
@@ -6,7 +6,7 @@ import org.junit.Assert._
 
 class ExtractionsTest extends TestHelper with Extractions {
   @Test
-  def findExtractionTargets = {
+  def findExtractionTargets() = {
     val s = toSelection("""
       object O{
         def fn = {
@@ -21,7 +21,7 @@ class ExtractionsTest extends TestHelper with Extractions {
   }
 
   @Test
-  def noExtractionTargetsForSyntheticScopes = {
+  def noExtractionTargetsForSyntheticScopes() = {
     val s = toSelection("""
       object O{
         def fn =
@@ -34,7 +34,7 @@ class ExtractionsTest extends TestHelper with Extractions {
   }
 
   @Test
-  def noExtractionTargetsForCasesWithSelectedPattern = {
+  def noExtractionTargetsForCasesWithSelectedPattern() = {
     val s = toSelection("""
       object O{
         1 match {

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/imports/AddImportStatementTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/imports/AddImportStatementTest.scala
@@ -28,7 +28,7 @@ class AddImportStatementTest extends TestHelper {
   }
 
   @Test
-  def importPackageContainsKeyword = {
+  def importPackageContainsKeyword() = {
     addImport(("whatever.type", "Bla"), """
       object Main
     """,
@@ -40,7 +40,7 @@ class AddImportStatementTest extends TestHelper {
   }
 
   @Test
-  def importAnnotationOnClassWithoutPackage = {
+  def importAnnotationOnClassWithoutPackage() = {
     addImport(("scala.annotation.unchecked", "uncheckedStable"),
     """
       @uncheckedStable
@@ -53,7 +53,7 @@ class T
   }
 
   @Test
-  def importAnnotationOnObjectWithoutPackage = {
+  def importAnnotationOnObjectWithoutPackage() = {
     addImport(("scala.annotation.unchecked", "uncheckedStable"),
     """
       @uncheckedStable
@@ -66,7 +66,7 @@ object T
   }
 
   @Test
-  def importWithPackageObject = {
+  def importWithPackageObject() = {
     addImport(("java.util", "ArrayList"), """
       // Copyright blabla
       package object foo {
@@ -83,7 +83,7 @@ object T
   }
 
   @Test
-  def importWithPackageObjectAndExistingImport = {
+  def importWithPackageObjectAndExistingImport() = {
     addImport(("java.util", "ArrayList"), """
       import java.util.Arrays
       package object foo {
@@ -100,7 +100,7 @@ object T
   }
 
   @Test
-  def importInEmpty = {
+  def importInEmpty() = {
     addImport(("collection.mutable", "ListBuffer"), """
       object Main {val lb = ListBuffer(1)}
     """,
@@ -112,7 +112,7 @@ object T
   }
 
   @Test
-  def importInEmptyWithPackage = {
+  def importInEmptyWithPackage() = {
     addImport(("collection.mutable", "ListBuffer"), """
       package xy
 
@@ -128,7 +128,7 @@ object T
   }
 
   @Test
-  def importAlreadyExisting = {
+  def importAlreadyExisting() = {
     addImport(("collection.mutable", "ListBuffer"), """
       import collection.mutable.ListBuffer
       object Main {}
@@ -141,7 +141,7 @@ object T
   }
 
   @Test
-  def importIsInsertedAtEnd = {
+  def importIsInsertedAtEnd() = {
     addImport(("collection.mutable", "ListBuffer"), """
       import collection.mutable.HashMap
 
@@ -159,7 +159,7 @@ object T
   }
 
   @Test
-  def importWithNestedPackages = {
+  def importWithNestedPackages() = {
     addImport(("collection.mutable", "ListBuffer"), """
       package nstd
       package pckg
@@ -183,7 +183,7 @@ object T
   }
 
   @Test
-  def importExistsBetweenPackages = {
+  def importExistsBetweenPackages() = {
     addImport(("collection.mutable", "ListBuffer"), """
       package nstd
 
@@ -211,7 +211,7 @@ object T
   }
 
   @Test
-  def importWithPackage = {
+  def importWithPackage() = {
     addImport(("collection.mutable", "ListBuffer"), """
       package just.some.pkg
 
@@ -227,7 +227,7 @@ object T
   }
 
   @Test
-  def importWithMultiplePackages = {
+  def importWithMultiplePackages() = {
     addImport(("collection.mutable", "ListBuffer"), """
       package just
       package some
@@ -247,7 +247,7 @@ object T
   }
 
   @Test
-  def importWithMultiplePackagesAndBraces = {
+  def importWithMultiplePackagesAndBraces() = {
     addImport(("collection.mutable", "ListBuffer"), """
       package just
       package some
@@ -271,7 +271,7 @@ object T
   }
 
   @Test
-  def importWithNestedImports = {
+  def importWithNestedImports() = {
     addImport(("collection.mutable", "ListBuffer"), """
       package just
       package some

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsCollapseSelectorsToWildcardTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsCollapseSelectorsToWildcardTest.scala
@@ -12,7 +12,7 @@ class OrganizeImportsCollapseSelectorsToWildcardTest extends OrganizeImportsBase
   }.mkChanges
 
   @Test
-  def collapseImportSelectorsToWildcard = new FileSet {
+  def collapseImportSelectorsToWildcard() = new FileSet {
     """
       import scala.math.{BigDecimal, BigInt, Numeric}
 
@@ -29,7 +29,7 @@ class OrganizeImportsCollapseSelectorsToWildcardTest extends OrganizeImportsBase
 
   @Test
   @Ignore("I don't know why but this test fails when running the complete test suite")
-  def dontCollapseImportsWhenRename = new FileSet {
+  def dontCollapseImportsWhenRename() = new FileSet {
     val before = """
       import scala.math.{BigDecimal, BigInt, Numeric => N}
 
@@ -41,7 +41,7 @@ class OrganizeImportsCollapseSelectorsToWildcardTest extends OrganizeImportsBase
   } applyRefactoring organize()
 
   @Test
-  def dontCollapseWhenCollidingWithExplicitImport = new FileSet {
+  def dontCollapseWhenCollidingWithExplicitImport() = new FileSet {
     """
       import scala.collection.immutable.{HashSet, BitSet, HashMap}
       import scala.collection.mutable.{ArrayStack, ArrayBuilder, ArrayBuffer}
@@ -61,7 +61,7 @@ class OrganizeImportsCollapseSelectorsToWildcardTest extends OrganizeImportsBase
   } applyRefactoring organize()
 
   @Test
-  def dontCollapseWhenPackageInExcludes = new FileSet {
+  def dontCollapseWhenPackageInExcludes() = new FileSet {
     val before = """
       import scala.collection.immutable.{BitSet, HashMap, HashSet}
 

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsFullyRecomputeTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsFullyRecomputeTest.scala
@@ -93,7 +93,7 @@ class OrganizeImportsFullyRecomputeTest extends OrganizeImportsBaseTest {
   }
 
   @Test
-  def dependencyOnMultipleOverloadedMethods = new FileSet {
+  def dependencyOnMultipleOverloadedMethods() = new FileSet {
     """
     import scala.math.BigDecimal._
 
@@ -117,7 +117,7 @@ class OrganizeImportsFullyRecomputeTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def expandImportsButNotWildcards = new FileSet {
+  def expandImportsButNotWildcards() = new FileSet {
     """
     package tests.importing
 
@@ -135,7 +135,7 @@ class OrganizeImportsFullyRecomputeTest extends OrganizeImportsBaseTest {
   } applyRefactoring organizeExpand
 
   @Test
-  def dontCollapseImports = new FileSet {
+  def dontCollapseImports() = new FileSet {
     """
     package tests.importing
 
@@ -155,7 +155,7 @@ class OrganizeImportsFullyRecomputeTest extends OrganizeImportsBaseTest {
   } applyRefactoring organizeWithoutCollapsing
 
   @Test
-  def collapse = new FileSet {
+  def collapse() = new FileSet {
     """
     import scala.collection.mutable.Set
     import scala.collection.mutable.Queue
@@ -170,7 +170,7 @@ class OrganizeImportsFullyRecomputeTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def sortSelectors = new FileSet {
+  def sortSelectors() = new FileSet {
     """
     import scala.collection.mutable.{Set, Queue}
 
@@ -184,7 +184,7 @@ class OrganizeImportsFullyRecomputeTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def sortAndCollapse = new FileSet {
+  def sortAndCollapse() = new FileSet {
     """
     import scala.collection.mutable.ListBuffer
     import scala.collection.mutable.Set
@@ -200,7 +200,7 @@ class OrganizeImportsFullyRecomputeTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def collapseWithRename = new FileSet {
+  def collapseWithRename() = new FileSet {
     """
     import collection.mutable.{Set => S}
     import collection.mutable.{Queue => Q}
@@ -215,7 +215,7 @@ class OrganizeImportsFullyRecomputeTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def removeOneFromMany = new FileSet {
+  def removeOneFromMany() = new FileSet {
     """
     import collection.mutable.{HashSet, Queue}
 
@@ -229,7 +229,7 @@ class OrganizeImportsFullyRecomputeTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def importAll = new FileSet {
+  def importAll() = new FileSet {
     """
     import java.lang._
     import java.lang.String
@@ -244,7 +244,7 @@ class OrganizeImportsFullyRecomputeTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def importOnTrait = new FileSet {
+  def importOnTrait() = new FileSet {
     """
     package importOnTrait
     import java.lang._
@@ -266,7 +266,7 @@ class OrganizeImportsFullyRecomputeTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def importWithSpace = new FileSet {
+  def importWithSpace() = new FileSet {
     """
 
     import scala.collection.mutable.ListBuffer
@@ -283,7 +283,7 @@ class OrganizeImportsFullyRecomputeTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def importAllWithRename = new FileSet {
+  def importAllWithRename() = new FileSet {
     """
     import collection.mutable._
     import collection.mutable.{Set => S}
@@ -298,7 +298,7 @@ class OrganizeImportsFullyRecomputeTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def importRemovesUnneeded = new FileSet {
+  def importRemovesUnneeded() = new FileSet {
     """
     import java.lang._
     import java.lang.{String => S}
@@ -324,7 +324,7 @@ class OrganizeImportsFullyRecomputeTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def multipleImportsOnOneLine = new FileSet {
+  def multipleImportsOnOneLine() = new FileSet {
     """
     import java.lang.String, String._
 
@@ -341,7 +341,7 @@ class OrganizeImportsFullyRecomputeTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def importsInNestedPackages = new FileSet {
+  def importsInNestedPackages() = new FileSet {
     """
     package outer
     package inner
@@ -365,7 +365,7 @@ class OrganizeImportsFullyRecomputeTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def importFromPackageObject = new FileSet {
+  def importFromPackageObject() = new FileSet {
     """
     import scala.collection.breakOut
     import scala.collection.mutable.ListBuffer
@@ -383,7 +383,7 @@ class OrganizeImportsFullyRecomputeTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def unusedImportWildcards = new FileSet {
+  def unusedImportWildcards() = new FileSet {
     """
     import java.util._
     import scala.collection._
@@ -398,7 +398,7 @@ class OrganizeImportsFullyRecomputeTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def simplifyWildcards = new FileSet {
+  def simplifyWildcards() = new FileSet {
     """
     import scala.collection.mutable._
     import scala.collection.mutable.ListBuffer
@@ -414,7 +414,7 @@ class OrganizeImportsFullyRecomputeTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def appliedType = new FileSet {
+  def appliedType() = new FileSet {
     """
     import scala.collection.mutable.HashMap
     import scala.collection.mutable.ListBuffer
@@ -431,7 +431,7 @@ class OrganizeImportsFullyRecomputeTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def annotation = new FileSet {
+  def annotation() = new FileSet {
     """
     import scala.beans.BeanProperty
     case class JavaPerson(@BeanProperty var name: String, @BeanProperty var addresses: java.lang.Object)
@@ -443,7 +443,7 @@ class OrganizeImportsFullyRecomputeTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def selfTypeAnnotation = new FileSet {
+  def selfTypeAnnotation() = new FileSet {
     """
     import java.util.Observer
     trait X {
@@ -459,7 +459,7 @@ class OrganizeImportsFullyRecomputeTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def renamedPackage = new FileSet {
+  def renamedPackage() = new FileSet {
     """
     import java.{ lang => jl, util => ju }
     import ju.{ArrayList => AL}
@@ -479,7 +479,7 @@ class OrganizeImportsFullyRecomputeTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def abstractVals = new FileSet {
+  def abstractVals() = new FileSet {
     """
     import scala.collection.mutable.ListBuffer
     import scala.collection._
@@ -501,7 +501,7 @@ class OrganizeImportsFullyRecomputeTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def fullPaths = new FileSet {
+  def fullPaths() = new FileSet {
     """
     trait FullPaths {
       sys.error("")
@@ -517,7 +517,7 @@ class OrganizeImportsFullyRecomputeTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def organizeNeededForTypeInClassOf = new FileSet {
+  def organizeNeededForTypeInClassOf() = new FileSet {
     """
     import scala.io.Source
 
@@ -535,7 +535,7 @@ class OrganizeImportsFullyRecomputeTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def SystemcurrentTimeMillis = new FileSet {
+  def SystemcurrentTimeMillis() = new FileSet {
     """
     import System.currentTimeMillis
 
@@ -553,7 +553,7 @@ class OrganizeImportsFullyRecomputeTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def dontImportSystem = new FileSet {
+  def dontImportSystem() = new FileSet {
     """
     class SystemTypeDef {
       type S = System
@@ -567,7 +567,7 @@ class OrganizeImportsFullyRecomputeTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def importMethodFromSamePackage = new FileSet {
+  def importMethodFromSamePackage() = new FileSet {
 
     addToCompiler("testimplicits", """
     package a.b.c
@@ -595,7 +595,7 @@ class OrganizeImportsFullyRecomputeTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def importedPackageHasKeywordName = new FileSet {
+  def importedPackageHasKeywordName() = new FileSet {
 
     addToCompiler("testkeyword", """
     package other
@@ -624,7 +624,7 @@ class OrganizeImportsFullyRecomputeTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def fileWithoutNewline = new FileSet {
+  def fileWithoutNewline() = new FileSet {
     """
     import java.util.Date
     class MyClass[T]""" becomes
@@ -634,7 +634,7 @@ class OrganizeImportsFullyRecomputeTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def parensAtEndOfFile = new FileSet {
+  def parensAtEndOfFile() = new FileSet {
     """
     import java.util.Date
     class MyClass(i: Int)""" becomes
@@ -644,7 +644,7 @@ class OrganizeImportsFullyRecomputeTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def importFromSamePackage = new FileSet {
+  def importFromSamePackage() = new FileSet {
 
     addToCompiler("first", """
     package mypackage
@@ -671,7 +671,7 @@ class OrganizeImportsFullyRecomputeTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def importFromSameNestedPackage = new FileSet {
+  def importFromSameNestedPackage() = new FileSet {
 
     addToCompiler("first", """
     package mypackage
@@ -701,7 +701,7 @@ class OrganizeImportsFullyRecomputeTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def importWithSelfType = new FileSet {
+  def importWithSelfType() = new FileSet {
     """
     package importWithSelfType
 
@@ -735,7 +735,7 @@ class OrganizeImportsFullyRecomputeTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def collapseTypes = new FileSet {
+  def collapseTypes() = new FileSet {
     """
     import scala.util.DynamicVariable
     import scala.util.Random
@@ -756,7 +756,7 @@ class OrganizeImportsFullyRecomputeTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def typeConstructors = new FileSet {
+  def typeConstructors() = new FileSet {
     """
     trait Property[+T]
 
@@ -777,7 +777,7 @@ class OrganizeImportsFullyRecomputeTest extends OrganizeImportsBaseTest {
 
   @Test
   @ScalaVersion(matches="2.10")
-  def annotationTypeDef = new FileSet {
+  def annotationTypeDef() = new FileSet {
 
     addToCompiler("ann.scala", """
       package pkg
@@ -803,7 +803,7 @@ class OrganizeImportsFullyRecomputeTest extends OrganizeImportsBaseTest {
     """
   } applyRefactoring organize
 
-  def qualifiedImportFromPackageObject = new FileSet {
+  def qualifiedImportFromPackageObject() = new FileSet {
     addToCompiler("package.scala", """
       package test
 
@@ -837,7 +837,7 @@ class OrganizeImportsFullyRecomputeTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def implicitConversion = new FileSet {
+  def implicitConversion() = new FileSet {
     addToCompiler("implicitConversion.scala", """
       package implicitConversion
       trait AimplicitConversion {
@@ -865,7 +865,7 @@ class OrganizeImportsFullyRecomputeTest extends OrganizeImportsBaseTest {
 
   @Test
   @Ignore // fails when run by Jenkins
-  def dependencyInSameFile = new FileSet {
+  def dependencyInSameFile() = new FileSet {
     """
     package dependencyInSameFile
     class Foo {
@@ -899,7 +899,7 @@ class OrganizeImportsFullyRecomputeTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def ignoreScalaLanguageImports = new FileSet {
+  def ignoreScalaLanguageImports() = new FileSet {
     """
     package ignoreScalaLanguageImports
 
@@ -919,7 +919,7 @@ class OrganizeImportsFullyRecomputeTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def ignoreLanguageImports = new FileSet {
+  def ignoreLanguageImports() = new FileSet {
     """
     package ignoreScalaLanguageImports
 
@@ -939,7 +939,7 @@ class OrganizeImportsFullyRecomputeTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def runWith = new FileSet {
+  def runWith() = new FileSet {
     """
     package runWith
 
@@ -963,7 +963,7 @@ class OrganizeImportsFullyRecomputeTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def shouldIgnoreScalaPackage = new FileSet {
+  def shouldIgnoreScalaPackage() = new FileSet {
     """
     package shouldIgnoreScalaPackage
 

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsGroupsTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsGroupsTest.scala
@@ -34,7 +34,7 @@ class OrganizeImportsGroupsTest extends OrganizeImportsBaseTest {
     """
 
   @Test
-  def noGrouping = new FileSet {
+  def noGrouping() = new FileSet {
     source becomes
     """
       import java.util.AbstractList
@@ -54,7 +54,7 @@ class OrganizeImportsGroupsTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize(List())
 
   @Test
-  def oneScalaGroup = new FileSet {
+  def oneScalaGroup() = new FileSet {
     source becomes
     """
       import scala.collection.mutable.HashMap
@@ -75,7 +75,7 @@ class OrganizeImportsGroupsTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize(List("scala"))
 
   @Test
-  def scalaAndJavaGroup = new FileSet {
+  def scalaAndJavaGroup() = new FileSet {
     source becomes
     """
       import scala.collection.mutable.HashMap
@@ -97,7 +97,7 @@ class OrganizeImportsGroupsTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize(List("scala", "java"))
 
   @Test
-  def severalScalaGroups = new FileSet {
+  def severalScalaGroups() = new FileSet {
     source becomes
     """
       import java.util.AbstractList
@@ -120,7 +120,7 @@ class OrganizeImportsGroupsTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize(List("java", "scala.collection", "scala.io"))
 
   @Test
-  def emptyGroups = new FileSet {
+  def emptyGroups() = new FileSet {
     source becomes
     """
       import java.util.AbstractList
@@ -142,7 +142,7 @@ class OrganizeImportsGroupsTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize(List("java", "scala.collection", "scala.tools"))
 
   @Test
-  def packagesNeedToMatchCompletely = new FileSet {
+  def packagesNeedToMatchCompletely() = new FileSet {
     source becomes
     """
       import java.util.AbstractList

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsRecomputeAndModifyTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsRecomputeAndModifyTest.scala
@@ -28,7 +28,7 @@ class OrganizeImportsRecomputeAndModifyTest extends OrganizeImportsBaseTest {
   }.mkChanges
 
   @Test
-  def wildcardImportIsNotExpanded = new FileSet {
+  def wildcardImportIsNotExpanded() = new FileSet {
     """
     import scala.math.BigDecimal._
 
@@ -52,7 +52,7 @@ class OrganizeImportsRecomputeAndModifyTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def wildcardAndRename = new FileSet {
+  def wildcardAndRename() = new FileSet {
     """
     package tests.importing
 
@@ -70,7 +70,7 @@ class OrganizeImportsRecomputeAndModifyTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def removeOneFromMany = new FileSet {
+  def removeOneFromMany() = new FileSet {
     """
     import collection.mutable.{HashSet, Queue}
 
@@ -84,7 +84,7 @@ class OrganizeImportsRecomputeAndModifyTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def wildcardImportIsPreserved = new FileSet {
+  def wildcardImportIsPreserved() = new FileSet {
     """
     import java.lang._
     import java.lang.String
@@ -99,7 +99,7 @@ class OrganizeImportsRecomputeAndModifyTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def sortAndGroup = new FileSet {
+  def sortAndGroup() = new FileSet {
     """
     import scala.collection.mutable.ListBuffer
     import java.util.Map
@@ -122,7 +122,7 @@ class OrganizeImportsRecomputeAndModifyTest extends OrganizeImportsBaseTest {
   } applyRefactoring organizeCleanup(List("java", "scala"))
 
   @Test
-  def importRemovesUnneeded = new FileSet {
+  def importRemovesUnneeded() = new FileSet {
     """
     import java.lang.{String => S}
     import java.util.Map
@@ -147,7 +147,7 @@ class OrganizeImportsRecomputeAndModifyTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def importFromPackageObject = new FileSet {
+  def importFromPackageObject() = new FileSet {
     """
     import scala.collection.breakOut
     import scala.collection.mutable.ListBuffer
@@ -165,7 +165,7 @@ class OrganizeImportsRecomputeAndModifyTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def selfTypeAnnotation = new FileSet {
+  def selfTypeAnnotation() = new FileSet {
     """
     import java.util.Observer
     trait X {
@@ -181,7 +181,7 @@ class OrganizeImportsRecomputeAndModifyTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def renamedPackage = new FileSet {
+  def renamedPackage() = new FileSet {
     """
     import java.{ lang => jl, util => ju }
     import ju.{ArrayList => AL}
@@ -201,7 +201,7 @@ class OrganizeImportsRecomputeAndModifyTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def SystemcurrentTimeMillis = new FileSet {
+  def SystemcurrentTimeMillis() = new FileSet {
     """
     import System.currentTimeMillis
     import scala.collection.mutable.ListBuffer
@@ -220,7 +220,7 @@ class OrganizeImportsRecomputeAndModifyTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def importMethodFromSamePackage = new FileSet {
+  def importMethodFromSamePackage() = new FileSet {
 
     addToCompiler("testimplicits", """
     package a.b.c
@@ -247,7 +247,7 @@ class OrganizeImportsRecomputeAndModifyTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def importFromSamePackage = new FileSet {
+  def importFromSamePackage() = new FileSet {
 
     addToCompiler("first", """
     package mypackage
@@ -274,7 +274,7 @@ class OrganizeImportsRecomputeAndModifyTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def importFromSameNestedPackage = new FileSet {
+  def importFromSameNestedPackage() = new FileSet {
 
     addToCompiler("first", """
     package mypackage
@@ -304,7 +304,7 @@ class OrganizeImportsRecomputeAndModifyTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def severalScalaGroups = new FileSet {
+  def severalScalaGroups() = new FileSet {
     """
       import scala.collection.mutable.ListBuffer
       import java.util.BitSet
@@ -343,7 +343,7 @@ class OrganizeImportsRecomputeAndModifyTest extends OrganizeImportsBaseTest {
   } applyRefactoring organizeCleanup(List("java", "scala.collection", "scala.io"))
 
   @Test
-  def qualifiedImportFromPackageObject = new FileSet {
+  def qualifiedImportFromPackageObject() = new FileSet {
     addToCompiler("package.scala", """
       package test
 
@@ -377,7 +377,7 @@ class OrganizeImportsRecomputeAndModifyTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def importDependingOnImport = new FileSet {
+  def importDependingOnImport() = new FileSet {
     addToCompiler("Bar.scala", """
     package barr
 
@@ -422,7 +422,7 @@ class OrganizeImportsRecomputeAndModifyTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def removeDuplicate = new FileSet {
+  def removeDuplicate() = new FileSet {
     """
     package removeDuplicate
     import collection.mutable

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
@@ -90,7 +90,7 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
   }
 
   @Test
-  def expandImports = new FileSet {
+  def expandImports() = new FileSet {
     """
       package tests.importing
 
@@ -109,7 +109,7 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
   } applyRefactoring organizeExpand
 
   @Test
-  def expandImportsButNotWildcards = new FileSet {
+  def expandImportsButNotWildcards() = new FileSet {
     """
       package tests.importing
 
@@ -127,7 +127,7 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
   } applyRefactoring organizeExpand
 
   @Test
-  def dontCollapseImports = new FileSet {
+  def dontCollapseImports() = new FileSet {
     """
       package tests.importing
 
@@ -147,7 +147,7 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
   } applyRefactoring organizeWithoutCollapsing
 
   @Test
-  def sort = new FileSet {
+  def sort() = new FileSet {
     """
       package tests.importing
 
@@ -167,7 +167,7 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def collapse = new FileSet {
+  def collapse() = new FileSet {
     """
       import java.lang.String
       import java.lang.Object
@@ -182,7 +182,7 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def sortSelectors = new FileSet {
+  def sortSelectors() = new FileSet {
     """
       import java.lang.{String, Object}
 
@@ -196,7 +196,7 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def sortAndCollapse = new FileSet {
+  def sortAndCollapse() = new FileSet {
     """
       import scala.collection.mutable.ListBuffer
       import java.lang.String
@@ -213,7 +213,7 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def collapseWithRename = new FileSet {
+  def collapseWithRename() = new FileSet {
     """
       import java.lang.{String => S}
       import java.lang.{Object => Objekt}
@@ -228,7 +228,7 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def removeOneFromMany = new FileSet {
+  def removeOneFromMany() = new FileSet {
     """
       import java.lang.{String, Math}
 
@@ -242,7 +242,7 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def importAll = new FileSet {
+  def importAll() = new FileSet {
     """
       import java.lang._
       import java.lang.String
@@ -257,7 +257,7 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def importOnTrait = new FileSet {
+  def importOnTrait() = new FileSet {
     """
       package importOnTrait
       import java.lang._
@@ -281,7 +281,7 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def importWithSpace = new FileSet {
+  def importWithSpace() = new FileSet {
     """
 
       import scala.collection.mutable.ListBuffer
@@ -299,7 +299,7 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def importAllWithRename = new FileSet {
+  def importAllWithRename() = new FileSet {
     """
       import java.lang._
       import java.lang.{String => S}
@@ -314,7 +314,7 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def importRemovesUnneeded = new FileSet {
+  def importRemovesUnneeded() = new FileSet {
     """
       import java.lang._
       import java.lang.{String => S}
@@ -341,7 +341,7 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def multipleImportsOnOneLine = new FileSet {
+  def multipleImportsOnOneLine() = new FileSet {
       """
       import java.lang.String, String._
 
@@ -359,7 +359,7 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def importsInNestedPackages = new FileSet {
+  def importsInNestedPackages() = new FileSet {
     """
        package outer
        package inner
@@ -383,7 +383,7 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def importFromPackageObject = new FileSet {
+  def importFromPackageObject() = new FileSet {
     """
     import scala.collection.breakOut
     import scala.collection.mutable.ListBuffer
@@ -401,7 +401,7 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def unusedImportWildcards = new FileSet {
+  def unusedImportWildcards() = new FileSet {
     """
       import java.util._
       import scala.collection._
@@ -416,7 +416,7 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def simplifyWildcards = new FileSet {
+  def simplifyWildcards() = new FileSet {
     """
       import scala.collection.mutable._
       import scala.collection.mutable.ListBuffer
@@ -433,7 +433,7 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def appliedType = new FileSet {
+  def appliedType() = new FileSet {
     """
       import scala.collection.mutable.HashMap
       import scala.collection.mutable.ListBuffer
@@ -450,7 +450,7 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def annotateClass = new FileSet {
+  def annotateClass() = new FileSet {
     """
       import scala.collection.mutable.HashMap
       import scala.collection.mutable.ListBuffer
@@ -469,7 +469,7 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def importSymbolicName = new FileSet {
+  def importSymbolicName() = new FileSet {
     """
       import collection.immutable.Nil.++
 
@@ -491,7 +491,7 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize
 
   @Test
-  def finalBraceShouldNotBeRemoved = new FileSet {
+  def finalBraceShouldNotBeRemoved() = new FileSet {
     """
       import java.io.Serializable
       object A extends Serializable {

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsWildcardsTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsWildcardsTest.scala
@@ -30,7 +30,7 @@ class OrganizeImportsWildcardsTest extends OrganizeImportsBaseTest {
     """
 
   @Test
-  def noGrouping = new FileSet {
+  def noGrouping() = new FileSet {
     source becomes
     """
     import org.xml.sax.Attributes
@@ -46,7 +46,7 @@ class OrganizeImportsWildcardsTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize(Set())
 
   @Test
-  def simpleWildcard = new FileSet {
+  def simpleWildcard() = new FileSet {
     source becomes
     """
     import org.xml.sax.Attributes
@@ -62,7 +62,7 @@ class OrganizeImportsWildcardsTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize(Set("scala.collection.mutable.Set"))
 
   @Test
-  def renamedImport = new FileSet {
+  def renamedImport() = new FileSet {
     """
     import java.lang.Integer.{valueOf => vo}
     import java.lang.Integer.toBinaryString
@@ -88,7 +88,7 @@ class OrganizeImportsWildcardsTest extends OrganizeImportsBaseTest {
   } applyRefactoring organize(Set("java.lang.Integer"))
 
   @Test
-  def multipleImportsOneWildcard = new FileSet {
+  def multipleImportsOneWildcard() = new FileSet {
     """
     import java.lang.Integer.valueOf
     import java.lang.Integer.toBinaryString

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeMissingImportsTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeMissingImportsTest.scala
@@ -22,7 +22,7 @@ class OrganizeMissingImportsTest extends TestHelper with TestRefactoring {
   }.changes
 
   @Test
-  def applyall = new FileSet {
+  def applyall() = new FileSet {
     """
       object Main {val lb = ListBuffer(1)}
     """ becomes
@@ -34,7 +34,7 @@ class OrganizeMissingImportsTest extends TestHelper with TestRefactoring {
   } applyRefactoring organize("collection.mutable" -> "ListBuffer" :: Nil)
 
   @Test
-  def parameter = new FileSet {
+  def parameter() = new FileSet {
     """
       object Main { def method(l: ListBuffer) = "" }
     """ becomes
@@ -46,7 +46,7 @@ class OrganizeMissingImportsTest extends TestHelper with TestRefactoring {
   } applyRefactoring organize("collection.mutable" -> "ListBuffer" :: Nil)
 
   @Test
-  def returnValue = new FileSet {
+  def returnValue() = new FileSet {
     """
       object Main { def method(): ListBuffer = new collection.mutable.ListBuffer() }
     """ becomes
@@ -58,7 +58,7 @@ class OrganizeMissingImportsTest extends TestHelper with TestRefactoring {
   } applyRefactoring organize("collection.mutable" -> "ListBuffer" :: Nil)
 
   @Test
-  def newInstance = new FileSet {
+  def newInstance() = new FileSet {
     """
       object Main { def method() = new ListBuffer() }
     """ becomes
@@ -70,7 +70,7 @@ class OrganizeMissingImportsTest extends TestHelper with TestRefactoring {
   } applyRefactoring organize("collection.mutable" -> "ListBuffer" :: Nil)
 
   @Test
-  def newInstance2 = new FileSet {
+  def newInstance2() = new FileSet {
     """
       object Main { def method() = new mutable.ListBuffer() }
     """ becomes
@@ -82,7 +82,7 @@ class OrganizeMissingImportsTest extends TestHelper with TestRefactoring {
   } applyRefactoring organize("collection.mutable" -> "ListBuffer" :: Nil)
 
   @Test
-  def importFromMissingImport = new FileSet {
+  def importFromMissingImport() = new FileSet {
     """
       object Main { import ListBuffer._ }
     """ becomes
@@ -94,7 +94,7 @@ class OrganizeMissingImportsTest extends TestHelper with TestRefactoring {
   } applyRefactoring organize("collection.mutable" -> "ListBuffer" :: Nil)
 
   @Test
-  def missingSuperclass = new FileSet {
+  def missingSuperclass() = new FileSet {
     """
       class Subclass extends LinkedList
     """ becomes
@@ -106,7 +106,7 @@ class OrganizeMissingImportsTest extends TestHelper with TestRefactoring {
   } applyRefactoring organize("collection.mutable" -> "LinkedList" :: Nil)
 
   @Test
-  def importRemovesUnneeded = new FileSet {
+  def importRemovesUnneeded() = new FileSet {
     """
       import java.lang._
       import java.lang.{String => S}
@@ -135,7 +135,7 @@ class OrganizeMissingImportsTest extends TestHelper with TestRefactoring {
   } applyRefactoring organize("scala.collection.mutable" -> "LinkedList" :: Nil)
 
   @Test
-  def sort = new FileSet {
+  def sort() = new FileSet {
     """
       import scala.collection.mutable.ListBuffer
       import java.lang.Object
@@ -151,7 +151,7 @@ class OrganizeMissingImportsTest extends TestHelper with TestRefactoring {
   } applyRefactoring organize("scala.collection.mutable" -> "LinkedList" :: Nil)
 
   @Test
-  def collapse = new FileSet {
+  def collapse() = new FileSet {
     """
       import java.lang.String
       import java.lang.Object
@@ -167,7 +167,7 @@ class OrganizeMissingImportsTest extends TestHelper with TestRefactoring {
   } applyRefactoring organize("scala.collection.mutable" -> "LinkedList" :: Nil)
 
   @Test
-  def sortAndCollapse = new FileSet {
+  def sortAndCollapse() = new FileSet {
     """
       import scala.collection.mutable.ListBuffer
       import java.lang.String
@@ -184,7 +184,7 @@ class OrganizeMissingImportsTest extends TestHelper with TestRefactoring {
   } applyRefactoring organize("scala.collection.mutable" -> "LinkedList" :: Nil)
 
   @Test
-  def collapseWithRename = new FileSet {
+  def collapseWithRename() = new FileSet {
     """
       import java.lang.{String => S}
       import java.lang.{Object => Objekt}
@@ -200,7 +200,7 @@ class OrganizeMissingImportsTest extends TestHelper with TestRefactoring {
   } applyRefactoring organize("scala.collection.mutable" -> "LinkedList" :: Nil)
 
   @Test
-  def removeOneFromMany = new FileSet {
+  def removeOneFromMany() = new FileSet {
     """
       import java.lang.{String, Math}
 
@@ -215,7 +215,7 @@ class OrganizeMissingImportsTest extends TestHelper with TestRefactoring {
   } applyRefactoring organize("scala.collection.mutable" -> "LinkedList" :: Nil)
 
   @Test
-  def importAll = new FileSet {
+  def importAll() = new FileSet {
     """
       import java.lang._
       import java.lang.String
@@ -231,7 +231,7 @@ class OrganizeMissingImportsTest extends TestHelper with TestRefactoring {
   } applyRefactoring organize("scala.collection.mutable" -> "LinkedList" :: Nil)
 
   @Test
-  def importOnTrait = new FileSet {
+  def importOnTrait() = new FileSet {
     """
       package importOnTrait
       import java.lang._
@@ -256,7 +256,7 @@ class OrganizeMissingImportsTest extends TestHelper with TestRefactoring {
   } applyRefactoring organize("scala.collection.mutable" -> "LinkedList" :: Nil)
 
   @Test
-  def importWithSpace = new FileSet {
+  def importWithSpace() = new FileSet {
     """
 
       import scala.collection.mutable.ListBuffer
@@ -274,7 +274,7 @@ class OrganizeMissingImportsTest extends TestHelper with TestRefactoring {
   } applyRefactoring organize("scala.collection.mutable" -> "LinkedList" :: Nil)
 
   @Test
-  def importAllWithRename = new FileSet {
+  def importAllWithRename() = new FileSet {
     """
       import java.lang._
       import java.lang.{String => S}
@@ -288,9 +288,9 @@ class OrganizeMissingImportsTest extends TestHelper with TestRefactoring {
       object Main { val s: String = ""; val ll = new LinkedList }
     """
   } applyRefactoring organize("scala.collection.mutable" -> "LinkedList" :: Nil)
-  
+
   @Test
-  def trailingCommentWithClosingBrace = new FileSet {
+  def trailingCommentWithClosingBrace() = new FileSet {
     """
     package trailingCommentWithClosingBrace
 

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/imports/PrependOrDropScalaPackageFromRecomputedTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/imports/PrependOrDropScalaPackageFromRecomputedTest.scala
@@ -22,7 +22,7 @@ class PrependOrDropScalaPackageFromRecomputedTest extends OrganizeImportsBaseTes
   }.mkChanges
 
   @Test
-  def dropScalaPackageWildcardImport = new FileSet {
+  def dropScalaPackageWildcardImport() = new FileSet {
     """
     import scala.math.BigDecimal._
 
@@ -46,7 +46,7 @@ class PrependOrDropScalaPackageFromRecomputedTest extends OrganizeImportsBaseTes
   } applyRefactoring organizeDropScalaPackage
 
   @Test
-  def prependScalaPackageWildcardImport = new FileSet {
+  def prependScalaPackageWildcardImport() = new FileSet {
     """
     import math.BigDecimal._
 
@@ -70,7 +70,7 @@ class PrependOrDropScalaPackageFromRecomputedTest extends OrganizeImportsBaseTes
   } applyRefactoring organizePrependScalaPackage
 
   @Test
-  def wildcardAndRename = new FileSet {
+  def wildcardAndRename() = new FileSet {
     """
     package tests.importing
 
@@ -88,7 +88,7 @@ class PrependOrDropScalaPackageFromRecomputedTest extends OrganizeImportsBaseTes
   } applyRefactoring organizeDropScalaPackage
 
   @Test
-  def importFromPackageObject = new FileSet {
+  def importFromPackageObject() = new FileSet {
     """
     import scala.collection.breakOut
     import scala.collection.mutable.ListBuffer
@@ -106,7 +106,7 @@ class PrependOrDropScalaPackageFromRecomputedTest extends OrganizeImportsBaseTes
   } applyRefactoring organizeDropScalaPackage
 
   @Test
-  def fromMixedToUniformDrop = new FileSet {
+  def fromMixedToUniformDrop() = new FileSet {
     """
     package fromMixedToUniformDrop
     import collection.immutable
@@ -131,7 +131,7 @@ class PrependOrDropScalaPackageFromRecomputedTest extends OrganizeImportsBaseTes
   } applyRefactoring organizeDropScalaPackage
 
   @Test
-  def fromMixedToUniformPrepend = new FileSet {
+  def fromMixedToUniformPrepend() = new FileSet {
     """
     package fromMixedToUniformDrop
     import collection.immutable

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/imports/PrependOrDropScalaPackageKeepTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/imports/PrependOrDropScalaPackageKeepTest.scala
@@ -22,7 +22,7 @@ class PrependOrDropScalaPackageKeepTest extends OrganizeImportsBaseTest {
   }.mkChanges
 
   @Test
-  def dropScalaPackageWildcardImport = new FileSet {
+  def dropScalaPackageWildcardImport() = new FileSet {
     """
     import scala.math.BigDecimal._
 
@@ -46,7 +46,7 @@ class PrependOrDropScalaPackageKeepTest extends OrganizeImportsBaseTest {
   } applyRefactoring organizeDropScalaPackage
 
   @Test
-  def prependScalaPackageWildcardImport = new FileSet {
+  def prependScalaPackageWildcardImport() = new FileSet {
     """
     import math.BigDecimal._
 
@@ -70,7 +70,7 @@ class PrependOrDropScalaPackageKeepTest extends OrganizeImportsBaseTest {
   } applyRefactoring organizePrependScalaPackage
 
   @Test
-  def wildcardAndRename = new FileSet {
+  def wildcardAndRename() = new FileSet {
     """
     package tests.importing
 
@@ -88,7 +88,7 @@ class PrependOrDropScalaPackageKeepTest extends OrganizeImportsBaseTest {
   } applyRefactoring organizeDropScalaPackage
 
   @Test
-  def importFromPackageObject = new FileSet {
+  def importFromPackageObject() = new FileSet {
     """
     import scala.collection.breakOut
     import scala.collection.mutable.ListBuffer
@@ -106,7 +106,7 @@ class PrependOrDropScalaPackageKeepTest extends OrganizeImportsBaseTest {
   } applyRefactoring organizeDropScalaPackage
 
   @Test
-  def fromMixedToUniformDrop = new FileSet {
+  def fromMixedToUniformDrop() = new FileSet {
     """
     package fromMixedToUniformDrop
     import collection.immutable
@@ -131,7 +131,7 @@ class PrependOrDropScalaPackageKeepTest extends OrganizeImportsBaseTest {
   } applyRefactoring organizeDropScalaPackage
 
   @Test
-  def fromMixedToUniformPrepend = new FileSet {
+  def fromMixedToUniformPrepend() = new FileSet {
     """
     package fromMixedToUniformDrop
     import collection.immutable

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/sourcegen/CustomFormattingTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/sourcegen/CustomFormattingTest.scala
@@ -53,7 +53,7 @@ class CustomFormattingTest extends TestHelper with TestRefactoring with SourceGe
   }
 
   @Test
-  def collapse = {
+  def collapse() = {
     surroundingImport = " "
 
     new FileSet {

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/sourcegen/IndividualSourceGenTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/sourcegen/IndividualSourceGenTest.scala
@@ -108,7 +108,7 @@ class IndividualSourceGenTest extends TestHelper with SilentTracing {
   }
 
   @Test
-  def selfTypeAnnotation = global.ask { () =>
+  def selfTypeAnnotation() = global.ask { () =>
     val src = """
 trait tr[A] {
   self: List[A] =>
@@ -145,7 +145,7 @@ trait tr[A] {
   }
 
   @Test
-  def addMethodToEmptyTraitWithSelfTypeAnnotation = global.ask { () =>
+  def addMethodToEmptyTraitWithSelfTypeAnnotation() = global.ask { () =>
     val src = """
 trait tr[A] {
   self: List[A] =>
@@ -178,7 +178,7 @@ trait tr[A] {
   }
 
   @Test
-  def misprintedFunctionDefinition = global.ask { () =>
+  def misprintedFunctionDefinition() = global.ask { () =>
 
     val ast = treeFrom("""
       package generated
@@ -750,7 +750,7 @@ class Test
   }
 
   @Test
-  def testFunctionArg = global.ask { () =>
+  def testFunctionArg() = global.ask { () =>
     val ast = treeFrom(
 """
 class A {
@@ -765,7 +765,7 @@ def fun[A, B, C](fu: (A, B, C) => A): A
   }
 
   @Test
-  def testClassParameter = global.ask { () =>
+  def testClassParameter() = global.ask { () =>
     val ast = treeFrom("""
 class A(a: Int) {
 }
@@ -777,7 +777,7 @@ class A(a: Int) {
     }
 
   @Test
-  def testPrintParentheses = global.ask { () =>
+  def testPrintParentheses() = global.ask { () =>
 
     val ast = treeFrom("""
     trait tr {
@@ -810,7 +810,7 @@ class A(a: Int) {
   }
 
   @Test
-  def testPrintNoParentheses = global.ask { () =>
+  def testPrintNoParentheses() = global.ask { () =>
 
     val ast = treeFrom("""
     trait tr {
@@ -842,7 +842,7 @@ class A(a: Int) {
   }
 
   @Test
-  def replaceWithThis = global.ask { () =>
+  def replaceWithThis() = global.ask { () =>
 
     val str = """
     class MyList[T] {
@@ -899,7 +899,7 @@ class A(a: Int) {
   }
 
     @Test
-  def changeMethodInvocation = global.ask { () =>
+  def changeMethodInvocation() = global.ask { () =>
 
     val str = """
     package abc
@@ -945,7 +945,7 @@ class A(a: Int) {
   }
 
   @Test
-  def changeMethodInvocation2 = global.ask { () =>
+  def changeMethodInvocation2() = global.ask { () =>
 
     val src = """
     package abc
@@ -991,7 +991,7 @@ class A(a: Int) {
   }
 
   @Test
-  def testRemoveAnArgument = global.ask { () =>
+  def testRemoveAnArgument() = global.ask { () =>
 
     val src = """
     trait tr {
@@ -1027,7 +1027,7 @@ class A(a: Int) {
   }
 
    @Test
-  def testParentheses = global.ask { () =>
+  def testParentheses() = global.ask { () =>
 
     val ast = treeFrom("""
     package abc
@@ -1060,7 +1060,7 @@ class A(a: Int) {
   }
 
    @Test
-  def testFullQualifiedName = global.ask { () =>
+  def testFullQualifiedName() = global.ask { () =>
     val str = """
     package asd
     object primitive {
@@ -1107,7 +1107,7 @@ class A(a: Int) {
   }
 
   @Test
-  def changeMethodInvocation3 = global.ask { () =>
+  def changeMethodInvocation3() = global.ask { () =>
 
     val ast = treeFrom("""
     package abc
@@ -1147,7 +1147,7 @@ class A(a: Int) {
   }
 
   @Test
-  def testCopy = global.ask { () =>
+  def testCopy() = global.ask { () =>
     val str = """
     object primitive {
       def member[A](a:A, li:List[A]):Boolean = {
@@ -1187,7 +1187,7 @@ class A(a: Int) {
   }
 
   @Test
-  def testCopy2 = global.ask { () =>
+  def testCopy2() = global.ask { () =>
     val str = """
     package abc
     case class Pair[A, B](a: A, b: B)
@@ -1249,7 +1249,7 @@ class A(a: Int) {
   }
 
   @Test
-  def testCopy3 = global.ask { () =>
+  def testCopy3() = global.ask { () =>
     val str = """
     package abc
     object primitive {
@@ -1311,7 +1311,7 @@ class A(a: Int) {
   }
 
   @Test
-  def testCopy4 = global.ask { () =>
+  def testCopy4() = global.ask { () =>
     val str = """
     package abc
     object primitive {
@@ -1346,7 +1346,7 @@ class A(a: Int) {
   }
 
   @Test
-  def testCopy4Variation = global.ask { () =>
+  def testCopy4Variation() = global.ask { () =>
     val str = """
     package abc
     object primitive {
@@ -1395,7 +1395,7 @@ class A(a: Int) {
   }
 
   @Test
-  def testCopy5 = global.ask { () =>
+  def testCopy5() = global.ask { () =>
     val str = """
     package abc
     object primitive {
@@ -1467,7 +1467,7 @@ class A(a: Int) {
   }
 
   @Test
-  def changeMethodInvocation4 = global.ask { () =>
+  def changeMethodInvocation4() = global.ask { () =>
 
     val ast = treeFrom("""
     package abc
@@ -1505,7 +1505,7 @@ class A(a: Int) {
   }
 
   @Test
-  def changeMethodInvocation5 = global.ask { () =>
+  def changeMethodInvocation5() = global.ask { () =>
 
    val str = """
     package abc
@@ -1557,7 +1557,7 @@ class A(a: Int) {
   }
 
   @Test
-  def patternMatchTest = global.ask { () =>
+  def patternMatchTest() = global.ask { () =>
     val src = """
   object acmatch {
     def fail = throw new UnsupportedOperationException("unsupported")
@@ -1608,7 +1608,7 @@ class A(a: Int) {
   }
 
   @Test
-  def patternMatchTest2 = global.ask { () =>
+  def patternMatchTest2() = global.ask { () =>
     val src = """
   object acmatch {
     def fail = throw new UnsupportedOperationException("unsupported")
@@ -1691,7 +1691,7 @@ class A(a: Int) {
   }
 
   @Test
-  def patternMatchTest3 = global.ask { () =>
+  def patternMatchTest3() = global.ask { () =>
     val src = """
 object acmatch {
     def fail = throw new UnsupportedOperationException("unsupported")
@@ -1765,7 +1765,7 @@ object acmatch {
   }
 
   @Test
-  def patternMatchTest4 = global.ask { () =>
+  def patternMatchTest4() = global.ask { () =>
     val src = """
 object acmatch {
     def fail = throw new UnsupportedOperationException("unsupported")
@@ -1842,7 +1842,7 @@ object acmatch {
   }
 
   @Test
-  def changeMethodInvocation7 = global.ask { () =>
+  def changeMethodInvocation7() = global.ask { () =>
 
     val str = """
     package abc
@@ -1890,7 +1890,7 @@ object acmatch {
   }
 
   @Test
-  def changeMethodInvocation8 = global.ask { () =>
+  def changeMethodInvocation8() = global.ask { () =>
 
     val str = """
     object primitive {
@@ -1933,7 +1933,7 @@ object acmatch {
   }
 
   @Test
-  def testAddSealed = global.ask { () =>
+  def testAddSealed() = global.ask { () =>
     val str = """
     abstract class asd {
     }
@@ -1965,7 +1965,7 @@ object acmatch {
   }
 
   @Test
-  def testRemoveSealed = global.ask { () =>
+  def testRemoveSealed() = global.ask { () =>
     val str = """
     abstract sealed class asd {
     }
@@ -1994,7 +1994,7 @@ object acmatch {
   }
 
   @Test
-  def testAddSealedPP = global.ask { () =>
+  def testAddSealedPP() = global.ask { () =>
     val str = """
     abstract class asd {
     }
@@ -2026,7 +2026,7 @@ object acmatch {
   }
 
   @Test
-  def testRemoveSealedPP = global.ask { () =>
+  def testRemoveSealedPP() = global.ask { () =>
     val str = """
     abstract sealed class asd {
     }
@@ -2055,7 +2055,7 @@ object acmatch {
   }
 
   @Test
-  def insertPlainString = global.ask { () =>
+  def insertPlainString() = global.ask { () =>
     val source = """
     class InsertHere {
       def method = {

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/sourcegen/PrettyPrinterTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/sourcegen/PrettyPrinterTest.scala
@@ -115,7 +115,7 @@ class PrettyPrinterTest extends TestHelper with SilentTracing {
   }
 
   @Test
-  def testSuperCall =  {
+  def testSuperCall() =  {
 
     val tree = mkCaseClass(
         name = "A",
@@ -126,7 +126,7 @@ class PrettyPrinterTest extends TestHelper with SilentTracing {
   }
 
   @Test
-  def testSuperConstructorCall =  {
+  def testSuperConstructorCall() =  {
 
     val tree = mkCaseClass(
         name = "A",
@@ -138,7 +138,7 @@ class PrettyPrinterTest extends TestHelper with SilentTracing {
   }
 
   @Test
-  def testDefDefWithoutParens =  {
+  def testDefDefWithoutParens() =  {
 
     val tree = Block(
         DefDef(
@@ -165,7 +165,7 @@ class PrettyPrinterTest extends TestHelper with SilentTracing {
   }
 
   @Test
-  def testImplicitKeyword =  {
+  def testImplicitKeyword() =  {
 
     val tree = DefDef(
           NoMods withPosition (Flags.IMPLICIT, NoPosition) withPosition (Flags.METHOD, NoPosition) ,
@@ -180,7 +180,7 @@ class PrettyPrinterTest extends TestHelper with SilentTracing {
   }
 
   @Test
-  def testDefDefWithTypeParams =  {
+  def testDefDefWithTypeParams() =  {
 
     val arg = ValDef(NoMods withPosition (Flags.IMPLICIT, NoPosition), newTermName("a"),
                 TypeDef(NoMods, newTypeName("R"), TypeDef(NoMods, newTypeName("X"), Nil, EmptyTree) :: Nil, EmptyTree), EmptyTree)
@@ -906,7 +906,7 @@ object User {
   }
 
   @Test
-  def testAlteredPattern = global.ask { () =>
+  def testAlteredPattern() = global.ask { () =>
     val tree = treeFrom("""
     object Demo {
       5 match { case i => () }
@@ -1410,7 +1410,7 @@ class A {
   }
 
   @Test
-  def testFunctionArg = global.ask { () =>
+  def testFunctionArg() = global.ask { () =>
     treeFrom("""
     class A {
       def fun[A, B, C](fu: (A, B, C) => A): A
@@ -1421,7 +1421,7 @@ class A {
   }
 
   @Test
-  def partialFunctionArg = global.ask { () =>
+  def partialFunctionArg() = global.ask { () =>
     treeFrom("""
     class A {
       def main[A, B](e: Either[A, B]) {
@@ -1438,7 +1438,7 @@ class A {
     }
 
   @Test
-  def operatorPrecedences1 = global.ask { () =>
+  def operatorPrecedences1() = global.ask { () =>
     treeFrom("""
     class A {
       5 * (2 + 1)
@@ -1449,7 +1449,7 @@ class A {
     }
 
   @Test
-  def operatorPrecedences2 = global.ask { () =>
+  def operatorPrecedences2() = global.ask { () =>
     treeFrom("""
     class A {
       5 * 2 + 1
@@ -1460,7 +1460,7 @@ class A {
   }
 
   @Test
-  def operatorPrecedences3 = global.ask { () =>
+  def operatorPrecedences3() = global.ask { () =>
     treeFrom("""
     class A {
       1 + 2 + 3
@@ -1471,7 +1471,7 @@ class A {
   }
 
   @Test
-  def operatorPrecedences4 = global.ask { () =>
+  def operatorPrecedences4() = global.ask { () =>
     treeFrom("""
     class A {
       1 + (2 + 3)

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/sourcegen/SourceGenTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/sourcegen/SourceGenTest.scala
@@ -846,7 +846,7 @@ class SourceGenTest extends TestHelper with SilentTracing {
   }
 
   @Test
-  def testAlteredPattern = global.ask { () =>
+  def testAlteredPattern() = global.ask { () =>
     val tree = treeFrom("""
     object Demo {
       5 match { case i => () }
@@ -869,7 +869,7 @@ class SourceGenTest extends TestHelper with SilentTracing {
   }
 
   @Test
-  def testAlteredPatternWithGuard = global.ask { () =>
+  def testAlteredPatternWithGuard() = global.ask { () =>
     val tree = treeFrom("""
     object Demo {
       5 match { case i if true => () }
@@ -892,7 +892,7 @@ class SourceGenTest extends TestHelper with SilentTracing {
   }
 
   @Test
-  def testAlteredSubPattern = global.ask { () =>
+  def testAlteredSubPattern() = global.ask { () =>
     val tree = treeFrom("""
     object Demo {
       5 match { case 1 | 2 => () }
@@ -1615,7 +1615,7 @@ class SourceGenTest extends TestHelper with SilentTracing {
   }
 
   @Test
-  def testExprInRequiredParens = global.ask { () =>
+  def testExprInRequiredParens() = global.ask { () =>
     val code = """
       object Main{
         (1 to 10).foreach(println(_))
@@ -1626,7 +1626,7 @@ class SourceGenTest extends TestHelper with SilentTracing {
   }
 
   @Test
-  def testExprInOptionalParens = global.ask { () =>
+  def testExprInOptionalParens() = global.ask { () =>
     val code = """
       object Main{
         (List(1)).foreach(println(_))
@@ -1637,7 +1637,7 @@ class SourceGenTest extends TestHelper with SilentTracing {
   }
 
   @Test
-  def testConsOperator = {
+  def testConsOperator() = {
     val code = """
       object ConsClient{
         val a = 1 :: 2 :: Nil
@@ -1658,7 +1658,7 @@ class SourceGenTest extends TestHelper with SilentTracing {
   }
 
   @Test
-  def testNewParameterList = global.ask { () =>
+  def testNewParameterList() = global.ask { () =>
     val tree = treeFrom("""
       object O{
         def fn = 1
@@ -1673,7 +1673,7 @@ class SourceGenTest extends TestHelper with SilentTracing {
   }
 
   @Test
-  def testNewParamInEmptyList = global.ask { () =>
+  def testNewParamInEmptyList() = global.ask { () =>
     val tree = treeFrom("""
       object O{
         def fn() = 1

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/transformation/TransformableSelectionTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/transformation/TransformableSelectionTest.scala
@@ -24,7 +24,7 @@ class TransformableSelectionTest extends TestHelper with TransformableSelections
       val result = trans(root)
 
       new {
-        def toFail =
+        def toFail() =
           assertTrue(result.isEmpty)
 
         def toBecome(expectedSrc: String) = {
@@ -42,7 +42,7 @@ class TransformableSelectionTest extends TestHelper with TransformableSelections
   }
 
   @Test
-  def replaceSingleStatement = """
+  def replaceSingleStatement() = """
     object O{
       def f = /*(*/1/*)*/
     }
@@ -53,7 +53,7 @@ class TransformableSelectionTest extends TestHelper with TransformableSelections
     """)
 
   @Test
-  def replaceSingleStatementInArgument = """
+  def replaceSingleStatementInArgument() = """
     object O{
       println(/*(*/1/*)*/)
     }
@@ -64,7 +64,7 @@ class TransformableSelectionTest extends TestHelper with TransformableSelections
     """)
 
   @Test
-  def replaceSequence = """
+  def replaceSequence() = """
     object O{
       def f = {
         /*(*/println(1)
@@ -82,7 +82,7 @@ class TransformableSelectionTest extends TestHelper with TransformableSelections
     """)
 
   @Test
-  def replaceAllExpressionsInBlock = """
+  def replaceAllExpressionsInBlock() = """
     object O{
       def f = {
         /*(*/println(1)
@@ -97,7 +97,7 @@ class TransformableSelectionTest extends TestHelper with TransformableSelections
     """)
 
   @Test
-  def replaceAllExpressionsInBlockPreservingHierarchy = """
+  def replaceAllExpressionsInBlockPreservingHierarchy() = """
     object O{
       def f = {
         /*(*/println(1)

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/util/FreshCompilerForeachTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/util/FreshCompilerForeachTest.scala
@@ -14,7 +14,7 @@ trait FreshCompilerForeachTest extends TestHelper {
   override val global = (new CompilerInstance).compiler
 
   @After
-  def shutdownCompiler {
+  def shutdownCompiler() {
     global.askShutdown
   }
 }

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/util/TestHelper.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/util/TestHelper.scala
@@ -101,8 +101,8 @@ trait TestHelper extends ScalaVersionTestRule with Refactoring with CompilerProv
       new {
         def withResultTree(fn: global.Tree => Unit) = fn(treeFrom(res.mkString("\n")))
         def withResultSource(fn: String => Unit) = fn(res.mkString("\n"))
-        def assertEqualSource = assert(res)
-        def assertEqualTree = withResultTree { actualTree =>
+        def assertEqualSource() = assert(res)
+        def assertEqualTree() = withResultTree { actualTree =>
           val expectedTree = treeFrom(srcs.head._2)
           val (expected, actual) = global.ask { () =>
             (expectedTree.toString(), actualTree.toString())


### PR DESCRIPTION
One thing that always bugged me in scala-refactoring is that the
side-effecting nullary methods had no parentheses. This fixes it, along with a
couple other straightforward issues (e.g. Option warts).
