### PR TITLE
Don't call symbol.isLazy in test suite

### DIFF
--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/sourcegen/ReusingPrinterTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/sourcegen/ReusingPrinterTest.scala
@@ -139,7 +139,7 @@ class ReusingPrinterTest extends TestHelper with SilentTracing {
     """ after topdown { matchingChildren {
       filter {
         case d: DefDef =>
-          d.symbol.isLazy
+          d.symbol.owner.nameString == "TT"
       } &>
       transform {
         case d: DefDef =>


### PR DESCRIPTION
This tests sometimes fails spuriously and it may be that the failure is
triggered by the call of `isLazy`. While there is no guarantee that this
change actually works around the problem, we have to try it.

Fixes #69
