### PR TITLE
Fix renaming for lazy vals

### DIFF
--- a/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/common/Selections.scala
+++ b/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/common/Selections.scala
@@ -85,12 +85,27 @@ trait Selections extends TreeTraverser with common.PimpedTrees {
      * fully contains a SymTree, if true, the first selected is returned. Otherwise
      * the result of findSelectedOfType[SymTree] is returned.
      */
-    lazy val selectedSymbolTree = (root filter (cond(_) {
+    lazy val selectedSymbolTree = eventuallyFixModifierPositionsForLazyVals((root filter (cond(_) {
       case t: SymTree => contains(t)
     }) filter (t => t.pos.start < t.pos.end) match {
       case (x: SymTree) :: _ => Some(x)
       case _ => None
-    }) orElse findSelectedOfType[SymTree]
+    }) orElse findSelectedOfType[SymTree])
+
+    /*
+     * See #1002392 if you wonder why we need this
+     */
+    private def eventuallyFixModifierPositionsForLazyVals(t: Option[SymTree]): Option[SymTree] = t.map {
+      case lDef: DefDef if lDef.mods.isLazy && lDef.mods.positions.isEmpty =>
+        root.foreach {
+          case lVal: ValDef if lDef.mods.isLazy && !lVal.mods.positions.isEmpty && lVal.pos.point == lDef.pos.point =>
+            lDef.mods.setPositions(lVal.asInstanceOf[ValDef].mods.positions)
+          case _ => ()
+        }
+
+        lDef
+      case other => other
+    }
 
     /**
      * Finds a selected tree by its type.
@@ -233,7 +248,7 @@ trait Selections extends TreeTraverser with common.PimpedTrees {
 
       // some trees have to be selected as a whole if more than one child
       // is selected. For example if a method parameter and the body is selected,
-      // we select the DefDef as a whole to get a complete selection. 
+      // we select the DefDef as a whole to get a complete selection.
       def expandToParentIfRequired(s: Selection) =
         s.enclosingTree match {
           case t @ (_: DefDef | _: Function | _: If | _: Match | _: Try | _: CaseDef) =>

--- a/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/common/Selections.scala
+++ b/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/common/Selections.scala
@@ -99,7 +99,7 @@ trait Selections extends TreeTraverser with common.PimpedTrees {
       case lDef: DefDef if lDef.mods.isLazy && lDef.mods.positions.isEmpty =>
         root.foreach {
           case lVal: ValDef if lDef.mods.isLazy && !lVal.mods.positions.isEmpty && lVal.pos.point == lDef.pos.point =>
-            lDef.mods.setPositions(lVal.asInstanceOf[ValDef].mods.positions)
+            lDef.mods.setPositions(lVal.mods.positions)
           case _ => ()
         }
 

--- a/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/common/Selections.scala
+++ b/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/common/Selections.scala
@@ -96,14 +96,14 @@ trait Selections extends TreeTraverser with common.PimpedTrees {
      * See #1002392 if you wonder why we need this
      */
     private def eventuallyFixModifierPositionsForLazyVals(t: Option[SymTree]): Option[SymTree] = t.map {
-      case lDef: DefDef if lDef.mods.isLazy && lDef.mods.positions.isEmpty =>
+      case dd: DefDef if dd.mods.isLazy && dd.mods.positions.isEmpty =>
         root.foreach {
-          case lVal: ValDef if lDef.mods.isLazy && !lVal.mods.positions.isEmpty && lVal.pos.point == lDef.pos.point =>
-            lDef.mods.setPositions(lVal.mods.positions)
+          case ld: ValDef if dd.mods.isLazy && !ld.mods.positions.isEmpty && ld.pos.point == dd.pos.point =>
+            dd.mods.setPositions(ld.mods.positions)
           case _ => ()
         }
 
-        lDef
+        dd
       case other => other
     }
 

--- a/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/common/Selections.scala
+++ b/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/common/Selections.scala
@@ -98,7 +98,7 @@ trait Selections extends TreeTraverser with common.PimpedTrees {
     private def eventuallyFixModifierPositionsForLazyVals(t: Option[SymTree]): Option[SymTree] = t.map {
       case dd: DefDef if dd.mods.isLazy && dd.mods.positions.isEmpty =>
         root.foreach {
-          case ld: ValDef if dd.mods.isLazy && !ld.mods.positions.isEmpty && ld.pos.point == dd.pos.point =>
+          case ld: ValDef if ld.mods.isLazy && !ld.mods.positions.isEmpty && ld.pos.point == dd.pos.point =>
             dd.mods.setPositions(ld.mods.positions)
           case _ => ()
         }

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
@@ -10,7 +10,6 @@ import tests.util.TestRefactoring
 import tests.util.TestHelper
 import org.junit.Assert._
 import org.junit.Ignore
-
 import language.reflectiveCalls
 
 class RenameTest extends TestHelper with TestRefactoring {
@@ -142,6 +141,63 @@ class RenameTest extends TestHelper with TestRefactoring {
     }
     """
   } applyRefactoring(renameTo("c"))
+
+  /*
+   * See Assembla ticket #1002392
+   */
+  @Test
+  def renameLazyValFromClass() = new FileSet {
+    """
+    package renameLazyValFromClass
+    class Bug {
+      lazy val /*(*/tryRenameMe/*)*/ = "bar"
+    }
+    """ becomes
+    """
+    package renameLazyValFromClass
+    class Bug {
+      lazy val /*(*/test/*)*/ = "bar"
+    }
+    """
+  } applyRefactoring(renameTo("test"))
+
+  /*
+   * See Assembla ticket #1002392
+   */
+  @Test
+  def renameProtectedLazyValFromClass() = new FileSet {
+    """
+    package renameLazyValFromClass
+    class Bug {
+      protected lazy val /*(*/tryRenameMe/*)*/ = "bar"
+    }
+    """ becomes
+    """
+    package renameLazyValFromClass
+    class Bug {
+      protected lazy val /*(*/test/*)*/ = "bar"
+    }
+    """
+  } applyRefactoring(renameTo("test"))
+
+  /*
+   * See Assembla ticket #1002392
+   */
+  @Test
+  def renameLazyValFromClassWithOneLetterName() = new FileSet {
+    """
+    package renameLazyValFromClass
+    class Bug {
+      lazy val /*(*/x/*)*/ = "bar"
+    }
+    """ becomes
+    """
+    package renameLazyValFromClass
+    class Bug {
+      lazy val /*(*/y/*)*/ = "bar"
+    }
+    """
+  } applyRefactoring(renameTo("y"))
 
   @Test
   def renameParameterWithoutSelection() = new FileSet {


### PR DESCRIPTION
This should fix [Ticket 1002392](https://www.assembla.com/spaces/scala-ide/tickets/1002392-rename-refactoring-breaks-with-lazy-vals#/activity/ticket:).

Note that I think that this fix is kind of a hack, since `DefDef.mods.positions` should be set by the compiler, not by us, so we might want to discuss this further...