### PR TITLE
Improves annotation handling for "Organize Imports"

### DIFF
--- a/org.scala-refactoring.library/.classpath
+++ b/org.scala-refactoring.library/.classpath
@@ -7,6 +7,6 @@
 	<classpathentry kind="src" path="src/main/scala"/>
 	<classpathentry kind="src" path="src/test/java"/>
 	<classpathentry kind="src" path="src/test/scala"/>
-
+	<classpathentry kind="src" path="src/main/scala-2_11"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/org.scala-refactoring.library/pom.xml
+++ b/org.scala-refactoring.library/pom.xml
@@ -35,6 +35,25 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>1.9.1</version>
+        <executions>
+          <execution>
+            <id>add-source</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>${scala.versioned.source}</source>
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
   <reporting>

--- a/org.scala-refactoring.library/src/main/scala-2_10/README
+++ b/org.scala-refactoring.library/src/main/scala-2_10/README
@@ -1,0 +1,1 @@
+Put sources specifically for Scala-2.10.x here

--- a/org.scala-refactoring.library/src/main/scala-2_10/scala/tools/refactoring/ScalaVersionsAdapter.scala
+++ b/org.scala-refactoring.library/src/main/scala-2_10/scala/tools/refactoring/ScalaVersionsAdapter.scala
@@ -1,0 +1,12 @@
+package scala.tools.refactoring
+
+import scala.tools.refactoring.common.CompilerApiExtensions
+
+object ScalaVersionAdapters {
+
+  trait CompilerApiAdapters { self: common.InteractiveScalaCompiler =>
+    import global._
+
+    def annotationInfoTree(info: AnnotationInfo): Tree = info.original
+  }
+}

--- a/org.scala-refactoring.library/src/main/scala-2_11/README
+++ b/org.scala-refactoring.library/src/main/scala-2_11/README
@@ -1,0 +1,1 @@
+Put sources specifically for Scala-2.11.x here

--- a/org.scala-refactoring.library/src/main/scala-2_11/scala/tools/refactoring/ScalaVersionsAdapter.scala
+++ b/org.scala-refactoring.library/src/main/scala-2_11/scala/tools/refactoring/ScalaVersionsAdapter.scala
@@ -1,0 +1,12 @@
+package scala.tools.refactoring
+
+import scala.tools.refactoring.common.CompilerApiExtensions
+
+object ScalaVersionAdapters {
+
+  trait CompilerApiAdapters { self: common.InteractiveScalaCompiler =>
+    import global._
+
+    def annotationInfoTree(info: AnnotationInfo): Tree = info.tree
+  }
+}

--- a/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/analysis/CompilationUnitDependencies.scala
+++ b/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/analysis/CompilationUnitDependencies.scala
@@ -95,22 +95,12 @@ trait CompilationUnitDependencies extends CompilerApiExtensions with ScalaVersio
     val wholeTree = t
 
     def qualifierIsEnclosingPackage(t: Select) = {
-      t.pos
       enclosingPackage(wholeTree, t.pos) match {
         case pkgDef: PackageDef =>
           t.qualifier.nameString == pkgDef.nameString
         case _ => false
       }
     }
-
-    def extractQualifier(tpe: TypeRef) = {
-      val tpeStr = tpe.toString
-      val suffix = tpe.trimPrefix(tpeStr)
-      val prefix = tpeStr.substring(0, tpeStr.length - suffix.length)
-      if (prefix.endsWith(".")) prefix.init
-      else prefix
-    }
-
 
     def isDefinedLocally(t: Tree): Boolean = isSymDefinedLocally(t.symbol)
 
