### PR TITLE
Adapt to concurrency changes in interactive

### DIFF
--- a/org.scala-refactoring.library/.classpath
+++ b/org.scala-refactoring.library/.classpath
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_COMPILER_CONTAINER"/>
 	<classpathentry kind="src" path="src/main/scala"/>
 	<classpathentry kind="src" path="src/test/java"/>
 	<classpathentry kind="src" path="src/test/scala"/>
-
+	<classpathentry combineaccessrules="false" exported="true" kind="src" path="/scala-compiler"/>
+	<classpathentry combineaccessrules="false" exported="true" kind="src" path="/scala-library"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/common/InteractiveScalaCompiler.scala
+++ b/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/common/InteractiveScalaCompiler.scala
@@ -17,7 +17,9 @@ trait InteractiveScalaCompiler extends CompilerAccess {
 
   val global: tools.nsc.interactive.Global
 
-  def compilationUnitOfFile(f: AbstractFile) = global.unitOfFile.get(f)
+  implicit def flattenGet(or: Option[Option[global.RichCompilationUnit]]): Option[global.RichCompilationUnit] = or.flatten
+
+  def compilationUnitOfFile(f: AbstractFile): Option[global.RichCompilationUnit] = Option(global.unitOfFile.get(f))
 
   /**
    * Returns a fully loaded and typed Tree instance for the given SourceFile.

--- a/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/implementations/MarkOccurrences.scala
+++ b/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/implementations/MarkOccurrences.scala
@@ -25,7 +25,8 @@ abstract class MarkOccurrences extends common.Selections with analysis.Indexes w
       occurrences map (_.namePosition) filter  (_ != global.NoPosition)
     }
 
-    val selectedTree = (new FileSelection(file, global.unitOfFile(file).body, from, to)).findSelectedWithPredicate {
+    implicit def unsafeGet(or: Option[global.RichCompilationUnit]): global.RichCompilationUnit = or.get
+    val selectedTree = (new FileSelection(file, global.unitOfFile.get(file).body, from, to)).findSelectedWithPredicate {
       case (_: global.TypeTree) | (_: global.SymTree) | (_: global.Ident) => true
       case _ => false
     }

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/analysis/MultipleFilesIndexTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/analysis/MultipleFilesIndexTest.scala
@@ -23,8 +23,8 @@ class MultipleFilesIndexTest extends TestHelper with GlobalIndexes with FreshCom
   }
 
   def buildIndex(pro: FileSet) = {
-
-    val trees = pro.sources map (x => addToCompiler(pro.fileName(x), x)) map (global.unitOfFile(_).body)
+    implicit def unsafeGet(or: Option[global.RichCompilationUnit]): global.RichCompilationUnit = or.get
+    val trees = pro.sources map (x => addToCompiler(pro.fileName(x), x)) map (global.unitOfFile.get(_).body)
 
     val cuIndexes = global.ask { () =>
       trees map CompilationUnitIndex.apply

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/MarkOccurrencesTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/MarkOccurrencesTest.scala
@@ -21,8 +21,9 @@ class MarkOccurrencesTest extends TestHelper {
       val global = outer.global
 
       val index = {
+        implicit def unsafeGet(or: Option[global.RichCompilationUnit]): global.RichCompilationUnit = or.get
         val file = tree.pos.source.file
-        val t = global.unitOfFile(file).body
+        val t = global.unitOfFile.get(file).body
         global.ask { () =>
           GlobalIndex(CompilationUnitIndex(t) :: Nil)
         }

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/imports/UnusedImportsFinderTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/imports/UnusedImportsFinderTest.scala
@@ -18,7 +18,8 @@ class UnusedImportsFinderTest extends TestHelper {
 
         val global = outer.global
 
-        val unit = global.unitOfFile(addToCompiler(randomFileName(), src))
+       implicit def unsafeGet(or: Option[global.RichCompilationUnit]): global.RichCompilationUnit = or.get
+        val unit = global.unitOfFile.get(addToCompiler(randomFileName(), src))
 
         def compilationUnitOfFile(f: AbstractFile) = Some(unit)
 

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/util/TestHelper.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/util/TestHelper.scala
@@ -116,7 +116,8 @@ trait TestHelper extends ScalaVersionTestRule with Refactoring with CompilerProv
   def selection(refactoring: Selections with InteractiveScalaCompiler, project: FileSet) = {
 
     val files = project.sources map (x => addToCompiler(project.fileName(x), x))
-    val trees: List[refactoring.global.Tree] = files map (refactoring.global.unitOfFile(_).body)
+    implicit def unsafeGet(or: Option[global.RichCompilationUnit]): global.RichCompilationUnit = or.get
+    val trees: List[refactoring.global.Tree] = files map (refactoring.global.unitOfFile.get(_).body)
 
     (project.sources zip trees flatMap {
       case (src, tree) =>

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/util/TestRefactoring.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/util/TestRefactoring.scala
@@ -26,13 +26,14 @@ trait TestRefactoring extends TestHelper {
 
       val global = TestRefactoring.this.global
 
+      implicit def unsafeGet(or: Option[global.RichCompilationUnit]): global.RichCompilationUnit = or.get
       lazy val trees = {
-        project.sources map (x => addToCompiler(project.fileName(x), x)) map (global.unitOfFile(_).body)
+        project.sources map (x => addToCompiler(project.fileName(x), x)) map (global.unitOfFile.get(_).body)
       }
 
       override val index = global.ask { () =>
         val cuIndexes = trees map (_.pos.source.file) map { file =>
-          global.unitOfFile(file).body
+          global.unitOfFile.get(file).body
         } map CompilationUnitIndex.apply
         GlobalIndex(cuIndexes)
       }


### PR DESCRIPTION
See https://github.com/scala/scala/pull/3903
The implicits should rovide backward compatibility.
