### PR TITLE
Take care of file rename operations in `rename` refactorings

### DIFF
--- a/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/common/Change.scala
+++ b/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/common/Change.scala
@@ -10,27 +10,8 @@ import scala.reflect.internal.util.SourceFile
 
 /**
  * The common interface for all changes.
- *
- * Note: in versions < 0.4 Change was a case-class, now it's the
- * super type of `TextChange` and `NewFileChange`. `NewFileChanges
- * are used by refactorings that create new source files (Move Class).
- *
- * Additionally, the `file` attribute is now of type `SourceFile`,
- * because parts of the refactoring process need to access the content
- * of the  underlying source file.
  */
-sealed trait Change {
-  val text: String
-
-  @deprecated("Pattern-match on the subclasses.", "0.4.0")
-  def file: AbstractFile
-
-  @deprecated("Pattern-match on the subclasses.", "0.4.0")
-  def from: Int
-
-  @deprecated("Pattern-match on the subclasses.", "0.4.0")
-  def to: Int
-}
+sealed trait Change
 
 case class TextChange(sourceFile: SourceFile, from: Int, to: Int, text: String) extends Change {
 
@@ -52,12 +33,9 @@ case class TextChange(sourceFile: SourceFile, from: Int, to: Int, text: String) 
  * The changes creates a new source file, indicated by the `fullName` parameter. It is of
  * the form "some.package.FileName".
  */
-case class NewFileChange(fullName: String, text: String) extends Change {
+case class NewFileChange(fullName: String, text: String) extends Change
 
-  def file = throw new UnsupportedOperationException
-  def from = throw new UnsupportedOperationException
-  def to   = throw new UnsupportedOperationException
-}
+case class RenameSourceFileChange(sourceFile: AbstractFile, to: String) extends Change
 
 object Change {
   /**

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/analysis/MultipleFilesIndexTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/analysis/MultipleFilesIndexTest.scala
@@ -24,7 +24,7 @@ class MultipleFilesIndexTest extends TestHelper with GlobalIndexes with FreshCom
 
   def buildIndex(pro: FileSet) = {
 
-    val trees = pro.sources map (x => addToCompiler(pro.fileName(x), x)) map (global.unitOfFile(_).body)
+    val trees = pro.sources map { case (code, filename) => addToCompiler(filename, code) } map (global.unitOfFile(_).body)
 
     val cuIndexes = global.ask { () =>
       trees map CompilationUnitIndex.apply

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
@@ -1551,4 +1551,63 @@ class Blubb
     }
     """
   } applyRefactoring(renameTo("x"))
+
+  /*
+   * See Assembla ticket #1001928
+   */
+  @Test
+  def testRenameClassInSamePackageButOtherFile() = new FileSet {
+    """
+    class A
+    """ -> "A.scala" becomes
+    """
+    class B
+    """ -> "B.scala";
+
+    """
+    class C extends /*(*/A/*)*/
+    """ becomes
+    """
+    class C extends /*(*/B/*)*/
+    """
+  } applyRefactoring(renameTo("B"))
+
+
+  /*
+   * See Assembla ticket #1001928
+   */
+  @Test
+  def testRenameClassInDifferentPackageAndOtherFile() = new FileSet {
+    """
+    package one
+    class Eins
+    """ -> "Eins.scala" becomes
+    """
+    package one
+    class One
+    """ -> "One.scala";
+
+    """
+    package two
+    import one._
+
+    class Two {
+      val uno = new /*(*/Eins/*)*/
+    }
+    """ becomes
+    """
+    package two
+    import one._
+
+    class Two {
+      val uno = new /*(*/One/*)*/
+    }
+    """
+  } applyRefactoring(renameTo("One"))
+
+  @Test
+  def testClassInDedicatedFile() = new FileSet {
+    "class /*(*/Foo/*)*/" -> "Foo.scala" becomes
+    "class /*(*/Bazius/*)*/" -> "Bazius.scala"
+  } applyRefactoring(renameTo("Bazius"))
 }

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/util/TestRefactoring.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/util/TestRefactoring.scala
@@ -27,7 +27,7 @@ trait TestRefactoring extends TestHelper {
       val global = TestRefactoring.this.global
 
       lazy val trees = {
-        project.sources map (x => addToCompiler(project.fileName(x), x)) map (global.unitOfFile(_).body)
+        project.sources map { case(code, filename) => addToCompiler(filename, code) } map (global.unitOfFile(_).body)
       }
 
       override val index = global.ask { () =>


### PR DESCRIPTION
Add a new `scala.tools.refactoring.common.Change` for rename operations

`scala.tools.refactoring.tests.util.TestHelper` now supports testing for rename operations

Code cleanups

Fixes [#1001928](https://www.assembla.com/spaces/scala-ide/tickets/1001928#/activity/ticket:) in connection with an associated update for the IDE