### PR TITLE
Don't emit duplicate "RenameSourceFileChanges"

### DIFF
--- a/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/implementations/Rename.scala
+++ b/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/implementations/Rename.scala
@@ -95,7 +95,7 @@ abstract class Rename extends MultiStageRefactoring with TreeAnalysis with analy
     val renameSourceChanges = renamedTreesWithOriginals.collect {
       case (newTree: ImplDef, oldTree: ImplDef) if sourceShouldBeRenamed(newTree, oldTree) =>
         RenameSourceFileChange(oldTree.pos.source.file, newTree.name.toString() + ".scala")
-    }
+    }.distinct
 
     Right(refactor(renamedTreesWithOriginals.map(_._1)) ++ renameSourceChanges)
   }

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
@@ -1911,4 +1911,19 @@ class Blubb
     }
     """ -> TaggedAsGlobalRename
   } prepareAndApplyRefactoring(prepareAndRenameTo("xyz"))
+
+  /*
+   * See Assembla Ticket 1002490
+   */
+  @Test
+  def testRenameClassWithCompanion() = new FileSet {
+    """
+    class /*(*/Bug/*)*/
+    object Bug
+    """ -> "Bug.scala" becomes
+    """
+    class /*(*/Buggy/*)*/
+    object Buggy
+    """ -> "Buggy.scala"
+  } applyRefactoring(renameTo("Buggy"))
 }

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/util/TestHelper.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/util/TestHelper.scala
@@ -118,6 +118,15 @@ trait TestHelper extends TestRules with Refactoring with CompilerProvider with c
           r.sourceFile.name == oldName && r.to == newName
         })
       }
+
+      assertNoDuplicates(sourceRenames.map(_.to), d => s"Destination '$d' appearing multiple times")
+      assertNoDuplicates(sourceRenames.map(_.sourceFile.canonicalPath), s => s"Source '$s' appearing multiple times")
+    }
+
+    private def assertNoDuplicates[T](values: Seq[T], mkErrMsg: Any => String): Unit = {
+      values.groupBy(identity).foreach { case (v, vs) =>
+        assertTrue(mkErrMsg(v), vs.size < 2)
+      }
     }
 
     private def fileRenameOps = {


### PR DESCRIPTION
Only emit one `RenameSourceFileChange` if a class is renamed together with its companion object.

Fixes [#1002490](https://scala-ide-portfolio.assembla.com/spaces/scala-ide/tickets/1002490#/activity/ticket:)