### PR TITLE
Handle type annotations on lazy vals and some refactoring

### DIFF
--- a/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/Refactoring.scala
+++ b/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/Refactoring.scala
@@ -12,13 +12,14 @@ import scala.tools.refactoring.common.Change
 import scala.tools.refactoring.sourcegen.SourceGenerator
 import scala.tools.refactoring.transformation.TreeTransformations
 import scala.tools.refactoring.common.TextChange
+import scala.tools.refactoring.common.TracingImpl
 
 /**
  * The Refactoring trait combines the transformation and source generation traits with
  * their dependencies. Refactoring is mixed in by all concrete refactorings and can be
  * used by users of the library.
  */
-trait Refactoring extends Selections with TreeTransformations with SilentTracing with SourceGenerator with PimpedTrees {
+trait Refactoring extends Selections with TreeTransformations with TracingImpl with SourceGenerator with PimpedTrees {
 
   this: common.CompilerAccess =>
 

--- a/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/common/PositionDebugging.scala
+++ b/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/common/PositionDebugging.scala
@@ -1,0 +1,30 @@
+package scala.tools.refactoring.common
+
+import scala.reflect.api.Position
+import scala.reflect.internal.util.RangePosition
+import scala.reflect.internal.util.NoSourceFile
+
+/**
+ * Some utilities for debugging purposes.
+ */
+object PositionDebugging {
+  def format(pos: Position): String = {
+    if (pos.source != NoSourceFile) {
+      (pos.getClass.getSimpleName + "[" + format(pos.start, pos.end, pos.source.content) + "]")
+    } else {
+      "UndefinedPosition"
+    }
+  }
+
+  def format(start: Int, end: Int, source: Array[Char]): String = {
+    def slice(start: Int, end: Int): String = {
+      source.view(start, end).mkString("").replace("\r\n", "\\r\\n").replace("\n", "\\n")
+    }
+
+    val ctxChars = 10
+    val l = slice(start - ctxChars, start)
+    val m = slice(start, end)
+    val r = slice(end, end + ctxChars)
+    s"$l«$m»$r".trim
+  }
+}

--- a/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/common/package.scala
+++ b/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/common/package.scala
@@ -1,0 +1,10 @@
+package scala.tools.refactoring
+
+package object common {
+  /**
+   * The selected tracing implementation.
+   *
+   * Use [[SilentTracing]] for production; consider [[ConsoleTracing]] for debugging.
+   */
+  type TracingImpl = SilentTracing
+}

--- a/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/implementations/Rename.scala
+++ b/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/implementations/Rename.scala
@@ -11,7 +11,7 @@ import analysis.TreeAnalysis
 import tools.nsc.symtab.Flags
 import scala.tools.refactoring.common.RenameSourceFileChange
 
-abstract class Rename extends MultiStageRefactoring with TreeAnalysis with analysis.Indexes with TreeFactory with common.InteractiveScalaCompiler  {
+abstract class Rename extends MultiStageRefactoring with TreeAnalysis with analysis.Indexes with TreeFactory with common.InteractiveScalaCompiler {
 
   import global._
 

--- a/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/implementations/UnusedImportsFinder.scala
+++ b/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/implementations/UnusedImportsFinder.scala
@@ -10,8 +10,9 @@ import common.PimpedTrees
 import common.SilentTracing
 import common.TreeTraverser
 import sourcegen.SourceGenerator
+import scala.tools.refactoring.common.TracingImpl
 
-trait UnusedImportsFinder extends SourceGenerator with CompilerAccess with TreeTraverser with PimpedTrees with SilentTracing {
+trait UnusedImportsFinder extends SourceGenerator with CompilerAccess with TreeTraverser with PimpedTrees with TracingImpl {
 
   import global._
 

--- a/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/sourcegen/TreeChangesDiscoverer.scala
+++ b/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/sourcegen/TreeChangesDiscoverer.scala
@@ -52,6 +52,8 @@ trait TreeChangesDiscoverer {
           t.qual.toString != o.qual.toString
         case (t: Import, o: Import) =>
           t != o
+        case (t: TypeTree, o: TypeTree) if (o.original == null) =>
+          !(t.samePos(o) && t.tpe.safeToString == o.tpe.safeToString)
         case _ =>
           false
       }

--- a/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/transformation/TreeFactory.scala
+++ b/org.scala-refactoring.library/src/main/scala/scala/tools/refactoring/transformation/TreeFactory.scala
@@ -115,7 +115,7 @@ trait TreeFactory {
     }
 
     if (mods != NoMods) valOrVarDef setSymbol NoSymbol.newValue(termName, newFlags = mods.flags) else valOrVarDef
-  }  
+  }
 
   def mkParam(name: String, tpe: Type, defaultVal: Tree = EmptyTree): ValDef = {
     ValDef(Modifiers(Flags.PARAM), newTermName(name), TypeTree(tpe), defaultVal)

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/AddFieldTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/AddFieldTest.scala
@@ -14,7 +14,7 @@ class AddFieldTest extends TestHelper {
 
   def addField(className: String, valName: String, isVar: Boolean, returnType: Option[String], target: AddMethodTarget, src: String, expected: String) = {
     global.ask { () =>
-      val refactoring = new AddField with SilentTracing {
+      val refactoring = new AddField {
         val global = outer.global
         val file = addToCompiler(randomFileName(), src)
         val change = addField(file, className, valName, isVar, returnType, target)

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/AddMethodTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/AddMethodTest.scala
@@ -14,7 +14,7 @@ class AddMethodTest extends TestHelper {
 
   def addMethod(className: String, methodName: String, parameters: List[List[(String, String)]], typeParameters: List[String], returnType: Option[String], target: AddMethodTarget, src: String, expected: String) = {
     global.ask { () =>
-      val refactoring = new AddMethod with SilentTracing {
+      val refactoring = new AddMethod {
         val global = outer.global
         val file = addToCompiler(randomFileName(), src)
         val change = addMethod(file, className, methodName, parameters, typeParameters, returnType, target)

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/ChangeParamOrderTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/ChangeParamOrderTest.scala
@@ -10,7 +10,7 @@ import language.reflectiveCalls
 class ChangeParamOrderTest extends TestHelper with TestRefactoring {
 
   def changeParamOrder(permutations: List[List[Int]])(pro: FileSet) = new TestRefactoringImpl(pro) {
-    val refactoring = new ChangeParamOrder with SilentTracing with TestProjectIndex
+    val refactoring = new ChangeParamOrder with TestProjectIndex
     val changes = performRefactoring(permutations)
   }.changes
 

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/EliminateMatchTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/EliminateMatchTest.scala
@@ -16,7 +16,7 @@ class EliminateMatchTest extends TestHelper with TestRefactoring {
   outer =>
 
   def elim(pro: FileSet) = new TestRefactoringImpl(pro) {
-    val refactoring = new EliminateMatch with SilentTracing with common.InteractiveScalaCompiler {
+    val refactoring = new EliminateMatch with common.InteractiveScalaCompiler {
       val global = outer.global
     }
     val changes = performRefactoring()

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/ExpandCaseClassBindingTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/ExpandCaseClassBindingTest.scala
@@ -16,7 +16,7 @@ import language.reflectiveCalls
 class ExpandCaseClassBindingTest extends TestHelper with TestRefactoring {
 
   def expand(pro: FileSet) = new TestRefactoringImpl(pro) {
-    val refactoring = new ExpandCaseClassBinding with SilentTracing with TestProjectIndex
+    val refactoring = new ExpandCaseClassBinding with TestProjectIndex
     val changes = performRefactoring()
   }.changes
 

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/ExplicitGettersSettersTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/ExplicitGettersSettersTest.scala
@@ -16,7 +16,7 @@ class ExplicitGettersSettersTest extends TestHelper with TestRefactoring {
   outer =>
 
   def explicitGettersSetters(pro: FileSet) = new TestRefactoringImpl(pro) {
-    val refactoring = new ExplicitGettersSetters with SilentTracing {
+    val refactoring = new ExplicitGettersSetters  {
       val global = outer.global
     }
     val changes = performRefactoring()

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/ExtractLocalTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/ExtractLocalTest.scala
@@ -17,7 +17,7 @@ class ExtractLocalTest extends TestHelper with TestRefactoring {
 
   def extract(param: ExtractLocal#RefactoringParameters)(pro: FileSet) = {
     val testRefactoring = new TestRefactoringImpl(pro) {
-      val refactoring = new ExtractLocal with SilentTracing with TestProjectIndex
+      val refactoring = new ExtractLocal with TestProjectIndex
     }
     testRefactoring.performRefactoring(param)
   }

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/ExtractMethodTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/ExtractMethodTest.scala
@@ -14,7 +14,7 @@ import language.reflectiveCalls
 class ExtractMethodTest extends TestHelper with TestRefactoring {
 
   def extract(name: String)(pro: FileSet) = new TestRefactoringImpl(pro) {
-    val refactoring = new ExtractMethod with SilentTracing with TestProjectIndex
+    val refactoring = new ExtractMethod with TestProjectIndex
     val changes = performRefactoring(name)
   }.changes
 

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/ExtractTraitTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/ExtractTraitTest.scala
@@ -23,13 +23,13 @@ class ExtractTraitTest extends TestRefactoring {
   }
 
   def extractTrait(params: (String, String => Boolean))(pro: FileSet) = new TestRefactoringImpl(pro) {
-    val refactoring = new ExtractTrait with SilentTracing with TestProjectIndex
+    val refactoring = new ExtractTrait with TestProjectIndex
     def filter(member: refactoring.global.ValOrDefDef) = params._2(member.symbol.nameString)
     val changes = performRefactoring(new refactoring.RefactoringParameters(params._1, filter))
   }.changes
 
   def extractTraitByParamListLength(params: (String, Int => Boolean))(pro: FileSet) = new TestRefactoringImpl(pro) {
-    val refactoring = new ExtractTrait with SilentTracing with TestProjectIndex
+    val refactoring = new ExtractTrait with TestProjectIndex
     def filter(member: refactoring.global.ValOrDefDef) = member match {
       case valdef: refactoring.global.ValDef => false
       case defdef: refactoring.global.DefDef => defdef.vparamss.headOption.map(vparams => params._2(vparams.size)).getOrElse(false)

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/GenerateHashcodeAndEqualsTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/GenerateHashcodeAndEqualsTest.scala
@@ -25,7 +25,7 @@ class GenerateHashcodeAndEqualsTest extends TestHelper with TestRefactoring {
   }
 
   def generateHashcodeAndEquals(params: (Boolean, String => Boolean, Boolean))(pro: FileSet) = new TestRefactoringImpl(pro) {
-    val refactoring = new GenerateHashcodeAndEquals with SilentTracing {
+    val refactoring = new GenerateHashcodeAndEquals  {
       val global = outer.global
     }
     import refactoring.global.ValDef

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/InlineLocalTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/InlineLocalTest.scala
@@ -16,7 +16,7 @@ class InlineLocalTest extends TestHelper with TestRefactoring {
   outer =>
 
   def inline(pro: FileSet) = new TestRefactoringImpl(pro) {
-    val refactoring = new InlineLocal with SilentTracing with TestProjectIndex
+    val refactoring = new InlineLocal with TestProjectIndex
     val changes = performRefactoring()
   }.changes
 

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/IntroduceProductNTraitTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/IntroduceProductNTraitTest.scala
@@ -24,7 +24,7 @@ class IntroduceProductNTraitTest extends TestHelper with TestRefactoring {
   }
 
   def introduceProductNTrait(params: (Boolean, String => Boolean, Boolean))(pro: FileSet) = new TestRefactoringImpl(pro) {
-    val refactoring = new IntroduceProductNTrait with SilentTracing {
+    val refactoring = new IntroduceProductNTrait  {
       val global = outer.global
     }
     import refactoring.global.ValDef

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/MergeParameterListsTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/MergeParameterListsTest.scala
@@ -15,7 +15,7 @@ class MergeParameterListsTest extends TestHelper with TestRefactoring {
   import outer.global._
 
   def mergeParameterLists(mergePositions: List[Int])(pro: FileSet) = new TestRefactoringImpl(pro) {
-    val refactoring = new MergeParameterLists with SilentTracing with TestProjectIndex
+    val refactoring = new MergeParameterLists with TestProjectIndex
     val changes = performRefactoring(mergePositions)
   }.changes
 

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/MoveClassTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/MoveClassTest.scala
@@ -13,7 +13,7 @@ class MoveClassTest extends TestHelper with TestRefactoring {
 
   private def createRefactoring(pro: FileSet) = {
     new TestRefactoringImpl(pro) {
-      val refactoring = new MoveClass with SilentTracing with TestProjectIndex
+      val refactoring = new MoveClass with TestProjectIndex
     }
   }
 

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/MoveConstructorToCompanionObjectTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/MoveConstructorToCompanionObjectTest.scala
@@ -10,7 +10,7 @@ import language.reflectiveCalls
 class MoveConstructorToCompanionObjectTest extends TestHelper with TestRefactoring {
 
   def moveConstructorToCompanion(pro: FileSet) = new TestRefactoringImpl(pro) {
-    val refactoring = new MoveConstructorToCompanionObject with SilentTracing with TestProjectIndex
+    val refactoring = new MoveConstructorToCompanionObject with TestProjectIndex
     val changes = performRefactoring()
   }.changes
 

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
@@ -1931,7 +1931,6 @@ class Blubb
   /*
    * See Assembla Ticket 1002436
    */
-  @Ignore
   @Test
   def testRenameTypeAnnotatingLazyVal() = new FileSet {
     """
@@ -1962,7 +1961,6 @@ class Blubb
     """
   } applyRefactoring(renameTo("Mistkaefer"))
 
-  @Ignore
   @Test
   def testRenameTypeAnnotatingLazyValMinimal() = new FileSet {
     """

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
@@ -1926,4 +1926,61 @@ class Blubb
     object Buggy
     """ -> "Buggy.scala"
   } applyRefactoring(renameTo("Buggy"))
+
+  /*
+   * See Assembla Ticket 1002436
+   */
+  @Ignore
+  @Test
+  def testRenameTypeAnnotatingLazyVal() = new FileSet {
+    """
+    class /*(*/Bug/*)*/
+
+    class Buggy {
+      lazy val bug: Bug = new Bug
+
+      def moreBugs = {
+        lazy val buggy: Bug = new Bug
+        val notBuggy: Bug = new Bug
+        buggy.hashCode + notBuggy.hashCode
+      }
+    }
+    """ becomes
+    """
+    class /*(*/Mistkaefer/*)*/
+
+    class Buggy {
+      lazy val bug: Mistkaefer = new Mistkaefer
+
+      def moreBugs = {
+        lazy val buggy: Mistkaefer = new Mistkaefer
+        val notBuggy: Mistkaefer = new Mistkaefer
+        buggy.hashCode + notBuggy.hashCode
+      }
+    }
+    """
+  } applyRefactoring(renameTo("Mistkaefer"))
+
+  @Ignore
+  @Test
+  def testRenameTypeAnnotatingLazyValMinimal() = new FileSet {
+    """
+    object Buggy {
+      class /*(*/Bug/*)*/
+      def err = {
+        lazy val bug: Bug = new Bug
+        bug.hashCode
+      }
+    }
+    """ becomes
+    """
+    object Buggy {
+      class /*(*/Mistkaefer/*)*/
+      def err = {
+        lazy val bug: Mistkaefer = new Mistkaefer
+        bug.hashCode
+      }
+    }
+    """
+  } applyRefactoring(renameTo("Mistkaefer"))
 }

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
@@ -14,13 +14,14 @@ import language.reflectiveCalls
 import scala.language.existentials
 import scala.tools.refactoring.common.Change
 import TestHelper.PrepResultWithChanges
+import scala.tools.refactoring.common.TracingImpl
 
 class RenameTest extends TestHelper with TestRefactoring {
   outer =>
 
   private def prepareAndRenameTo(name: String)(pro: FileSet): PrepResultWithChanges = {
     val impl = new TestRefactoringImpl(pro) {
-      val refactoring = new Rename with SilentTracing with TestProjectIndex
+      val refactoring = new Rename with TracingImpl with TestProjectIndex
     }
     PrepResultWithChanges(Some(impl.preparationResult()), impl.performRefactoring(name))
   }

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/SplitParameterListsTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/SplitParameterListsTest.scala
@@ -12,7 +12,7 @@ import language.reflectiveCalls
 class SplitParameterListsTest extends TestHelper with TestRefactoring {
 
   def splitParameterLists(splitPositions: List[List[Int]])(pro: FileSet) = new TestRefactoringImpl(pro) {
-    val refactoring = new SplitParameterLists with SilentTracing with TestProjectIndex
+    val refactoring = new SplitParameterLists with TestProjectIndex
     val changes = performRefactoring(splitPositions)
   }.changes
 

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/extraction/ExtractCodeTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/extraction/ExtractCodeTest.scala
@@ -8,7 +8,7 @@ import tests.util.TestRefactoring
 class ExtractCodeTest extends TestHelper with TestRefactoring {
   def extract(extractionIdx: Int)(pro: FileSet) = {
     val testRefactoring = new TestRefactoringImpl(pro) {
-      val refactoring = new ExtractCode with SilentTracing with TestProjectIndex
+      val refactoring = new ExtractCode with TestProjectIndex
       val e = preparationResult.right.get.extractions(extractionIdx)
     }
     testRefactoring.performRefactoring(testRefactoring.e)

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/extraction/ExtractExtractorTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/extraction/ExtractExtractorTest.scala
@@ -7,7 +7,7 @@ import scala.tools.refactoring.implementations.extraction.ExtractExtractor
 class ExtractExtractorTest extends TestHelper with TestRefactoring {
   def extract(extractionIdx: Int)(pro: FileSet) = {
     val testRefactoring = new TestRefactoringImpl(pro) {
-      val refactoring = new ExtractExtractor with SilentTracing with TestProjectIndex
+      val refactoring = new ExtractExtractor with TestProjectIndex
       val extraction = preparationResult.right.get.extractions(extractionIdx).asInstanceOf[refactoring.Extraction]
     }
     testRefactoring.performRefactoring(testRefactoring.extraction)

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/extraction/ExtractMethodTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/extraction/ExtractMethodTest.scala
@@ -8,7 +8,7 @@ import tests.util.TestRefactoring
 class ExtractMethodTest extends TestHelper with TestRefactoring {
   def extract(extractionIdx: Int)(pro: FileSet) = {
     val testRefactoring = new TestRefactoringImpl(pro) {
-      val refactoring = new ExtractMethod with SilentTracing with TestProjectIndex
+      val refactoring = new ExtractMethod with TestProjectIndex
       val extraction = preparationResult.right.get.extractions(extractionIdx).asInstanceOf[refactoring.MethodExtraction]
     }
     testRefactoring.performRefactoring(testRefactoring.extraction)

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/extraction/ExtractParameterTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/extraction/ExtractParameterTest.scala
@@ -8,7 +8,7 @@ class ExtractParameterTest extends TestHelper with TestRefactoring {
 
   def extract(extractionIdx: Int)(pro: FileSet) = {
     val testRefactoring = new TestRefactoringImpl(pro) {
-      val refactoring = new ExtractParameter with SilentTracing with TestProjectIndex
+      val refactoring = new ExtractParameter with TestProjectIndex
       val extraction = preparationResult.right.get.extractions(extractionIdx)
     }
     testRefactoring.performRefactoring(testRefactoring.extraction)

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/extraction/ExtractValueTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/extraction/ExtractValueTest.scala
@@ -10,7 +10,7 @@ class ExtractValueTest extends TestHelper with TestRefactoring {
 
   def extract(extractionIdx: Int)(pro: FileSet) = {
     val testRefactoring = new TestRefactoringImpl(pro) {
-      val refactoring = new ExtractValue with SilentTracing with TestProjectIndex
+      val refactoring = new ExtractValue with TestProjectIndex
       val extraction = preparationResult.right.get.extractions(extractionIdx)
     }
     testRefactoring.performRefactoring(testRefactoring.extraction)

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/imports/AddImportStatementTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/imports/AddImportStatementTest.scala
@@ -18,7 +18,7 @@ class AddImportStatementTest extends TestHelper {
 
   def addImport(imp: (String, String), src: String, expected: String) = global.ask { () =>
 
-    val refactoring = new AddImportStatement with SilentTracing {
+    val refactoring = new AddImportStatement  {
       val global = outer.global
       val file = addToCompiler(randomFileName(), src)
       val change = addImport(file, imp._1 + "." + imp._2)

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsBaseTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsBaseTest.scala
@@ -12,7 +12,7 @@ import tests.util.TestRefactoring
 abstract class OrganizeImportsBaseTest extends TestHelper with TestRefactoring {
 
   abstract class OrganizeImportsRefatoring(pro: FileSet) extends TestRefactoringImpl(pro) {
-    val refactoring = new OrganizeImports with SilentTracing { val global = OrganizeImportsBaseTest.this.global }
+    val refactoring = new OrganizeImports { val global = OrganizeImportsBaseTest.this.global }
     type RefactoringParameters = refactoring.RefactoringParameters
     val params: RefactoringParameters
     def mkChanges = performRefactoring(params)

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeMissingImportsTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeMissingImportsTest.scala
@@ -15,7 +15,7 @@ class OrganizeMissingImportsTest extends TestHelper with TestRefactoring {
   outer =>
 
   def organize(imports: List[(String, String)])(pro: FileSet) = new TestRefactoringImpl(pro) {
-    val refactoring = new OrganizeImports with SilentTracing {
+    val refactoring = new OrganizeImports  {
       val global = outer.global
     }
     val changes = performRefactoring(new refactoring.RefactoringParameters(imports))

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/sourcegen/CustomFormattingTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/sourcegen/CustomFormattingTest.scala
@@ -16,14 +16,14 @@ import scala.tools.refactoring.tests.util.TestRefactoring
 
 import language.reflectiveCalls
 
-class CustomFormattingTest extends TestHelper with TestRefactoring with SourceGenerator with SilentTracing {
+class CustomFormattingTest extends TestHelper with TestRefactoring with SourceGenerator {
 
   var surroundingImport = ""
 
   override def spacingAroundMultipleImports = surroundingImport
 
   abstract class OrganizeImportsRefatoring(pro: FileSet) extends TestRefactoringImpl(pro) {
-    val refactoring = new OrganizeImports with SilentTracing {
+    val refactoring = new OrganizeImports {
       val global = CustomFormattingTest.this.global
       override def spacingAroundMultipleImports = surroundingImport
     }

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/sourcegen/IndividualSourceGenTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/sourcegen/IndividualSourceGenTest.scala
@@ -17,7 +17,7 @@ import tools.nsc.ast.parser.Tokens
 
 import language.{postfixOps, implicitConversions}
 
-class IndividualSourceGenTest extends TestHelper with SilentTracing {
+class IndividualSourceGenTest extends TestHelper {
 
   import global._
 

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/sourcegen/PrettyPrinterTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/sourcegen/PrettyPrinterTest.scala
@@ -15,7 +15,7 @@ import tools.nsc.symtab.Flags
 import tools.nsc.ast.parser.Tokens
 import scala.reflect.internal.util.BatchSourceFile
 
-class PrettyPrinterTest extends TestHelper with SilentTracing {
+class PrettyPrinterTest extends TestHelper {
 
   import global._
 

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/sourcegen/ReusingPrinterTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/sourcegen/ReusingPrinterTest.scala
@@ -10,7 +10,7 @@ import scala.tools.refactoring.tests.util.TestHelper
 
 import org.junit.ComparisonFailure
 
-class ReusingPrinterTest extends TestHelper with SilentTracing {
+class ReusingPrinterTest extends TestHelper {
 
   import global._
 

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/sourcegen/SourceGenTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/sourcegen/SourceGenTest.scala
@@ -16,7 +16,7 @@ import tools.nsc.ast.parser.Tokens
 
 import language.{ postfixOps, implicitConversions }
 
-class SourceGenTest extends TestHelper with SilentTracing {
+class SourceGenTest extends TestHelper {
 
   import global._
 

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/sourcegen/TreeChangesDiscovererTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/sourcegen/TreeChangesDiscovererTest.scala
@@ -11,7 +11,7 @@ import common.SilentTracing
 import common.PimpedTrees
 import sourcegen.TreeChangesDiscoverer
 
-class TreeChangesDiscovererTest extends TestHelper with SilentTracing {
+class TreeChangesDiscovererTest extends TestHelper {
 
   import global._
 

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/transformation/TreeTransformationsTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/transformation/TreeTransformationsTest.scala
@@ -10,9 +10,9 @@ import org.junit.Assert._
 import common.PimpedTrees
 import language.{ postfixOps, reflectiveCalls }
 import scala.tools.nsc.util.FailedInterrupt
-import scala.tools.refactoring.common.SilentTracing
+import scala.tools.refactoring.common.TracingImpl
 
-class TreeTransformationsTest extends TestHelper with SilentTracing {
+class TreeTransformationsTest extends TestHelper with TracingImpl {
 
   import global._
 

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/util/SourceWithMarkerTest.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/util/SourceWithMarkerTest.scala
@@ -55,7 +55,6 @@ class SourceWithMarkerTest {
     val src5 = SourceWithMarker(srcStr5, srcStr5.size - 1)
 
     val res = src5.moveMarker(commentsAndSpaces.backward)
-    println(s"res: $res")
 
     assertEquals("x", src4.moveMarker(commentsAndSpaces.backward).current.toString)
     assertEquals("v", src1.moveMarker(commentsAndSpaces).current.toString)
@@ -119,9 +118,6 @@ class SourceWithMarkerTest {
     val src = SourceWithMarker(srcStr, srcStr.lastIndexOf("]"))
     val mvmt = (("private" | "protected") ~ commentsAndSpaces ~ bracketsWithContents).backward
 
-    println("bracketsWithContents: " + src.moveMarker(bracketsWithContents.backward))
-    println("commentsAndSpaces ~ bracketsWithContents: " + src.moveMarker((commentsAndSpaces ~ bracketsWithContents).backward))
-    println("mvmt: " + src.moveMarker(mvmt))
     assertEquals("p", src.moveMarker(mvmt ~ commentsAndSpaces).current.toString)
   }
 

--- a/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/util/TestHelper.scala
+++ b/org.scala-refactoring.library/src/test/scala/scala/tools/refactoring/tests/util/TestHelper.scala
@@ -21,15 +21,15 @@ import scala.tools.refactoring.common.Selections
 import language.{ postfixOps, implicitConversions, reflectiveCalls }
 import scala.tools.refactoring.common.NewFileChange
 import scala.tools.refactoring.common.RenameSourceFileChange
-import scala.tools.refactoring.common.RenameSourceFileChange
 import scala.tools.refactoring.implementations.Rename
+import scala.tools.refactoring.common.TracingImpl
 
 object TestHelper {
   case class PrepResultWithChanges(prepResult: Option[Either[MultiStageRefactoring#PreparationError, Rename#PreparationResult]], changes: List[Change])
 }
 
 
-trait TestHelper extends TestRules with Refactoring with CompilerProvider with common.InteractiveScalaCompiler {
+trait TestHelper extends TestRules with Refactoring with CompilerProvider with common.InteractiveScalaCompiler with TracingImpl {
   import TestHelper._
 
   @Before


### PR DESCRIPTION
This pull request introduces
* a fix for [Ticket 1002436](https://www.assembla.com/spaces/scala-ide/tickets/1002436#/activity/ticket:) (see d87ff3f28904ac521f7dd6b095a719242b3c2f91)
* some changes for more convenient debugging (da6f017a65f7dae00f842dffe322d4d5327a7998, da01b33df25127d05bca0ddbb322168cf241f6cd)
* Cosmetics (9e85b7d01c1cf92c3277aa8057383e56d0834b2a)
