### PR TITLE
Refactorings might mess with parens

### DIFF
--- a/src/main/scala/scala/tools/refactoring/sourcegen/CommentsUtils.scala
+++ b/src/main/scala/scala/tools/refactoring/sourcegen/CommentsUtils.scala
@@ -1,0 +1,6 @@
+package scala.tools.refactoring.sourcegen
+
+/**
+ * Only here for backward compatibility - use [[SourceUtils]] instead
+ */
+object CommentsUtils extends SourceUtils

--- a/src/main/scala/scala/tools/refactoring/sourcegen/CommonPrintUtils.scala
+++ b/src/main/scala/scala/tools/refactoring/sourcegen/CommonPrintUtils.scala
@@ -56,9 +56,7 @@ trait CommonPrintUtils {
   }
 
   def balanceParens(open: Char, close: Char)(f: Fragment) = Fragment {
-    val txt = f.toLayout.withoutComments // TODO also without strings, etc.
-    val opening = txt.count(_ == open)
-    val closing = txt.count(_ == close)
+    val (opening, closing) = SourceUtils.countRelevantBrackets(f.toLayout.asText, open, close)
     if (opening > closing && closing > 0) {
       f.asText.reverse.replaceFirst("\\" + close, ("" + close) * (opening - closing + 1)).reverse
     } else if (opening > closing) {

--- a/src/main/scala/scala/tools/refactoring/sourcegen/CommonPrintUtils.scala
+++ b/src/main/scala/scala/tools/refactoring/sourcegen/CommonPrintUtils.scala
@@ -51,11 +51,11 @@ trait CommonPrintUtils {
     }
   }
 
-  def balanceParensInLayout(open: Char, close: Char, l: Layout) = {
-    balanceParens(open, close)(Fragment(l.asText)).toLayout
+  def balanceBracketsInLayout(open: Char, close: Char, l: Layout) = {
+    balanceBrackets(open, close)(Fragment(l.asText)).toLayout
   }
 
-  def balanceParens(open: Char, close: Char)(f: Fragment) = Fragment {
+  def balanceBrackets(open: Char, close: Char)(f: Fragment) = Fragment {
     val (opening, closing) = SourceUtils.countRelevantBrackets(f.toLayout.asText, open, close)
     if (opening > closing && closing > 0) {
       f.asText.reverse.replaceFirst("\\" + close, ("" + close) * (opening - closing + 1)).reverse

--- a/src/main/scala/scala/tools/refactoring/sourcegen/CommonPrintUtils.scala
+++ b/src/main/scala/scala/tools/refactoring/sourcegen/CommonPrintUtils.scala
@@ -57,9 +57,7 @@ trait CommonPrintUtils {
 
   def balanceBrackets(open: Char, close: Char)(f: Fragment) = Fragment {
     val (opening, closing) = SourceUtils.countRelevantBrackets(f.toLayout.asText, open, close)
-    if (opening > closing && closing > 0) {
-      f.asText.reverse.replaceFirst("\\" + close, ("" + close) * (opening - closing + 1)).reverse
-    } else if (opening > closing) {
+    if (opening > closing) {
       f.asText + (("" + close) * (opening - closing))
     } else if (opening < closing) {
       (("" + open) * (closing - opening)) + f.asText

--- a/src/main/scala/scala/tools/refactoring/sourcegen/Indentation.scala
+++ b/src/main/scala/scala/tools/refactoring/sourcegen/Indentation.scala
@@ -40,7 +40,7 @@ trait Indentations {
       if(memoizedSourceWithoutComments contains tree.pos.source.path) {
         memoizedSourceWithoutComments(tree.pos.source.path)
       } else {
-        val src = CommentsUtils.stripComment(tree.pos.source.content)
+        val src = SourceUtils.stripComment(tree.pos.source.content)
         memoizedSourceWithoutComments += tree.pos.source.path → src
         src
       }

--- a/src/main/scala/scala/tools/refactoring/sourcegen/Layout.scala
+++ b/src/main/scala/scala/tools/refactoring/sourcegen/Layout.scala
@@ -18,7 +18,7 @@ trait Layout {
    * @return Returns this layout as a string but without comments.
    *         Comments are replaced by whitespace.
    */
-  lazy val withoutComments = CommentsUtils.stripComment(asText)
+  lazy val withoutComments = SourceUtils.stripComment(asText)
 
   def asText: String
 

--- a/src/main/scala/scala/tools/refactoring/sourcegen/LayoutHelper.scala
+++ b/src/main/scala/scala/tools/refactoring/sourcegen/LayoutHelper.scala
@@ -32,7 +32,7 @@ trait LayoutHelper {
         // therefore we have to skip them here otherwise we have no chance
         // to re-introduce missing (
 
-        val left = Layout(CommentsUtils.stripFromCode(l.asText, '('))
+        val left = Layout(SourceUtils.stripFromCode(l.asText, '('))
 
         (left, r)
       case (l, r) => (l, r)
@@ -346,7 +346,7 @@ trait LayoutHelper {
       case (l, r) =>
 
         val source = between(l, r).toString
-        val (layout, comments) = CommentsUtils.splitComment(source)
+        val (layout, comments) = SourceUtils.splitComment(source)
 
         val (ll, lr, rule) = (l, parent, r) match {
 

--- a/src/main/scala/scala/tools/refactoring/sourcegen/PrettyPrinter.scala
+++ b/src/main/scala/scala/tools/refactoring/sourcegen/PrettyPrinter.scala
@@ -280,7 +280,7 @@ trait PrettyPrinter extends TreePrintingTraversals with AbstractPrinter {
         case _ =>
           val fun_ = p(fun)
 
-          fun_ ++ balanceParens('(', ')') {
+          fun_ ++ balanceBrackets('(', ')') {
             EmptyFragment ++ "(" ++ pp(args, separator = ", ") ++ ")"
           }
       }
@@ -511,7 +511,7 @@ trait PrettyPrinter extends TreePrintingTraversals with AbstractPrinter {
         }
       }
 
-      val cond_ = balanceParens('(', ')') {
+      val cond_ = balanceBrackets('(', ')') {
         p(cond, before = "if (", after = ")") ++ thenLeadingLayout_ ++ Requisite.Blank
       }
 

--- a/src/main/scala/scala/tools/refactoring/sourcegen/ReusingPrinter.scala
+++ b/src/main/scala/scala/tools/refactoring/sourcegen/ReusingPrinter.scala
@@ -402,7 +402,7 @@ trait ReusingPrinter extends TreePrintingTraversals with AbstractPrinter {
 
       val _args = pp(args, separator = ", ", before = "[", after = "]")
 
-      l ++ _fun.dropTrailingLayout ++ balanceParens('[', ']')(_fun.trailing ++ _args ++ r)
+      l ++ _fun.dropTrailingLayout ++ balanceBrackets('[', ']')(_fun.trailing ++ _args ++ r)
     }
 
     override def Apply(tree: Apply, fun: Tree, args: List[Tree])(implicit ctx: PrintingContext) = {
@@ -413,10 +413,10 @@ trait ReusingPrinter extends TreePrintingTraversals with AbstractPrinter {
          * the case we include the trailing layout in the balanceParens call.
          */
         if (recv.trailing.contains("(")) {
-          val _arg = balanceParens('(', ')')(recv.trailing ++ args ++ r)
+          val _arg = balanceBrackets('(', ')')(recv.trailing ++ args ++ r)
           l ++ recv.dropTrailingLayout ++ _arg
         } else {
-          val _arg = balanceParens('(', ')')(args ++ r)
+          val _arg = balanceBrackets('(', ')')(args ++ r)
           l ++ recv ++ _arg
         }
       }
@@ -604,7 +604,7 @@ trait ReusingPrinter extends TreePrintingTraversals with AbstractPrinter {
     }
 
     override def CompoundTypeTree(tree: CompoundTypeTree, tpl: Template)(implicit ctx: PrintingContext) = {
-      balanceParens('{', '}') {
+      balanceBrackets('{', '}') {
         printTemplate(tpl, printExtends = false)
       }
     }
@@ -874,7 +874,7 @@ trait ReusingPrinter extends TreePrintingTraversals with AbstractPrinter {
         case f => (f.leading, f.dropLeadingLayout)
       }
 
-      val _cond = balanceParens('(', ')') {
+      val _cond = balanceBrackets('(', ')') {
         // we want to balance the parens around the condition and all adjacent layout
         l ++ p(cond, before = "(", after = Requisite.anywhere(")")) ++ _thenLeadingLayout
       }

--- a/src/main/scala/scala/tools/refactoring/sourcegen/SourceGenerator.scala
+++ b/src/main/scala/scala/tools/refactoring/sourcegen/SourceGenerator.scala
@@ -44,7 +44,7 @@ trait SourceGenerator extends PrettyPrinter with Indentations with ReusingPrinte
 
         lazy val trailingSrc = {
           val src = range.source.content.slice(range.end, range.source.length)
-          CommentsUtils.stripComment(src)
+          SourceUtils.stripComment(src)
         }
 
         def hasTrailingBraceAndSomething = {

--- a/src/main/scala/scala/tools/refactoring/sourcegen/SourceUtils.scala
+++ b/src/main/scala/scala/tools/refactoring/sourcegen/SourceUtils.scala
@@ -6,7 +6,7 @@ package scala.tools.refactoring
 package sourcegen
 import scala.language.postfixOps
 
-object SourceUtils {
+trait SourceUtils {
   /**
    * Counts brackets, skipping comments, back-tick identifiers, string and character constants.
    */
@@ -265,3 +265,5 @@ object SourceUtils {
     }
   }
 }
+
+object SourceUtils extends SourceUtils

--- a/src/main/scala/scala/tools/refactoring/sourcegen/SourceUtils.scala
+++ b/src/main/scala/scala/tools/refactoring/sourcegen/SourceUtils.scala
@@ -6,7 +6,7 @@ package scala.tools.refactoring
 package sourcegen
 import scala.language.postfixOps
 
-object CommentsUtils {
+object SourceUtils {
 
   def stripFromCode(source: String, c: Char) = {
 

--- a/src/main/scala/scala/tools/refactoring/sourcegen/TreePrintingTraversals.scala
+++ b/src/main/scala/scala/tools/refactoring/sourcegen/TreePrintingTraversals.scala
@@ -271,8 +271,8 @@ trait TreePrintingTraversals {
         case (l, r) if r.asText == "" => l
         case (l, r) =>
 
-          val leftCenter = balanceParensInLayout('(', ')', l.center)
-          val rightCenter = balanceParensInLayout('(', ')', r.center)
+          val leftCenter = balanceBracketsInLayout('(', ')', l.center)
+          val rightCenter = balanceBracketsInLayout('(', ')', r.center)
 
           val left = l.post(leftCenter ++ l.trailing, NoLayout)
           val right = r.pre(NoLayout, r.leading ++ rightCenter)

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/AddImportStatementTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/AddImportStatementTest.scala
@@ -306,7 +306,7 @@ object T
 
 
   /*
-   * See Assert Ticket #1002088
+   * See Assembla ticket #1002088
    */
   @Test
   def addImportWithRoundBracketStringTicket1002088Ex1() = {
@@ -334,6 +334,12 @@ object T
       """)
   }
 
+  /*
+   * This test inspired from ticket #1002088 deals with code that
+   * does not compile, and therefore for now is not of very high
+   * priority.
+   */
+  @Ignore
   @Test
   def addImportWithRoundBracketStringTicket1002088Ex2() = {
     addImport(("scala.util.matching", "Regex"), """

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/AddImportStatementTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/AddImportStatementTest.scala
@@ -303,4 +303,82 @@ object T
       }
     """)
   }
+
+
+  /*
+   * See Assert Ticket #1002088
+   */
+  @Test
+  def addImportWithRoundBracketStringTicket1002088Ex1() = {
+    addImport(("scala.util.matching", "Regex"), """
+      object X
+
+      class Y {
+
+        ")"
+
+        val r: Regex
+      }
+      """,
+      """
+      import scala.util.matching.Regex
+
+      object X
+
+      class Y {
+
+        ")"
+
+        val r: Regex
+      }
+      """)
+  }
+
+  @Test
+  def addImportWithRoundBracketStringTicket1002088Ex2() = {
+    addImport(("scala.util.matching", "Regex"), """
+      object X
+
+      ")"
+
+      class Y {
+
+        val r: Regex
+      }
+      """,
+      """
+      import scala.util.matching.Regex
+
+      object X
+
+      ")"
+
+      class Y {
+
+        val r: Regex
+      }
+      """)
+  }
+
+  @Test
+  def addImportWithRoundBracketStringTicket1002088Ex3() = {
+    addImport(("scala.collection.mutable", "LinkedHashSet"), """
+      object DummyObject
+
+      class WrongFormatting {
+        def importHere = LinkedHashSet("(")
+        ()
+      }
+      """,
+      """
+      import scala.collection.mutable.LinkedHashSet
+
+      object DummyObject
+
+      class WrongFormatting {
+        def importHere = LinkedHashSet("(")
+        ()
+      }
+      """)
+  }
 }

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
@@ -637,4 +637,30 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
     """
   } applyRefactoring organizeWithTypicalParams
 
+  /*
+   * See Assembla Ticket #1002088
+   */
+  @Test
+  def dontInsertExtraRoundBrackets1002088Ex3() = new FileSet {
+    """
+      package test
+      import java.lang.String
+
+      object Bug2 {
+        ')'
+      }
+
+      object O2
+    """ becomes
+    """
+      package test
+
+      object Bug2 {
+        ')'
+      }
+
+      object O2
+    """
+  } applyRefactoring organizeWithTypicalParams
+
 }

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
@@ -611,9 +611,6 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
     """
   } applyRefactoring organizeWithTypicalParams
 
-  /*
-   * See Assembla Ticket #1002088
-   */
   @Test
   def dontInsertExtraRoundBrackets1002088Ex2() = new FileSet {
     """
@@ -637,9 +634,6 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
     """
   } applyRefactoring organizeWithTypicalParams
 
-  /*
-   * See Assembla Ticket #1002088
-   */
   @Test
   def dontInsertExtraRoundBrackets1002088Ex3() = new FileSet {
     """
@@ -657,6 +651,29 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
 
       object Bug2 {
         ')'
+      }
+
+      object O2
+    """
+  } applyRefactoring organizeWithTypicalParams
+
+  @Test
+  def dontInsertExtraRoundBrackets1002088Ex4() = new FileSet {
+    """
+      package test
+      import java.lang.String
+
+      object Bug2 {
+        val `)` = ')'
+      }
+
+      object O2
+    """ becomes
+    """
+      package test
+
+      object Bug2 {
+        val `)` = ')'
       }
 
       object O2

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
@@ -12,19 +12,19 @@ import language.reflectiveCalls
 
 class OrganizeImportsTest extends OrganizeImportsBaseTest {
 
-  def organize(pro: FileSet) = new OrganizeImportsRefatoring(pro) {
+  private def organize(pro: FileSet) = new OrganizeImportsRefatoring(pro) {
     val params = new RefactoringParameters()
   }.mkChanges
 
-  def organizeWithoutCollapsing(pro: FileSet) = new OrganizeImportsRefatoring(pro) {
+  private def organizeWithoutCollapsing(pro: FileSet) = new OrganizeImportsRefatoring(pro) {
     val params = new RefactoringParameters(options = List(refactoring.SortImportSelectors))
   }.mkChanges
 
-  def organizeExpand(pro: FileSet) = new OrganizeImportsRefatoring(pro) {
+  private def organizeExpand(pro: FileSet) = new OrganizeImportsRefatoring(pro) {
     val params = new refactoring.RefactoringParameters(options = List(refactoring.ExpandImports, refactoring.SortImports))
   }.mkChanges
 
-  def organizeWithTypicalParams(pro: FileSet) = new OrganizeImportsRefatoring(pro) {
+  private def organizeWithTypicalParams(pro: FileSet) = new OrganizeImportsRefatoring(pro) {
     val params = {
       val groupImports = refactoring.GroupImports(List("java", "scala", "org", "com"))
       val alwaysUseWildcards = refactoring.AlwaysUseWildcards(Set("scalaz", "scalaz.Scalaz"))
@@ -561,7 +561,7 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
    * See Assembla Ticket #1002166
    */
   @Test
-  def dontInsertExtraRoundBrackets() = new FileSet {
+  def dontInsertExtraRoundBrackets1002166() = new FileSet {
     """
       package test
       import scala.collection.mutable.ListBuffer
@@ -584,4 +584,57 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
       }
     """
   } applyRefactoring organizeWithTypicalParams
+
+  /*
+   * See Assembla Ticket #1002088
+   */
+  @Test
+  def dontInsertExtraRoundBrackets1002088Ex1() = new FileSet {
+    """
+      package test
+      import java.lang.String
+
+      object O1
+
+      trait Bug1 {
+        ")"
+      }
+    """ becomes
+    """
+      package test
+
+      object O1
+
+      trait Bug1 {
+        ")"
+      }
+    """
+  } applyRefactoring organizeWithTypicalParams
+
+  /*
+   * See Assembla Ticket #1002088
+   */
+  @Test
+  def dontInsertExtraRoundBrackets1002088Ex2() = new FileSet {
+    """
+      package test
+      import java.lang.String
+
+      object Bug2 {
+        ")"
+      }
+
+      object O2
+    """ becomes
+    """
+      package test
+
+      object Bug2 {
+        ")"
+      }
+
+      object O2
+    """
+  } applyRefactoring organizeWithTypicalParams
+
 }

--- a/src/test/scala/scala/tools/refactoring/tests/sourcegen/SourceHelperTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/sourcegen/SourceHelperTest.scala
@@ -7,11 +7,11 @@ package tests.sourcegen
 
 import tests.util.TestHelper
 import org.junit.Assert._
-import sourcegen.CommentsUtils
+import sourcegen.SourceUtils
 
 class SourceHelperTest extends TestHelper {
 
-  import CommentsUtils._
+  import SourceUtils._
 
   @Test
   def liftSingleLineComment(): Unit = {

--- a/src/test/scala/scala/tools/refactoring/tests/sourcegen/SourceUtilsTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/sourcegen/SourceUtilsTest.scala
@@ -1,10 +1,10 @@
 package scala.tools.refactoring.tests.sourcegen
 
-import scala.tools.refactoring.sourcegen.CommentsUtils
+import scala.tools.refactoring.sourcegen.SourceUtils
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
-class CommentsUtilsTest {
+class SourceUtilsTest {
   @Test
   def testStripCommentWithExampleFromTicket1002166() {
     val source = """
@@ -14,13 +14,13 @@ class CommentsUtilsTest {
       }
     """
 
-   assertEquals(source, CommentsUtils.stripComment(source))
+   assertEquals(source, SourceUtils.stripComment(source))
   }
 
   @Test
   def testStripCommentWithMinimalExampleFromTicket1002166() {
     val source = """("\\")"""
-    assertEquals(source, CommentsUtils.stripComment(source))
+    assertEquals(source, SourceUtils.stripComment(source))
   }
 
   @Test
@@ -138,7 +138,7 @@ class CommentsUtilsTest {
   }
 
   private def testSplitComment(in: String, woComments: String, commentsOnly: String): Unit = {
-    val (resWoComments, resCommentsOnly) = CommentsUtils.splitComment(removeTrailingSpaceMarkers(in))
+    val (resWoComments, resCommentsOnly) = SourceUtils.splitComment(removeTrailingSpaceMarkers(in))
     assertEquals(s"woComments: $in", removeTrailingSpaceMarkers(woComments), resWoComments)
     assertEquals(s"commentsOnly: $in", removeTrailingSpaceMarkers(commentsOnly), resCommentsOnly)
   }

--- a/src/test/scala/scala/tools/refactoring/tests/sourcegen/SourceUtilsTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/sourcegen/SourceUtilsTest.scala
@@ -140,6 +140,7 @@ class SourceUtilsTest {
   @Test
   def testCountRelevantBracketsWithSimpleExamples() = {
     testCountRelevantBrackets("", 0, 0)
+    testCountRelevantBrackets("val `(` = 42", 0, 0)
     testCountRelevantBrackets("""val x = ")"""", 0, 0)
     testCountRelevantBrackets("""val x = "\")"""", 0, 0)
     testCountRelevantBrackets("def x = 3", 0, 0)
@@ -176,6 +177,8 @@ class SourceUtilsTest {
            val z = "\")))))))))))))))))))))))))))))))"
 
            val c = '('
+
+           val `))))))` = '\)'
 
            ())
            """, 1, 2


### PR DESCRIPTION
This PR, which is closely related to https://github.com/scala-ide/scala-refactoring/pull/93, deals mostly with `CommonPrintUtils.balanceBrackets` once more (details can be found in the commit messages). Please note that I still don't trust this function completely, as I don't understand what the `"\\"` in
```scala
f.asText.reverse.replaceFirst("\\" + close, ("" + close) * (opening - closing + 1)).reverse
```
(see https://github.com/mlangc/scala-refactoring/blob/organize-imports-adds-opening-parenthesis-1002088/src/main/scala/scala/tools/refactoring/sourcegen/CommonPrintUtils.scala#L61) is about. @misto Maybe you can clarify?

Last but not least, these changes fix [Ticket #1002088](https://www.assembla.com/spaces/scala-ide/tickets/1002088-automatic-import-adds-opening-parenthesis-if-a-string-with-a-closing-parenthesis-occurs).