### PR TITLE
Fix missing parens in calls to extracted methods with empty parameter lists

### DIFF
--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/extraction/ExtractMethodTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/extraction/ExtractMethodTest.scala
@@ -88,7 +88,7 @@ class ExtractMethodTest extends TestHelper with TestRefactoring {
       }
     """ becomes """
       object Demo {
-        /*(*/extracted()/*)*/
+        extracted()
 
         def extracted() = {
           /*(*/println(123)/*)*/
@@ -96,6 +96,23 @@ class ExtractMethodTest extends TestHelper with TestRefactoring {
       }
     """
   }.performRefactoring(extract(0)).assertEqualSource
+  
+  @Test
+  def extractMethodWithoutParametersAndCreateEmptyParameterList2() = new FileSet {
+    """
+      object Demo {
+        val a = /*(*/1 * 2/*)*/
+      }
+    """ becomes """
+      object Demo {
+        val a = extracted()/*)*/
+
+        def extracted() = {
+          /*(*/1 * 2
+        }
+      }
+    """
+  }.performRefactoring(extract(1)).assertEqualSource
 
   @Test
   def extractImportedDependency() = new FileSet {


### PR DESCRIPTION
This PR addresses an issue reported in scala-ide/scala-ide#686 by @huitseeker:

``` scala
class ExtractorTesting {

  val major: Int = 1
  val minor: Int = 2
  val patch: Int = 3

  major * 100000 + minor * 10000 + patch * 100

}
```

Should give me

``` scala
class ExtractorTesting {

  val major: Int = 1
  val minor: Int = 2
  val patch: Int = 3

  extracted()

  def extracted() = {
    major * 100000 + minor * 10000 + patch * 100
  }
}
```
