### PR TITLE
remove reference to non-existent repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -223,11 +223,6 @@
       <url>http://download.eclipse.org/releases/kepler</url>
     </repository>
     <repository>
-      <id>codehaus-snapshots</id>
-      <name>Maven Codehaus snapshot repository</name>
-      <url>http://snapshots.repository.codehaus.org/</url>
-    </repository>
-    <repository>
       <id>sonatype.release</id>
       <name>Sonatype maven release repository</name>
       <url>https://oss.sonatype.org/content/repositories/releases/</url>


### PR DESCRIPTION
codehaus.org has been shut down, but their server isn't 404'ing,
instead, they're sending back invalid data, which maven sticks
in ~/.m2 as if nothing were wrong.

thus, the presence of this entry is breaking the build here, which
then causes the build scripts in the scala-ide/uber-build repo to
break, which in turn is breaking the scripts/jobs/integrate/ide script
in the scala/scala repo, which in turn means Scala PR validation is
broken

I tested this change locally by deleting my ~/.m2 directory and
running the build-2.11.sh and build-2.10.sh scripts. they both
succeeded, so apparently the repo entry isn't even needed.