### PR TITLE
Reset reporter and typer before each unit test

### DIFF
--- a/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/util/CompilerProvider.scala
+++ b/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/util/CompilerProvider.scala
@@ -123,5 +123,8 @@ trait CompilerProvider extends TreeCreationMethods {
     global.askReset
 
     global.checkNoResponsesOutstanding
+
+    global.reporter.reset()      // Hopefully a fix for https://github.com/scala-ide/scala-refactoring/issues/69
+    global.analyzer.resetTyper() // ... added for good measure.
   }
 }


### PR DESCRIPTION
Reusing the presentation compiler is good for performance
but invites cross talk between tests. I modified
`resetPresentationCompiler` to check if the reporter was
clean before each test, and it turns out it wasn't. The
typechecker predicates addition of some synthetic trees on
an error-free reporter. I'm hoping this explains the errors
we have seen in `add_override_final_flags_to_lazy_val` recently.

Some code paths in the presentation compiler which run through
`backgroundCompile` do reset the reporter. Perhaps we only see
the problem sporadically (under load on Jenkins?) because we
have to trigger a race condition that avoids the call to
`backgroundCompile` before we pick up a work item in `pollForWork`.

This commit explicitly resets the reporter before each test.
It also does the same for the typer, although this is not in
response to an observed bug, but rather just as a precaution.

Relates to #69

Review by @sschaef @misto
