### PR TITLE
fix duplicated arrow when extracting extractors from case statements with body on next line

### DIFF
--- a/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/sourcegen/PrettyPrinter.scala
+++ b/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/sourcegen/PrettyPrinter.scala
@@ -130,8 +130,16 @@ trait PrettyPrinter extends TreePrintingTraversals with AbstractPrinter {
         case Some(patP(patStr)) if guard == EmptyTree => Fragment(patStr)
         case _ => p(pat)
       }
+      
+      val arrowReq = new Requisite {
+        def isRequired(l: Layout, r: Layout) = {
+          !(l.contains("=>") || r.contains("=>"))
+        }
 
-      Layout("case ") ++ patFrag ++ p(guard, before = " if ") ++ p(body, before = " => ")
+        def getLayout = Layout(" => ")
+      }
+
+      Layout("case ") ++ patFrag ++ p(guard, before = " if ") ++ p(body, before = arrowReq)
     }
 
     override def Alternative(tree: Alternative, trees: List[Tree])(implicit ctx: PrintingContext) = {

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/extraction/ExtractExtractorTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/extraction/ExtractExtractorTest.scala
@@ -39,6 +39,33 @@ class ExtractExtractorTest extends TestHelper with TestRefactoring {
   }.performRefactoring(extract(0)).assertEqualTree
 
   @Test
+  def extractWithBodyOnNextLine() = new FileSet {
+    """
+      object Demo {
+        List(1) match {
+	  	  case /*(*/List(i)/*)*/ =>
+	  		println(i)
+        }
+      }
+    """ becomes
+      """
+      object Demo {
+        List(1) match {
+	  	  case Extracted(i) =>
+            println(i)
+        }
+    
+        object Extracted {
+          def unapply(x: List[Int]) = x match {
+    		case List(i) => Some(i)
+            case _ => None
+          }
+        }
+      }
+    """
+  }.performRefactoring(extract(0)).assertEqualTree()
+
+  @Test
   def extractWithBodyOnNewLine() = new FileSet {
     """
       object Demo {


### PR DESCRIPTION
Fixes the following issue (copied from https://github.com/scala-ide/scala-ide/pull/686):

``` scala
class foo {
  def m(ar: AnyRef) =
    ar match {
    case /*1*/A(z) if (z == 2)/*1*/ =>
      5
    case /*2*/A(z)/*2*/ =>
      z
  }

  // extractor for selection 1
  // extra ') =>' in the generated code
  object ext1 {
    def unapply(x: AnyRef) = x match {
      case A(z) if z == 2) => => Some(z)
      case _ => None
    }
  }

  // extractor for selection 1
  // extra '=>' in the generated code
  object ext2 {
    def unapply(x: AnyRef) = x match {
      case A(z) => => Some(z)
      case _ => None
    }
  }
}
```
