### PR TITLE
Propose all possible extractions in ExtractCode

### DIFF
--- a/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/implementations/extraction/ExtractCode.scala
+++ b/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/implementations/extraction/ExtractCode.scala
@@ -18,7 +18,8 @@ trait AutoExtractions extends MethodExtractions with ValueExtractions with Extra
      */
     val availableCollectors =
       ExtractorExtraction ::
-        ValueOrMethodExtraction ::
+        ValueExtraction ::
+        MethodExtraction ::
         ParameterExtraction ::
         Nil
 
@@ -47,31 +48,5 @@ trait AutoExtractions extends MethodExtractions with ValueExtractions with Extra
     def isValidExtractionSource(s: Selection) = ???
 
     def createExtractions(source: Selection, targets: List[ExtractionTarget], name: String) = ???
-  }
-
-  /**
-   * Proposes either value or method extractions for an extraction target depending
-   * on whether all inbound dependencies are satisfied in the respective scope or not.
-   *
-   * If the extraction source contains (obvious) side effects it proposes only method
-   * extractions. 
-   */
-  object ValueOrMethodExtraction extends ExtractionCollector[Extraction] {
-    def isValidExtractionSource(s: Selection) =
-      MethodExtraction.isValidExtractionSource(s)
-
-    def createExtractions(source: Selection, targets: List[ExtractionTarget], name: String) = {
-      val valueExtractions =
-        if (source.mayHaveSideEffects)
-          Nil
-        else
-          ValueExtraction.createExtractions(source, targets, name)
-
-      val remainingTargets = targets.filterNot(t => valueExtractions.exists(e => e.extractionTarget == t))
-
-      val methodExtractions = MethodExtraction.createExtractions(source, remainingTargets, name)
-
-      valueExtractions ::: methodExtractions
-    }
   }
 }

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/extraction/ExtractCodeTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/extraction/ExtractCodeTest.scala
@@ -29,7 +29,7 @@ class ExtractCodeTest extends TestHelper with TestRefactoring {
         val extracted = a * a
       }
     """
-  }.performRefactoring(extract(1)).assertEqualTree
+  }.performRefactoring(extract(2)).assertEqualTree
 
   @Test
   def extractCodeWithUnknownDependencies() = new FileSet {
@@ -56,7 +56,7 @@ class ExtractCodeTest extends TestHelper with TestRefactoring {
         }
       }
     """
-  }.performRefactoring(extract(1)).assertEqualTree
+  }.performRefactoring(extract(2)).assertEqualTree
 
   @Test
   def extractMultipleExpressions() = new FileSet {
@@ -101,7 +101,7 @@ class ExtractCodeTest extends TestHelper with TestRefactoring {
         }
       }
     """
-  }.performRefactoring(extract(0)).assertEqualTree
+  }.performRefactoring(extract(1)).assertEqualTree
 
   @Test
   def extractCodeInCase() = new FileSet {
@@ -143,7 +143,7 @@ class ExtractCodeTest extends TestHelper with TestRefactoring {
         }
       }
     """
-  }.performRefactoring(extract(1)).assertEqualTree
+  }.performRefactoring(extract(3)).assertEqualTree
 
   @Test
   def extractCodeWithPotentialSideEffectsOnVar() = new FileSet {
@@ -168,7 +168,7 @@ class ExtractCodeTest extends TestHelper with TestRefactoring {
         }
       }
     """
-  }.performRefactoring(extract(1)).assertEqualTree
+  }.performRefactoring(extract(3)).assertEqualTree
 
   @Test
   def extractForEnumerator() = new FileSet {
@@ -232,7 +232,7 @@ class ExtractCodeTest extends TestHelper with TestRefactoring {
         }
       }
     """
-    }.performRefactoring(extract(0)).assertEqualTree
+    }.performRefactoring(extract(1)).assertEqualTree
   }
 
   @Test
@@ -290,10 +290,10 @@ class ExtractCodeTest extends TestHelper with TestRefactoring {
         def fn = {
           val extracted = 1
           val a = extracted
-	  	}
+	  	  }
       }
     """
-  }.performRefactoring(extract(1)).assertEqualTree
+  }.performRefactoring(extract(2)).assertEqualTree
   
   def avoidNameCollisions = new FileSet {
     """


### PR DESCRIPTION
This PR changes ExtractCode such that it does no longer filter the available extractions based on the side effect detection heuristic. This results in more proposed extractions but is more flexible.

After applying this PR, the "Extract..." command in Scala IDE can replace the remaining extraction commands "Extract Value", "Extract Method", "Extract Parameter" and "Extract Extractor".