@@ -320,7 +310,9 @@ trait CompilationUnitDependencies extends CompilerApiExtensions with ScalaVersio
       }
 
       override def handleAnnotations(as: List[AnnotationInfo]) {
-        if (annotationTree.isEmpty) {
+        val recusing = annotationTree.isDefined
+
+        if (!recusing) {
           try {
             as.foreach { a =>
               val tree = annotationInfoTree(a)

--- a/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/analysis/CompilationUnitDependencies.scala
+++ b/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/analysis/CompilationUnitDependencies.scala
@@ -7,7 +7,7 @@ package analysis
 
 import scala.tools.refactoring.common.CompilerApiExtensions
 
-trait CompilationUnitDependencies extends CompilerApiExtensions {
+trait CompilationUnitDependencies extends CompilerApiExtensions with ScalaVersionAdapters.CompilerApiAdapters {
   // we need to interactive compiler because we work with RangePositions
   this: common.InteractiveScalaCompiler with common.TreeTraverser with common.TreeExtractors with common.PimpedTrees =>
 
@@ -95,6 +95,7 @@ trait CompilationUnitDependencies extends CompilerApiExtensions {
     val wholeTree = t
 
     def qualifierIsEnclosingPackage(t: Select) = {
+      t.pos
       enclosingPackage(wholeTree, t.pos) match {
         case pkgDef: PackageDef =>
           t.qualifier.nameString == pkgDef.nameString
@@ -102,9 +103,24 @@ trait CompilationUnitDependencies extends CompilerApiExtensions {
       }
     }
 
-    def isDefinedLocally(t: Tree) = wholeTree.exists {
-      case defTree: DefTree if t.symbol == defTree.symbol => true
+    def extractQualifier(tpe: TypeRef) = {
+      val tpeStr = tpe.toString
+      val suffix = tpe.trimPrefix(tpeStr)
+      val prefix = tpeStr.substring(0, tpeStr.length - suffix.length)
+      if (prefix.endsWith(".")) prefix.init
+      else prefix
+    }
+
+
+    def isDefinedLocally(t: Tree): Boolean = isSymDefinedLocally(t.symbol)
+
+    def isSymDefinedLocally(sym: Symbol): Boolean = wholeTree.exists {
+      case defTree: DefTree if sym == defTree.symbol => true
       case _ => false
+    }
+
+    def isDefinedLocallyAndQualifiedWithEnclosingPackage(t: Select) = {
+      qualifierIsEnclosingPackage(t) && isDefinedLocally(t)
     }
 
     val result = new collection.mutable.HashMap[String, Select]
@@ -128,6 +144,21 @@ trait CompilationUnitDependencies extends CompilerApiExtensions {
     }
 
     val traverser = new TraverserWithFakedTrees {
+      var annotationTree: Option[Tree] = None
+
+      def traversingAnnotation() = annotationTree.isDefined
+
+      def tryFindTpeAndSymFor(ident: Ident) = {
+        Option(ident.tpe).map((_, ident.symbol)).orElse {
+          annotationTree.flatMap { tree =>
+            val name = ident.name
+
+            tree.collect {
+              case Literal(Constant(tpe @ TypeRef(_, sym, _))) if (sym.name == name) => (tpe, sym)
+            }.headOption
+          }
+        }
+      }
 
       def isSelectFromInvisibleThis(t: Tree) = {
 
@@ -241,12 +272,11 @@ trait CompilationUnitDependencies extends CompilerApiExtensions {
           }
 
         case t @ Select(qual, _) if t.pos.isOpaqueRange =>
-
           if (!isMethodCallFromExplicitReceiver(t)
               && !isSelectFromInvisibleThis(qual)
               && t.name != nme.WILDCARD
               && hasStableQualifier(t)
-              && !(isDefinedLocally(t) && qualifierIsEnclosingPackage(t))) {
+              && !isDefinedLocallyAndQualifiedWithEnclosingPackage(t)) {
             addToResult(t)
           }
 
@@ -255,29 +285,54 @@ trait CompilationUnitDependencies extends CompilerApiExtensions {
         /*
          * classOf[some.Type] is represented by a Literal
          * */
-        case t @ Literal(Constant(value)) =>
-
+        case t @ Literal(c @ Constant(value)) =>
           value match {
             case tpe @ TypeRef(_, sym, _) =>
               fakeSelectTreeFromType(tpe, sym, t.pos) match {
-                case t: Select => addToResult(t)
+                case s: Select if !isDefinedLocallyAndQualifiedWithEnclosingPackage(s) =>
+                  addToResult(s)
                 case _ => ()
               }
             case _ => ()
           }
 
-        case t: Ident if t.tpe != null && t.name != nme.EMPTY_PACKAGE_NAME =>
-          fakeSelectTree(t.tpe, t.symbol, t) match {
-            // only repeat if it's a Select, if it's an Ident,
-            // otherwise we risk to loop endlessly
-            case select: Select =>
-              traverse(select)
+        case t: Ident if t.name != nme.EMPTY_PACKAGE_NAME =>
+          tryFindTpeAndSymFor(t) match {
+            case Some((tpe, sym)) =>
+              fakeSelectTree(tpe, sym, t) match {
+                // only repeat if it's a Select, if it's an Ident,
+                // otherwise we risk to loop endlessly
+                case select: Select =>
+                  traverse(select)
+                case _ =>
+                  super.traverse(tree)
+              }
             case _ =>
               super.traverse(tree)
           }
 
+        case t: Ident => {
+          super.traverse(tree)
+        }
+
         case _ =>
           super.traverse(tree)
+      }
+
+      override def handleAnnotations(as: List[AnnotationInfo]) {
+        if (annotationTree.isEmpty) {
+          try {
+            as.foreach { a =>
+              val tree = annotationInfoTree(a)
+              val orig = a.original
+
+              annotationTree = Some(tree)
+              traverse(orig)
+            }
+          } finally {
+            annotationTree = None
+          }
+        }
       }
     }
 

--- a/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/common/TreeTraverser.scala
+++ b/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/common/TreeTraverser.scala
@@ -38,7 +38,13 @@ trait TreeTraverser {
       // we fake our own Select(Ident(..), ..) tree from the type
       // so we can handle them just like any other select call
 
-      val stringRep = tpe.trimPrefix(tpe.toString)
+      def trimTypeArgs(str: String) = {
+        val firstBracket = str.indexOf("[")
+        if (firstBracket < 0) str
+        else str.substring(0, firstBracket + 1)
+      }
+
+      val stringRep = trimTypeArgs(tpe.trimPrefix(tpe.toString))
 
       val select = stringRep.split("\\.").toList match {
         case x :: xs =>

--- a/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/util/CompilerProvider.scala
+++ b/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/util/CompilerProvider.scala
@@ -107,6 +107,8 @@ trait TreeCreationMethods {
     treeFrom(file) // use the side effect
     file.file
   }
+
+  def parseJava(src: String): global.Tree = treeFromString(src, true)
 }
 
 object CompilerInstance extends CompilerInstance
@@ -129,6 +131,4 @@ trait CompilerProvider extends TreeCreationMethods {
     global.reporter.reset()      // Hopefully a fix for https://github.com/scala-ide/scala-refactoring/issues/69
     global.analyzer.resetTyper() // ... added for good measure.
   }
-
-  def parseJava(src: String): Unit = treeFromString(src, true)
 }

--- a/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/util/CompilerProvider.scala
+++ b/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/util/CompilerProvider.scala
@@ -78,10 +78,12 @@ trait TreeCreationMethods {
     () => "file" + r.nextInt
   }
 
-  def treeFrom(src: String): global.Tree = {
-    val file = new BatchSourceFile(randomFileName(), src)
+  protected def treeFromString(src: String, isJava: Boolean = false): global.Tree = {
+    val file = new BatchSourceFile(randomFileName() + (if (isJava) ".java" else ""), src)
     treeFrom(file)
   }
+
+  def treeFrom(src: String): global.Tree = treeFromString(src, false)
 
   def treeFrom(file: SourceFile): global.Tree = {
 
@@ -127,4 +129,6 @@ trait CompilerProvider extends TreeCreationMethods {
     global.reporter.reset()      // Hopefully a fix for https://github.com/scala-ide/scala-refactoring/issues/69
     global.analyzer.resetTyper() // ... added for good measure.
   }
+
+  def parseJava(src: String): Unit = treeFromString(src, true)
 }

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/analysis/CompilationUnitDependenciesTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/analysis/CompilationUnitDependenciesTest.scala
@@ -1020,6 +1020,9 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
          Class<?> clazz2();
        }""")
 
+  /*
+   * See https://scala-ide-portfolio.assembla.com/spaces/scala-ide/tickets/1001793-organize-imports-removes-import-referenced-from-an-annotation
+   */
   @Ignore
   @Test
   def testWithSimpleJavaAnnotationAndIntConstant = assertNeededImports(

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/MoveClassTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/MoveClassTest.scala
@@ -1022,7 +1022,7 @@ sealed abstract class Term
 case object TmTrue extends Term
 case object TmFalse extends Term
 
-object /*(*/Arith/*)*/ extends scala.util.parsing.combinator.JavaTokenParsers {
+object /*(*/Arith/*)*/ {
 
   def isVal(t: Term) : Boolean = t match {
     case TmTrue | TmFalse => true
@@ -1043,7 +1043,7 @@ import arith.Term
 import arith.TmFalse
 import arith.TmTrue
 
-object /*(*/Arith/*)*/ extends scala.util.parsing.combinator.JavaTokenParsers {
+object /*(*/Arith/*)*/ {
 
   def isVal(t: Term) : Boolean = t match {
     case TmTrue | TmFalse => true

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
     <scala.binary.version>2.11</scala.binary.version>
     <scala.xml.version>1.0.1</scala.xml.version>
     <scala.parser-combinators.version>1.0.1</scala.parser-combinators.version>
+    <scala.versioned.source>src/main/scala-${version.suffix}</scala.versioned.source>
   </properties>
   <modules>
     <module>org.scala-refactoring.library</module>


### PR DESCRIPTION
This pull request should improve the annotation handling by the implementation of "Organize Imports", by not only processing `AnnotationInfo.original`, but also `AnnotationInfo.tree`. As the latter is only available with Scala-2.11, this request is based on #76, which should be merged first. You might also want to take a look at [Assembla Ticket 1001726](https://scala-ide-portfolio.assembla.com/spaces/scala-ide/tickets/1001726-organise-imports-and-scalatest-with-junitrunner-don-t-like-each-other) and  [Assembla Ticket 1001793](https://scala-ide-portfolio.assembla.com/spaces/scala-ide/tickets/1001793-organize-imports-removes-import-referenced-from-an-annotation).