### PR TITLE
Rename package private vals/defs with scoped access modifiers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 target
+.cache-main
+.cache-tests

--- a/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/common/PimpedTrees.scala
+++ b/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/common/PimpedTrees.scala
@@ -902,10 +902,11 @@ trait PimpedTrees {
 
           val missingModifierTree = {
             if (m.privateWithin.nonEmpty && pos.end - pos.start < 3) {
-              val srcAtModifierEnd = SourceWithMarker(pos.source.content, pos.start - 1).moveMarker(
-                 (commentsAndSpaces ~ (("abstract" | "override" | "lazy") ~ commentsAndSpaces).zeroOrMore ~ commentsAndSpaces).backward)
+              val srcAtModifierEnd = SourceWithMarker(pos.source.content, pos.start - 1).moveMarker(commentsAndSpaces.backward)
 
-              val srcAtModifierStart = srcAtModifierEnd.moveMarker((("private" | "protected") ~ commentsAndSpaces ~ bracketsWithContents).backward)
+              val srcAtModifierStart = srcAtModifierEnd.moveMarker(
+                  (("private" | "protected") ~
+                  commentsAndSpaces ~ bracketsWithContents ~ commentsAndSpaces).backward)
 
               Some(ModifierTree(extractAccessModifier(flag)).setPos(pos.withStart(srcAtModifierStart.marker + 1).withEnd(srcAtModifierEnd.marker + 1)))
             } else {

--- a/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/common/PimpedTrees.scala
+++ b/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/common/PimpedTrees.scala
@@ -907,7 +907,7 @@ trait PimpedTrees {
 
               val srcAtModifierStart = srcAtModifierEnd.moveMarker((("private" | "protected") ~ commentsAndSpaces ~ bracketsWithContents).backward)
 
-             Some(ModifierTree(extractAccessModifier(flag)).setPos(pos.withStart(srcAtModifierStart.marker + 1).withEnd(srcAtModifierEnd.marker + 1)))
+              Some(ModifierTree(extractAccessModifier(flag)).setPos(pos.withStart(srcAtModifierStart.marker + 1).withEnd(srcAtModifierEnd.marker + 1)))
             } else {
               None
             }

--- a/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/common/PimpedTrees.scala
+++ b/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/common/PimpedTrees.scala
@@ -900,6 +900,11 @@ trait PimpedTrees {
             else pos.end + 1
           }
 
+          /*
+           *  Unfortunately package private and protected vals/defs (like "private[pgk] val test = 2") might not be properly represented
+           *  in 'm.positions' (see https://www.assembla.com/spaces/scala-ide/tickets/1002446#/activity/ticket:). We therefore
+           *  add the associated modifier trees "by-hand" if needed.
+           */
           val missingModifierTree = {
             if (m.privateWithin.nonEmpty && pos.end - pos.start < 3) {
               val srcAtModifierEnd = SourceWithMarker(pos.source.content, pos.start - 1).moveMarker(commentsAndSpaces.backward)
@@ -926,6 +931,10 @@ trait PimpedTrees {
       else 0
     }
 
+    /*
+     * Positions might be set incorrectly by the compiler when dealing with 'private[this]' or 'protected[this]'; instead of pointing to
+     * ']', end might point to the end of 'private' or 'protected'. This method is meant to take care of this.
+     */
     private def fixEndForScopedAccessModifier(pos: global.Position): Int = {
       SourceWithMarker(pos.source.content, pos.end + 1).moveMarker(commentsAndSpaces ~ bracketsWithContents).marker
     }

--- a/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/sourcegen/Requisite.scala
+++ b/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/sourcegen/Requisite.scala
@@ -76,8 +76,8 @@ object Requisite {
 
   val Blank = new Requisite {
     def isRequired(l: Layout, r: Layout) = {
-      val _1 = l.matches(".*\\s+$")
-      val _2 = r.matches("^\\s+.*")
+      val _1 = l.matches("(?s).*\\s+$")
+      val _2 = r.matches("(?s)^\\s+.*")
 
       !(_1 || _2)
     }

--- a/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/util/SourceWithMarker.scala
+++ b/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/util/SourceWithMarker.scala
@@ -92,7 +92,7 @@ object SourceWithMarker {
    * scala> val src = SourceWithMarker("private val /*---*/ x = 4".toCharArray)
    * src: scala.tools.refactoring.util.SourceWithMarker = <p>riv...
    * scala> val movement = ("private" | "protected") ~ commentsAndSpaces ~ "val" ~ commentsAndSpaces
-   * scala> val = srcAtx = src.moveMarker(movement)
+   * scala> val srcAtx = src.moveMarker(movement)
    * srcAtx: scala.tools.refactoring.util.SourceWithMarker = ... <x> = ...
    * scala> val moveBackToVal = ("al" ~ commentsAndSpaces ~ "x").backward
    * scala> val srcAtVal = srcAtx.moveMarker(moveBackToVal)

--- a/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/util/SourceWithMarker.scala
+++ b/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/util/SourceWithMarker.scala
@@ -4,6 +4,7 @@ import scala.annotation.tailrec
 import java.util.Arrays
 import scala.collection.immutable.SortedMap
 import scala.language.implicitConversions
+import scala.reflect.internal.util.RangePosition
 
 /**
  * Represents source code with a movable marker.
@@ -19,6 +20,10 @@ final case class SourceWithMarker(source: Array[Char] = Array(), marker: Int = 0
   def moveMarker(movement: Movement): SourceWithMarker = {
     if (isDepleted) this
     else movement(this).map(m => copy(marker = m)).getOrElse(this)
+  }
+
+  def moveMarkerBack(movement: Movement): SourceWithMarker = {
+    moveMarker(movement.backward)
   }
 
   def current: Char = source(marker)
@@ -68,6 +73,14 @@ final case class SourceWithMarker(source: Array[Char] = Array(), marker: Int = 0
 }
 
 object SourceWithMarker {
+
+  def beforeStartOf(pos: RangePosition): SourceWithMarker = {
+    SourceWithMarker(pos.source.content, pos.start - 1)
+  }
+
+  def afterEndOf(pos: RangePosition): SourceWithMarker = {
+    SourceWithMarker(pos.source.content, pos.end + 1)
+  }
 
   /**
    * A context dependent, directional movement that can be applied to a [[SourceWithMarker]]

--- a/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/util/SourceWithMarker.scala
+++ b/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/util/SourceWithMarker.scala
@@ -253,7 +253,7 @@ object SourceWithMarker {
           }
         }
 
-        if(!forward) go(sourceWithMarker.marker).orElse(go(sourceWithMarker.marker, inSingleLineComment = true))
+        if(!forward) go(sourceWithMarker.marker, inSingleLineComment = true).orElse(go(sourceWithMarker.marker, inSingleLineComment = false))
         else go(sourceWithMarker.marker)
       }
 

--- a/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/util/SourceWithMarker.scala
+++ b/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/util/SourceWithMarker.scala
@@ -1,0 +1,315 @@
+package scala.tools.refactoring.util
+
+import scala.annotation.tailrec
+import java.util.Arrays
+import scala.collection.immutable.SortedMap
+import scala.language.implicitConversions
+
+/**
+ * Represents source code with a movable marker.
+ *
+ * @see [[SourceWithMarker.Movement]]
+ * @see [[SourceWithMarker.Movements]]
+ */
+final case class SourceWithMarker(source: Array[Char] = Array(), marker: Int = 0) {
+  import SourceWithMarker._
+
+  assertLegalState()
+
+  def moveMarker(movement: Movement): SourceWithMarker = {
+    if (isDepleted) this
+    else movement(this).map(m => copy(marker = m)).getOrElse(this)
+  }
+
+  def current: Char = source(marker)
+
+  def isDepleted: Boolean = {
+    marker < 0 || marker >= source.length
+  }
+
+  def length = source.length
+
+  override def toString = {
+    def mkFlatString(chars: Seq[Char]): String = {
+      chars.mkString("").replace("\r\n", "\\r\\n").replace("\n", "\\n")
+    }
+
+    val lrChars = 3
+    val nChars = lrChars*2 + 1
+
+    def leftDots = if (marker - lrChars > 0) "..." else ""
+    def rightDots = if (marker + lrChars < source.length - 1) "..." else ""
+
+    if (marker < 0) {
+      "<>" + mkFlatString(source.take(nChars)) + rightDots
+    } else if (marker >= source.length) {
+      leftDots + mkFlatString(source.takeRight(nChars)) + "<>"
+    } else {
+      val marked = current
+      val lStr = leftDots + mkFlatString(source.slice(marker - lrChars, marker))
+      val rStr = mkFlatString(source.slice(marker + 1, marker + 1 + lrChars)) + rightDots
+      s"$lStr<$marked>$rStr"
+    }
+  }
+
+  override def equals(obj: Any) = obj match {
+    case SourceWithMarker(otherSource, otherMarker) =>
+      source.toSeq == otherSource.toSeq && marker == otherMarker
+    case _ => false
+  }
+
+  override def hashCode = {
+    (source.toSeq, marker).hashCode
+  }
+
+  private def assertLegalState() {
+    require(marker >= -1 && marker <= source.length, s"Marker out of bounds: $marker")
+  }
+}
+
+object SourceWithMarker {
+
+  /**
+   * A context dependent, directional movement that can be applied to a [[SourceWithMarker]]
+   *
+   * ==Overview==
+   * Movements can be combined similar to parser combinators and optionally applied backwards.
+   * They are meant to be used to perform minor tweaks in already parsed source code that might be necessary
+   * due to compiler bugs or compiler API limitations.
+   *
+   * ==Why not use parser combinators?==
+   * <ul>
+   *  <li>We want to conveniently move forward <b>and</b> backward in the source code</li>
+   *  <li>The code we are looking at is already parsed; we only want to move to specific points</li>
+   * </ul>
+   *
+   * ==Examples==
+   * {{{
+   * scala> import scala.tools.refactoring.util.SourceWithMarker
+   * scala> import scala.tools.refactoring.util.SourceWithMarker._
+   * scala> import scala.tools.refactoring.util.SourceWithMarker.Movements._
+   *
+   * scala> val src = SourceWithMarker("private val /*---*/ x = 4".toCharArray)
+   * src: scala.tools.refactoring.util.SourceWithMarker = <p>riv...
+   * scala> val movement = ("private" | "protected") ~ commentsAndSpaces ~ "val" ~ commentsAndSpaces
+   * scala> val = srcAtx = src.moveMarker(movement)
+   * srcAtx: scala.tools.refactoring.util.SourceWithMarker = ... <x> = ...
+   * scala> val moveBackToVal = ("al" ~ commentsAndSpaces ~ "x").backward
+   * scala> val srcAtVal = srcAtx.moveMarker(moveBackToVal)
+   * srcAtVal:  scala.tools.refactoring.util.SourceWithMarker = ...te <v>al ...
+   * }}}
+   *
+   * @see [[Movements]]
+   */
+  trait Movement { outer =>
+    def apply(sourceWithMarker: SourceWithMarker): Option[Int]
+    def backward: Movement
+
+    final def ~(other: Movement): Movement = new Movement { inner =>
+      override def apply(sourceWithMarker: SourceWithMarker): Option[Int] = {
+        outer(sourceWithMarker).map(newMarker => sourceWithMarker.copy(marker = newMarker)).flatMap(other.apply)
+      }
+
+      override def backward = new Movement  {
+        override def apply(sourceWithMarker: SourceWithMarker): Option[Int] = {
+         other.backward.apply(sourceWithMarker).map(newMarker => sourceWithMarker.copy(marker = newMarker)).flatMap(outer.backward.apply)
+        }
+
+        override def backward = inner
+      }
+    }
+
+    final def |(other: Movement): Movement = new Movement { inner =>
+      override def apply(sourceWithMarker: SourceWithMarker): Option[Int] = {
+        outer(sourceWithMarker).orElse(other(sourceWithMarker))
+      }
+
+      override def backward = new Movement  {
+        override def apply(sourceWithMarker: SourceWithMarker): Option[Int] = {
+          (other.backward(sourceWithMarker)).orElse(outer.backward(sourceWithMarker))
+        }
+
+        override def backward = inner
+      }
+    }
+
+    final def zeroOrMore: Movement = {
+      class Repeat(forward: Boolean = true) extends Movement {
+        override def apply(sourceWithMarker: SourceWithMarker): Option[Int] = {
+          val mvmt = if (forward) outer else outer.backward
+
+          @tailrec
+          def go(sourceWithMarker: SourceWithMarker): Option[Int] = {
+            if (sourceWithMarker.isDepleted) {
+              Some(sourceWithMarker.marker)
+            } else {
+              mvmt(sourceWithMarker) match {
+                case Some(marker) =>
+                  if (marker != sourceWithMarker.marker) go(sourceWithMarker.copy(marker = marker))
+                  else Some(marker)
+                case None => Some(sourceWithMarker.marker)
+              }
+            }
+          }
+
+          go(sourceWithMarker)
+        }
+
+        override def backward: Movement = new Repeat(!forward)
+      }
+      new Repeat
+    }
+
+    final def atLeastOnce: Movement = {
+      this ~ this.zeroOrMore
+    }
+  }
+
+  object Movements {
+    import MovementHelpers._
+
+    final class ConsumeChar(c: Char, forward: Boolean = true) extends Movement {
+      override def apply(sourceWithMarker: SourceWithMarker) = {
+        if (sourceWithMarker.current == c) Some(nextMarker(sourceWithMarker.marker, forward))
+        else None
+      }
+
+      override def backward = new ConsumeChar(c, !forward)
+    }
+
+    final class ConsumeString(str: String, forward: Boolean = true) extends Movement {
+      override def apply(sourceWithMarker: SourceWithMarker) = {
+        def strAt(i: Int) = {
+          if (forward) str.charAt(i)
+          else str.charAt(str.length - 1 - i)
+        }
+
+        @tailrec
+        def go(m: Int, i: Int = 0): Option[Int] = {
+          if (i >= str.length) {
+            Some(m)
+          } else if (wouldBeDepleted(m, sourceWithMarker)) {
+            None
+          } else {
+            if (strAt(i) == sourceWithMarker.source(m)) go(nextMarker(m, forward), i + 1)
+            else None
+          }
+        }
+
+        go(sourceWithMarker.marker)
+      }
+
+      override def backward = new ConsumeString(str, !forward)
+    }
+
+    final class ConsumeSpace(forward: Boolean = true) extends Movement {
+      override def apply(sourceWithMarker: SourceWithMarker) = {
+        if (sourceWithMarker.current.isWhitespace) Some(nextMarker(sourceWithMarker.marker, forward))
+        else None
+      }
+
+      override def backward = new ConsumeSpace(!forward)
+    }
+
+    final class ConsumeComment(forward: Boolean = true) extends Movement {
+      override def apply(sourceWithMarker: SourceWithMarker) = {
+
+        @tailrec
+        def go(m: Int, inSingleLineComment: Boolean = false, inMultilineComment: Int = 0, slashSeen: Boolean = false, starSeen: Boolean = false): Option[Int] = {
+          if (wouldBeDepleted(m, sourceWithMarker)) {
+            if (inSingleLineComment && forward) Some(m) else None
+          } else {
+            val c = sourceWithMarker.source(m)
+            val nm = nextMarker(m, forward)
+
+            if (inSingleLineComment) {
+              if (c == '/') if(slashSeen && !forward) Some(nm) else go(nm, inSingleLineComment = true, slashSeen = true)
+              else if (c == '\n') if(forward) Some(m) else None
+              else go(nm, inSingleLineComment = true)
+            } else if (inMultilineComment > 0) {
+              if (c == '/') {
+                if (starSeen) {
+                  if (inMultilineComment == 1) Some(nm)
+                  else go(nm, inMultilineComment = inMultilineComment - 1)
+                } else {
+                  go(nm, inMultilineComment = inMultilineComment, slashSeen = true)
+                }
+              } else if (c == '*') {
+                if (slashSeen) go(nm, inMultilineComment = inMultilineComment + 1)
+                else go(nm, inMultilineComment = inMultilineComment, starSeen = true)
+              } else {
+                go(nm, inMultilineComment = inMultilineComment)
+              }
+            } else {
+              if (c == '/') {
+            	  if (slashSeen && forward) go(nm, inSingleLineComment = true)
+                else go(nm, slashSeen = true)
+              } else if(c == '*' && slashSeen) {
+                go(nm, inMultilineComment = 1)
+              } else {
+                None
+              }
+            }
+          }
+        }
+
+        if(!forward) go(sourceWithMarker.marker).orElse(go(sourceWithMarker.marker, inSingleLineComment = true))
+        else go(sourceWithMarker.marker)
+      }
+
+      override def backward = new ConsumeComment(!forward)
+    }
+
+    final class ConsumeInBrackets(open: Char, close: Char, forward: Boolean = true) extends Movement {
+      override def apply(sourceWithMarker: SourceWithMarker) = {
+        val (br1, br2) = if (forward) (open, close) else (close, open)
+        if (sourceWithMarker.isDepleted || sourceWithMarker.current != br1) {
+          None
+        } else {
+          val eventuallyReversedCommentsAndSpaces = {
+            if (forward) commentsAndSpaces
+            else commentsAndSpaces.backward
+          }
+
+          @tailrec
+          def go(m: Int): Option[Int] = {
+            val mm = sourceWithMarker.copy(marker = m).moveMarker(eventuallyReversedCommentsAndSpaces).marker
+            if (wouldBeDepleted(mm, sourceWithMarker)) {
+              None
+            } else {
+              val nm = if (mm == m) nextMarker(mm, forward) else mm
+              if(sourceWithMarker.source(nm) == br2) Some(nextMarker(nm, forward))
+              else go(nm)
+            }
+          }
+
+          go(nextMarker(sourceWithMarker.marker, forward))
+        }
+      }
+
+      override def backward = new ConsumeInBrackets(open, close, !forward)
+    }
+
+    val space: Movement = new ConsumeSpace()
+    val spaces: Movement = new ConsumeSpace().zeroOrMore
+    val comments: Movement = (new ConsumeComment() ~ spaces).zeroOrMore
+    val commentsAndSpaces: Movement = (spaces ~ comments).zeroOrMore
+    val bracketsWithContents: Movement = new ConsumeInBrackets('[', ']')
+
+    implicit def charToMovement(c: Char): ConsumeChar = new ConsumeChar(c)
+    implicit def stringToMovement(str: String): ConsumeString = new ConsumeString(str)
+  }
+
+  object MovementHelpers {
+    def nextMarker(currentMarker: Int, forward: Boolean): Int = {
+      if (forward) currentMarker + 1
+      else currentMarker - 1
+    }
+
+    def wouldBeDepleted(potentialMarker: Int, sourceWithMarker: SourceWithMarker): Boolean = {
+      if (potentialMarker < 0) true
+      else if (potentialMarker >= sourceWithMarker.source.length) true
+      else false
+    }
+  }
+}

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
@@ -1829,6 +1829,30 @@ class Blubb
     """ -> TaggedAsGlobalRename
   } prepareAndApplyRefactoring(prepareAndRenameTo("z"))
 
+  @Test
+  def testRenamePkgProtectedDefWithComments() = new FileSet {
+    """
+    package bug
+    class Bug {
+      protected/*--*/ //**//**//**//**//**/
+      ////
+      // -/**/-
+      // -/**/-
+      [/**/ bug /**/] /**/ def /*(*/nautilus/*)*/ = 99
+    }
+    """ becomes
+    """
+    package bug
+    class Bug {
+      protected/*--*/ //**//**//**//**//**/
+      ////
+      // -/**/-
+      // -/**/-
+      [/**/ bug /**/] /**/ def /*(*/z/*)*/ = 99
+    }
+    """ -> TaggedAsGlobalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("z"))
+
 
   /*
    * See Assembla Ticket 1002434

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
@@ -1736,7 +1736,7 @@ class Blubb
   } prepareAndApplyRefactoring(prepareAndRenameTo("z"))
 
   @Test
-  def testRenamePackagePrivateVal() = new FileSet {
+  def testRenamePkgPrivateVal() = new FileSet {
     """
     package test
     class Bug(private[test] val /*(*/number/*)*/: Int)
@@ -1764,7 +1764,7 @@ class Blubb
    * See Assembla Ticket #1002446
    */
   @Test
-  def testRenamePackgePrivateDef() = new FileSet {
+  def testRenamePkgPrivateDef() = new FileSet {
     """
     package bug
     class Bug {
@@ -1806,6 +1806,29 @@ class Blubb
     }
     """ -> TaggedAsLocalRename
   } prepareAndApplyRefactoring(prepareAndRenameTo("z"))
+
+  @Test
+  def testRenamePkgPrivateValWithComments() = new FileSet {
+    """
+    package bug
+    class Bug {
+      private/*--*/ //**//**//**//**//**/
+      // -/**/-
+      // -/**/-
+      [/**/ bug /**/] val /*(*/nautilus/*)*/ = 99
+    }
+    """ becomes
+    """
+    package bug
+    class Bug {
+      private/*--*/ //**//**//**//**//**/
+      // -/**/-
+      // -/**/-
+      [/**/ bug /**/] val /*(*/z/*)*/ = 99
+    }
+    """ -> TaggedAsGlobalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("z"))
+
 
   /*
    * See Assembla Ticket 1002434

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
@@ -1793,6 +1793,20 @@ class Blubb
     """ -> TaggedAsLocalRename
   } prepareAndApplyRefactoring(prepareAndRenameTo("z"))
 
+  @Test
+  def testRenameValWithCommentAfterModifier() = new FileSet {
+    """
+    class Bug {
+      private/*--*/ val /*(*/nautilus/*)*/ = 99
+    }
+    """ becomes
+    """
+    class Bug {
+      private/*--*/ val /*(*/z/*)*/ = 99
+    }
+    """ -> TaggedAsLocalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("z"))
+
   /*
    * See Assembla Ticket 1002434
    */

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
@@ -1735,6 +1735,64 @@ class Blubb
     """ -> TaggedAsLocalRename;
   } prepareAndApplyRefactoring(prepareAndRenameTo("z"))
 
+  @Test
+  def testRenamePackagePrivateVal() = new FileSet {
+    """
+    package test
+    class Bug(private[test] val /*(*/number/*)*/: Int)
+    """ becomes
+    """
+    package test
+    class Bug(private[test] val /*(*/z/*)*/: Int)
+    """;
+
+    """
+    package test
+    object Buggy {
+      def x = new Bug(32).number
+    }
+    """ becomes
+    """
+    package test
+    object Buggy {
+      def x = new Bug(32).z
+    }
+    """ -> TaggedAsGlobalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("z"))
+
+  /*
+   * See Assembla Ticket #1002446
+   */
+  @Test
+  def testRenamePackgePrivateDef() = new FileSet {
+    """
+    package bug
+    class Bug {
+      private[bug] def /*(*/bar/*)*/ = 99
+    }
+    """ becomes
+    """
+    package bug
+    class Bug {
+      private[bug] def /*(*/x/*)*/ = 99
+    }
+    """ -> TaggedAsGlobalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("x"))
+
+  @Test
+  def testRenamePrivateThisVal() = new FileSet {
+    """
+    class Bug {
+      private[this] val /*(*/nautilus/*)*/ = 99
+    }
+    """ becomes
+    """
+    class Bug {
+      private[this] val /*(*/z/*)*/ = 99
+    }
+    """ -> TaggedAsLocalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("z"))
+
   /*
    * See Assembla Ticket 1002434
    */

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
@@ -1853,10 +1853,30 @@ class Blubb
     """ -> TaggedAsGlobalRename
   } prepareAndApplyRefactoring(prepareAndRenameTo("z"))
 
+  /*
+   * Correctly renaming package private lazy vals is not as easy as one might hope,
+   * because of their representation in the ASTs, both as "ValDef"s and "DefDef"s.
+   */
+  @Ignore
+  @Test
+  def testRenamePkgProtectedLazyVal() = new FileSet {
+    """
+    package experiments
+    class Clazz {
+      private[experiments] lazy val /*(*/x/*)*/ = 999
+    }""" becomes
+    """
+    package experiments
+    class Clazz {
+      private[experiments] lazy val /*(*/xy/*)*/ = 999
+    }""" -> TaggedAsGlobalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("xy"))
+
 
   /*
    * See Assembla Ticket 1002434
    */
+  @Test
   def testRenameOverrideVal() = new FileSet {
     """
     trait Bug {
@@ -1889,6 +1909,6 @@ class Blubb
     class MoreBugs extends Buggy {
       override val /*(*/xyz/*)*/ = 99
     }
-    """ -> TaggedAsLocalRename
+    """ -> TaggedAsGlobalRename
   } prepareAndApplyRefactoring(prepareAndRenameTo("xyz"))
 }

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/util/SourceWithMarkerTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/util/SourceWithMarkerTest.scala
@@ -1,0 +1,120 @@
+package scala.tools.refactoring.tests.util
+import org.junit.Test
+import org.junit.Assert._
+import scala.tools.refactoring.util.SourceWithMarker
+import scala.language.implicitConversions
+
+class SourceWithMarkerTest {
+  import SourceWithMarker.Movements._
+
+  @Test
+  def testApplyCharMovemnts() {
+    val src = SourceWithMarker("implicit")
+    assertEquals('m', src.moveMarker('i').current)
+    assertEquals('l', src.moveMarker('u' | ('i' ~ 'm' ~ 'p')).current)
+    assertEquals('i', src.moveMarker('i' ~ 'm'.backward).current)
+  }
+
+
+  @Test
+  def testApplyCharAndStringMovements() {
+    val src = SourceWithMarker("abstract")
+    assertEquals('a', src.moveMarker("").current)
+    assertEquals('a', src.moveMarker(('a' ~ "bs") ~ ('b' ~ "str").backward).current)
+    assertTrue(src.moveMarker("abstrac" ~ "abstract".backward).isDepleted)
+  }
+
+  @Test
+  def testApplyBasicMovements() {
+    val src = SourceWithMarker("protected abstract override val x = 123")
+    assertEquals('=', src.moveMarker((("protected" | "abstract" | "override" | "val" | "x" | "=") ~ spaces).zeroOrMore ~ "12" ~ (spaces ~ "123").backward).current)
+  }
+
+  @Test
+  def testCommentsAndSpaces() {
+    val src1 = SourceWithMarker("""//--
+      val x = 3
+    """)
+
+    val src2 = SourceWithMarker("/**/val x = 3")
+
+    val src3 = SourceWithMarker("""
+      //--
+      //--/**/------------->>
+      //--
+
+      /*
+       * /**/
+       */
+      val test = 3
+    """)
+
+    val src4 = SourceWithMarker("x//", 2)
+
+   assertEquals("x", src4.moveMarker(commentsAndSpaces.backward).current.toString)
+   assertEquals("v", src1.moveMarker(commentsAndSpaces).current.toString)
+   assertEquals("v", src2.moveMarker(commentsAndSpaces).current.toString)
+   assertEquals("v", src3.moveMarker(commentsAndSpaces).current.toString)
+  }
+
+  @Test
+  def testSpaces() {
+    val src1 = SourceWithMarker(" s")
+    val src2 = SourceWithMarker("\n\ts")
+    val src3 = SourceWithMarker("""
+      s    s                s
+    """)
+
+    assertEquals("s", src1.moveMarker(spaces).current.toString)
+    assertEquals("s", src2.moveMarker(spaces).current.toString)
+    assertEquals("s", src3.moveMarker(spaces ~ 's' ~ spaces ~ 's' ~ spaces).current.toString)
+    assertTrue(src1.moveMarker(spaces ~ (spaces ~ "s").backward).isDepleted)
+  }
+
+  @Test
+  def testApplyWithMoreComplexExample() {
+    val src = SourceWithMarker("""protected //--
+      [test /**/]//--
+      /*
+       /*
+        /**/
+        */
+      */ override val test = 99""")
+
+    val moveToBracketOpen = "protected" ~ commentsAndSpaces
+    val moveToBracketClose = moveToBracketOpen ~ bracketsWithContents ~ '/'.backward
+    val moveToStartOfMultilineComment = moveToBracketClose ~ ']' ~ (new ConsumeComment) ~ spaces
+    val moveToEndOfMultilineComment = moveToStartOfMultilineComment ~ comments ~ (spaces ~ 'o').backward
+    val moveToVal = moveToBracketClose ~ ']' ~ commentsAndSpaces ~ "override" ~ commentsAndSpaces
+
+    assertEquals("[", src.moveMarker(moveToBracketOpen).current.toString)
+    assertEquals("]", src.moveMarker(moveToBracketClose).current.toString)
+    assertEquals("/", src.moveMarker(moveToStartOfMultilineComment).current.toString)
+    assertEquals("/", src.moveMarker(moveToEndOfMultilineComment).current.toString)
+    assertEquals("v", src.moveMarker(moveToVal).current.toString)
+
+    assertTrue(src.moveMarker("protected" ~ ("protected" ~ commentsAndSpaces).backward).isDepleted)
+    assertTrue(src.moveMarker(moveToVal ~ (moveToVal ~ "v").backward).isDepleted)
+  }
+
+  @Test
+  def testWithScopedAccessModifiers() {
+    val src = SourceWithMarker("private[test]").withMarkerOnLastChar
+    assertTrue(src.moveMarker((("private" | "protected") ~ commentsAndSpaces ~ bracketsWithContents).backward).isDepleted)
+  }
+
+  @Test(expected = classOf[IllegalArgumentException])
+  def testCtorWithTooLargeMarker() {
+    SourceWithMarker(Array(), 1)
+  }
+
+  @Test
+  def testWithEmptySource() {
+    assertTrue(SourceWithMarker().isDepleted)
+  }
+
+  private implicit def stringToCharArray(str: String): Array[Char] = str.toCharArray
+  private implicit class SourceWithMarkerOps(underlying: SourceWithMarker) {
+    def withMarkerOnLastChar = underlying.copy(marker = underlying.source.length - 1)
+  }
+}

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/util/SourceWithMarkerTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/util/SourceWithMarkerTest.scala
@@ -51,10 +51,17 @@ class SourceWithMarkerTest {
 
     val src4 = SourceWithMarker("x//", 2)
 
-   assertEquals("x", src4.moveMarker(commentsAndSpaces.backward).current.toString)
-   assertEquals("v", src1.moveMarker(commentsAndSpaces).current.toString)
-   assertEquals("v", src2.moveMarker(commentsAndSpaces).current.toString)
-   assertEquals("v", src3.moveMarker(commentsAndSpaces).current.toString)
+    val srcStr5 = "/**/ //**/"
+    val src5 = SourceWithMarker(srcStr5, srcStr5.size - 1)
+
+    val res = src5.moveMarker(commentsAndSpaces.backward)
+    println(s"res: $res")
+
+    assertEquals("x", src4.moveMarker(commentsAndSpaces.backward).current.toString)
+    assertEquals("v", src1.moveMarker(commentsAndSpaces).current.toString)
+    assertEquals("v", src2.moveMarker(commentsAndSpaces).current.toString)
+    assertEquals("v", src3.moveMarker(commentsAndSpaces).current.toString)
+    assertTrue(src5.moveMarker(commentsAndSpaces.backward).isDepleted)
   }
 
   @Test
@@ -95,6 +102,27 @@ class SourceWithMarkerTest {
 
     assertTrue(src.moveMarker("protected" ~ ("protected" ~ commentsAndSpaces).backward).isDepleted)
     assertTrue(src.moveMarker(moveToVal ~ (moveToVal ~ "v").backward).isDepleted)
+  }
+
+  @Test
+  def testWithRealisticExamples() {
+    val srcStr = """
+      package bug
+      class Bug {
+        private/*--*/ //**//**//**//**//**/
+        // -/**/-
+        // -/**/-
+        [/**/ bug /**/] val /*(*/z/*)*/ = 99
+      }
+      """
+
+    val src = SourceWithMarker(srcStr, srcStr.lastIndexOf("]"))
+    val mvmt = (("private" | "protected") ~ commentsAndSpaces ~ bracketsWithContents).backward
+
+    println("bracketsWithContents: " + src.moveMarker(bracketsWithContents.backward))
+    println("commentsAndSpaces ~ bracketsWithContents: " + src.moveMarker((commentsAndSpaces ~ bracketsWithContents).backward))
+    println("mvmt: " + src.moveMarker(mvmt))
+    assertEquals("p", src.moveMarker(mvmt ~ commentsAndSpaces).current.toString)
   }
 
   @Test


### PR DESCRIPTION
This PR introduces my attempt to fix [Ticket 1002446](https://www.assembla.com/spaces/scala-ide/tickets/1002446#/activity/ticket:). Unfortunately there are still problems in connection with *lazy* vals (see https://github.com/mlangc/scala-refactoring/blob/rename-package-private-removes-access-modifiers-1002446/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala#L1862), and I think also with *override*, but we might want to deal with these in separate tickets and PRs.

As for the code itself: The biggest addition of this PR are the utility classes `scala.tools.refactoring.util.SourceWithMarker` together with `scala.tools.refactoring.util.SourceWithMarker.Movement`. These classes are documented in the source and currently used in `scala.tools.refactoring.common.PimpedTrees.ModifierTree` to work around some limitations/bugs of the ASTs provided by the compiler.