### PR TITLE
Fix locating parameter assignments in argument lists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bin
 .cache-main
 .cache-tests
 .settings
+.attach_pid*

--- a/src/main/scala/scala/tools/refactoring/common/PimpedTrees.scala
+++ b/src/main/scala/scala/tools/refactoring/common/PimpedTrees.scala
@@ -1138,10 +1138,21 @@ trait PimpedTrees {
 
               if (nameStart >= 0) {
                 val nameLength = newVal.name.length
-                val namePos = (t.pos withStart (nameStart + startOffset) withPoint nameStart + startOffset + nameLength)
-                newVal.nameTree setPos namePos
-                newVal setPos namePos.withEnd(t.pos.end)
-                newVal
+                val newStart = nameStart + startOffset
+
+                // Note the FIXMEs above:
+                //  This can actually happen; what you see below is a hack that helps in some cases
+                //  by avoiding an exception that would otherwise be thrown a few lines below
+                //  (see ticket #1002540).
+                if (newStart > t.pos.end) {
+                  t
+                } else {
+                  val namePos = (t.pos withStart (nameStart + startOffset) withPoint nameStart + startOffset + nameLength)
+                  newVal.nameTree setPos namePos
+                  newVal setPos namePos.withEnd(t.pos.end)
+                  newVal
+                }
+
               } else /*no named argument*/ {
                 t.rhs
               }

--- a/src/main/scala/scala/tools/refactoring/common/PimpedTrees.scala
+++ b/src/main/scala/scala/tools/refactoring/common/PimpedTrees.scala
@@ -1101,7 +1101,7 @@ trait PimpedTrees {
 
     private def findParamAssignment(argsSource: String, paramName: String): Option[Int] = {
       val mvnt = until(paramName ~ spaces ~ '=', skipping = skipWhileSearchingForAssignment)
-      mvnt(SourceWithMarker(argsSource.toCharArray()))
+      mvnt(SourceWithMarker(argsSource))
     }
 
     def unapply(t: Block) = {

--- a/src/main/scala/scala/tools/refactoring/common/PimpedTrees.scala
+++ b/src/main/scala/scala/tools/refactoring/common/PimpedTrees.scala
@@ -1091,7 +1091,13 @@ trait PimpedTrees {
    * removed and named argument trees are created.
    */
   object BlockExtractor {
-    private val skipWhileSearchingForAssignment = (comment | stringLiteral | characterLiteral | literalIdentifier | symbolLiteral)
+    private val skipWhileSearchingForAssignment =
+      comment |
+      stringLiteral |
+      characterLiteral |
+      literalIdentifier |
+      symbolLiteral |
+      curlyBracesWithContents
 
     private def findParamAssignment(argsSource: String, paramName: String): Option[Int] = {
       val mvnt = until(paramName ~ spaces ~ '=', skipping = skipWhileSearchingForAssignment)

--- a/src/main/scala/scala/tools/refactoring/util/SourceWithMarker.scala
+++ b/src/main/scala/scala/tools/refactoring/util/SourceWithMarker.scala
@@ -17,7 +17,7 @@ final case class SourceWithMarker(source: Array[Char] = Array(), marker: Int = 0
 
   assertLegalState()
 
-  def moveMarker(movement: Movement): SourceWithMarker = {
+  def moveMarker(movement: SimpleMovement): SourceWithMarker = {
     if (isDepleted) this
     else movement(this).map(m => copy(marker = m)).getOrElse(this)
   }
@@ -83,6 +83,57 @@ object SourceWithMarker {
   }
 
   /**
+   * A [[Movement]] that can be applied in one direction.
+   *
+   * The difference between a [[SimpleMovement]] and a [[Movement]] is that [[SimpleMovement]]
+   * is missing the `backward` method. Apart from that, the documentation for [[Movement]] applies.
+   * Note that ''movements'' can be combined with ''simple movements'', so there is no need to
+   * implement `backward` unless you need it.
+   */
+  trait SimpleMovement { self =>
+    def apply(sourceWithMarker: SourceWithMarker): Option[Int]
+
+    final def ~(other: SimpleMovement): SimpleMovement = SimpleMovementOps.sequence(SimpleMovement.this, other) _
+    final def |(other: SimpleMovement): SimpleMovement = SimpleMovementOps.or(SimpleMovement.this, other) _
+    def zeroOrMore: SimpleMovement = SimpleMovementOps.repeat(SimpleMovement.this) _
+    def atLeastOnce: SimpleMovement = this ~ this.zeroOrMore
+  }
+
+  object SimpleMovement {
+    implicit class WrapSimpleMovementImpl(impl: SourceWithMarker => Option[Int]) extends SimpleMovement {
+      override def apply(sourceWithMarker: SourceWithMarker) = impl(sourceWithMarker)
+    }
+  }
+
+  private object SimpleMovementOps {
+    def sequence[MovementT <: SimpleMovement](mvnt1: MovementT, mvnt2: MovementT)(sourceWithMarker: SourceWithMarker): Option[Int] = {
+      mvnt1(sourceWithMarker).map(newMarker => sourceWithMarker.copy(marker = newMarker)).flatMap(mvnt2.apply)
+    }
+
+    def or[MovementT <: SimpleMovement](mvnt1: MovementT, mvnt2: MovementT)(sourceWithMarker: SourceWithMarker): Option[Int] = {
+      mvnt1(sourceWithMarker).orElse(mvnt2(sourceWithMarker))
+    }
+
+    def repeat[MovementT <: SimpleMovement](mvnt: MovementT)(sourceWithMarker: SourceWithMarker): Option[Int] = {
+      @tailrec
+      def go(sourceWithMarker: SourceWithMarker): Option[Int] = {
+        if (sourceWithMarker.isDepleted) {
+          Some(sourceWithMarker.marker)
+        } else {
+          mvnt(sourceWithMarker) match {
+            case Some(marker) =>
+              if (marker != sourceWithMarker.marker) go(sourceWithMarker.copy(marker = marker))
+              else Some(marker)
+            case None => Some(sourceWithMarker.marker)
+          }
+        }
+      }
+
+      go(sourceWithMarker)
+    }
+  }
+
+  /**
    * A context dependent, directional movement that can be applied to a [[SourceWithMarker]]
    *
    * ==Overview==
@@ -114,203 +165,153 @@ object SourceWithMarker {
    *
    * @see [[Movements]]
    */
-  trait Movement { outer =>
-    def apply(sourceWithMarker: SourceWithMarker): Option[Int]
+  trait Movement extends SimpleMovement { self =>
     def backward: Movement
 
-    final def ~(other: Movement): Movement = new Movement { inner =>
-      override def apply(sourceWithMarker: SourceWithMarker): Option[Int] = {
-        outer(sourceWithMarker).map(newMarker => sourceWithMarker.copy(marker = newMarker)).flatMap(other.apply)
-      }
-
-      override def backward = new Movement  {
-        override def apply(sourceWithMarker: SourceWithMarker): Option[Int] = {
-         other.backward.apply(sourceWithMarker).map(newMarker => sourceWithMarker.copy(marker = newMarker)).flatMap(outer.backward.apply)
-        }
-
-        override def backward = inner
+    final def ~(other: Movement) = Movement { (sourceWithMarker, forward) =>
+      if (forward) {
+        SimpleMovementOps.sequence(self, other)(sourceWithMarker)
+      } else {
+       other.backward.apply(sourceWithMarker).map(newMarker => sourceWithMarker.copy(marker = newMarker)).flatMap(self.backward.apply)
       }
     }
 
-    final def |(other: Movement): Movement = new Movement { inner =>
-      override def apply(sourceWithMarker: SourceWithMarker): Option[Int] = {
-        outer(sourceWithMarker).orElse(other(sourceWithMarker))
-      }
-
-      override def backward = new Movement  {
-        override def apply(sourceWithMarker: SourceWithMarker): Option[Int] = {
-          (other.backward(sourceWithMarker)).orElse(outer.backward(sourceWithMarker))
-        }
-
-        override def backward = inner
-      }
+    final def |(other: Movement) = Movement { (sourceWithMarker, forward) =>
+      if (forward) self(sourceWithMarker).orElse(other(sourceWithMarker))
+      else (other.backward(sourceWithMarker)).orElse(self.backward(sourceWithMarker))
     }
 
-    final def zeroOrMore: Movement = {
-      class Repeat(forward: Boolean = true) extends Movement {
-        override def apply(sourceWithMarker: SourceWithMarker): Option[Int] = {
-          val mvmt = if (forward) outer else outer.backward
-
-          @tailrec
-          def go(sourceWithMarker: SourceWithMarker): Option[Int] = {
-            if (sourceWithMarker.isDepleted) {
-              Some(sourceWithMarker.marker)
-            } else {
-              mvmt(sourceWithMarker) match {
-                case Some(marker) =>
-                  if (marker != sourceWithMarker.marker) go(sourceWithMarker.copy(marker = marker))
-                  else Some(marker)
-                case None => Some(sourceWithMarker.marker)
-              }
-            }
-          }
-
-          go(sourceWithMarker)
-        }
-
-        override def backward: Movement = new Repeat(!forward)
-      }
-      new Repeat
+    final override def zeroOrMore = Movement { (sourceWithMarker, forward) =>
+      val mvnt = if (forward) self else self.backward
+      SimpleMovementOps.repeat(mvnt)(sourceWithMarker)
     }
 
-    final def atLeastOnce: Movement = {
-      this ~ this.zeroOrMore
+    final override def atLeastOnce: Movement = this ~ this.zeroOrMore
+  }
+
+  object Movement {
+    def apply(impl: (SourceWithMarker, Boolean) => Option[Int]): Movement = {
+      class MovementImpl(forward: Boolean) extends Movement {
+        override def apply(sourceWithMarker: SourceWithMarker) = impl(sourceWithMarker, forward)
+        override def backward = new MovementImpl(!forward)
+      }
+
+      return new MovementImpl(true)
     }
   }
 
   object Movements {
     import MovementHelpers._
 
-    final class ConsumeChar(c: Char, forward: Boolean = true) extends Movement {
-      override def apply(sourceWithMarker: SourceWithMarker) = {
-        if (sourceWithMarker.current == c) Some(nextMarker(sourceWithMarker.marker, forward))
-        else None
-      }
-
-      override def backward = new ConsumeChar(c, !forward)
+    def consumeChar(c: Char) = Movement { (sourceWithMarker, forward) =>
+      if (sourceWithMarker.current == c) Some(nextMarker(sourceWithMarker.marker, forward))
+      else None
     }
 
-    final class ConsumeString(str: String, forward: Boolean = true) extends Movement {
-      override def apply(sourceWithMarker: SourceWithMarker) = {
-        def strAt(i: Int) = {
-          if (forward) str.charAt(i)
-          else str.charAt(str.length - 1 - i)
-        }
-
-        @tailrec
-        def go(m: Int, i: Int = 0): Option[Int] = {
-          if (i >= str.length) {
-            Some(m)
-          } else if (wouldBeDepleted(m, sourceWithMarker)) {
-            None
-          } else {
-            if (strAt(i) == sourceWithMarker.source(m)) go(nextMarker(m, forward), i + 1)
-            else None
-          }
-        }
-
-        go(sourceWithMarker.marker)
+    def consumeString(str: String) = Movement { (sourceWithMarker, forward) =>
+      def strAt(i: Int) = {
+        if (forward) str.charAt(i)
+        else str.charAt(str.length - 1 - i)
       }
 
-      override def backward = new ConsumeString(str, !forward)
-    }
-
-    final class ConsumeSpace(forward: Boolean = true) extends Movement {
-      override def apply(sourceWithMarker: SourceWithMarker) = {
-        if (sourceWithMarker.current.isWhitespace) Some(nextMarker(sourceWithMarker.marker, forward))
-        else None
-      }
-
-      override def backward = new ConsumeSpace(!forward)
-    }
-
-    final class ConsumeComment(forward: Boolean = true) extends Movement {
-      override def apply(sourceWithMarker: SourceWithMarker) = {
-
-        @tailrec
-        def go(m: Int, inSingleLineComment: Boolean = false, inMultilineComment: Int = 0, slashSeen: Boolean = false, starSeen: Boolean = false): Option[Int] = {
-          if (wouldBeDepleted(m, sourceWithMarker)) {
-            if (inSingleLineComment && forward) Some(m) else None
-          } else {
-            val c = sourceWithMarker.source(m)
-            val nm = nextMarker(m, forward)
-
-            if (inSingleLineComment) {
-              if (c == '/') if(slashSeen && !forward) Some(nm) else go(nm, inSingleLineComment = true, slashSeen = true)
-              else if (c == '\n') if(forward) Some(m) else None
-              else go(nm, inSingleLineComment = true)
-            } else if (inMultilineComment > 0) {
-              if (c == '/') {
-                if (starSeen) {
-                  if (inMultilineComment == 1) Some(nm)
-                  else go(nm, inMultilineComment = inMultilineComment - 1)
-                } else {
-                  go(nm, inMultilineComment = inMultilineComment, slashSeen = true)
-                }
-              } else if (c == '*') {
-                if (slashSeen) go(nm, inMultilineComment = inMultilineComment + 1)
-                else go(nm, inMultilineComment = inMultilineComment, starSeen = true)
-              } else {
-                go(nm, inMultilineComment = inMultilineComment)
-              }
-            } else {
-              if (c == '/') {
-            	  if (slashSeen && forward) go(nm, inSingleLineComment = true)
-                else go(nm, slashSeen = true)
-              } else if(c == '*' && slashSeen) {
-                go(nm, inMultilineComment = 1)
-              } else {
-                None
-              }
-            }
-          }
-        }
-
-        if(!forward) go(sourceWithMarker.marker, inSingleLineComment = true).orElse(go(sourceWithMarker.marker, inSingleLineComment = false))
-        else go(sourceWithMarker.marker)
-      }
-
-      override def backward = new ConsumeComment(!forward)
-    }
-
-    final class ConsumeInBrackets(open: Char, close: Char, forward: Boolean = true) extends Movement {
-      override def apply(sourceWithMarker: SourceWithMarker) = {
-        val (br1, br2) = if (forward) (open, close) else (close, open)
-        if (sourceWithMarker.isDepleted || sourceWithMarker.current != br1) {
+      @tailrec
+      def go(m: Int, i: Int = 0): Option[Int] = {
+        if (i >= str.length) {
+          Some(m)
+        } else if (wouldBeDepleted(m, sourceWithMarker)) {
           None
         } else {
-          val eventuallyReversedCommentsAndSpaces = {
-            if (forward) commentsAndSpaces
-            else commentsAndSpaces.backward
-          }
-
-          @tailrec
-          def go(m: Int): Option[Int] = {
-            val mm = sourceWithMarker.copy(marker = m).moveMarker(eventuallyReversedCommentsAndSpaces).marker
-            if (wouldBeDepleted(mm, sourceWithMarker)) {
-              None
-            } else {
-              val nm = if (mm == m) nextMarker(mm, forward) else mm
-              if(sourceWithMarker.source(nm) == br2) Some(nextMarker(nm, forward))
-              else go(nm)
-            }
-          }
-
-          go(nextMarker(sourceWithMarker.marker, forward))
+          if (strAt(i) == sourceWithMarker.source(m)) go(nextMarker(m, forward), i + 1)
+          else None
         }
       }
 
-      override def backward = new ConsumeInBrackets(open, close, !forward)
+      go(sourceWithMarker.marker)
     }
 
-    val space: Movement = new ConsumeSpace()
-    val spaces: Movement = new ConsumeSpace().zeroOrMore
-    val comments: Movement = (new ConsumeComment() ~ spaces).zeroOrMore
-    val commentsAndSpaces: Movement = (spaces ~ comments).zeroOrMore
-    val bracketsWithContents: Movement = new ConsumeInBrackets('[', ']')
+    val consumeSpace = Movement { (sourceWithMarker, forward) =>
+      if (sourceWithMarker.current.isWhitespace) Some(nextMarker(sourceWithMarker.marker, forward))
+      else None
+    }
 
-    implicit def charToMovement(c: Char): ConsumeChar = new ConsumeChar(c)
-    implicit def stringToMovement(str: String): ConsumeString = new ConsumeString(str)
+    val consumeComment = Movement { (sourceWithMarker, forward) =>
+      @tailrec
+      def go(m: Int, inSingleLineComment: Boolean = false, inMultilineComment: Int = 0, slashSeen: Boolean = false, starSeen: Boolean = false): Option[Int] = {
+        if (wouldBeDepleted(m, sourceWithMarker)) {
+          if (inSingleLineComment && forward) Some(m) else None
+        } else {
+          val c = sourceWithMarker.source(m)
+          val nm = nextMarker(m, forward)
+
+          if (inSingleLineComment) {
+            if (c == '/') if(slashSeen && !forward) Some(nm) else go(nm, inSingleLineComment = true, slashSeen = true)
+            else if (c == '\n') if(forward) Some(m) else None
+            else go(nm, inSingleLineComment = true)
+          } else if (inMultilineComment > 0) {
+            if (c == '/') {
+              if (starSeen) {
+                if (inMultilineComment == 1) Some(nm)
+                else go(nm, inMultilineComment = inMultilineComment - 1)
+              } else {
+                go(nm, inMultilineComment = inMultilineComment, slashSeen = true)
+              }
+            } else if (c == '*') {
+              if (slashSeen) go(nm, inMultilineComment = inMultilineComment + 1)
+              else go(nm, inMultilineComment = inMultilineComment, starSeen = true)
+            } else {
+              go(nm, inMultilineComment = inMultilineComment)
+            }
+          } else {
+            if (c == '/') {
+              if (slashSeen && forward) go(nm, inSingleLineComment = true)
+              else go(nm, slashSeen = true)
+            } else if(c == '*' && slashSeen) {
+              go(nm, inMultilineComment = 1)
+            } else {
+              None
+            }
+          }
+        }
+      }
+
+      if(!forward) go(sourceWithMarker.marker, inSingleLineComment = true).orElse(go(sourceWithMarker.marker, inSingleLineComment = false))
+      else go(sourceWithMarker.marker)
+    }
+
+    def consumeInBrackets(open: Char, close: Char) = Movement { (sourceWithMarker, forward) =>
+      val (br1, br2) = if (forward) (open, close) else (close, open)
+      if (sourceWithMarker.isDepleted || sourceWithMarker.current != br1) {
+        None
+      } else {
+        val eventuallyReversedCommentsAndSpaces = {
+          if (forward) commentsAndSpaces
+          else commentsAndSpaces.backward
+        }
+
+        @tailrec
+        def go(m: Int): Option[Int] = {
+          val mm = sourceWithMarker.copy(marker = m).moveMarker(eventuallyReversedCommentsAndSpaces).marker
+          if (wouldBeDepleted(mm, sourceWithMarker)) {
+            None
+          } else {
+            val nm = if (mm == m) nextMarker(mm, forward) else mm
+            if(sourceWithMarker.source(nm) == br2) Some(nextMarker(nm, forward))
+            else go(nm)
+          }
+        }
+
+        go(nextMarker(sourceWithMarker.marker, forward))
+      }
+    }
+
+    val space: Movement = consumeSpace
+    val spaces: Movement = consumeSpace.zeroOrMore
+    val comments: Movement = (consumeComment ~ spaces).zeroOrMore
+    val commentsAndSpaces: Movement = (spaces ~ comments).zeroOrMore
+    val bracketsWithContents = consumeInBrackets('[', ']')
+
+    implicit def charToMovement(c: Char) = consumeChar(c)
+    implicit def stringToMovement(str: String)  = consumeString(str)
   }
 
   object MovementHelpers {

--- a/src/main/scala/scala/tools/refactoring/util/SourceWithMarker.scala
+++ b/src/main/scala/scala/tools/refactoring/util/SourceWithMarker.scala
@@ -297,7 +297,7 @@ object SourceWithMarker {
   object Movements {
     import MovementHelpers._
 
-    class SingleCharMovement(private val acceptChar: Char => Boolean, private val forward: Boolean = true) extends Movement {
+    class SingleCharMovement(private val acceptChar: Int => Boolean, private val forward: Boolean = true) extends Movement {
       final override def apply(sourceWithMarker: SourceWithMarker): Option[Int] = {
         if (sourceWithMarker.isDepleted || !acceptChar(sourceWithMarker.current)) None
         else Some(nextMarker(sourceWithMarker.marker, forward))
@@ -312,6 +312,15 @@ object SourceWithMarker {
       final def butNot(mvnt: SingleCharMovement): SingleCharMovement = {
         new SingleCharMovement(c => acceptChar(c) && !mvnt.acceptChar(c))
       }
+    }
+
+    private implicit class CharacterOps(val underlying: Int) extends AnyVal {
+      def getType = Character.getType(underlying)
+      def isUpper = Character.isUpperCase(underlying)
+      def isLower = Character.isLowerCase(underlying)
+      def isTitleCase = Character.isTitleCase(underlying)
+      def isDigit = Character.isDigit(underlying)
+      def isControl = Character.isISOControl(underlying)
     }
 
     val any = new SingleCharMovement(_ => true)
@@ -445,7 +454,7 @@ object SourceWithMarker {
       go()
     }
 
-    def charOfClass(inClass: Char => Boolean) = new SingleCharMovement(inClass)
+    def charOfClass(inClass: Int => Boolean) = new SingleCharMovement(inClass)
 
     val space = charOfClass { c =>
       c == '\u0020' || c == '\u0009' || c == '\u000D' || c == '\u000A'
@@ -458,7 +467,7 @@ object SourceWithMarker {
       }
     }
 
-    val digit = charOfClass(_.isDigit)
+    val digit = charOfClass(c => c.isDigit)
 
     val bracket = charOfClass { c =>
       c == '(' || c == ')' || c == '[' || c == ']' || c == '{' || c == '}'

--- a/src/main/scala/scala/tools/refactoring/util/SourceWithMarker.scala
+++ b/src/main/scala/scala/tools/refactoring/util/SourceWithMarker.scala
@@ -478,6 +478,8 @@ object SourceWithMarker {
 
     val symbolLiteral = ''' ~ plainid
 
+    val literalIdentifier = '`' ~ any.butNot('`').atLeastOnce ~ '`'
+
     val spaces: Movement = space.zeroOrMore
     val comments: Movement = (comment ~ spaces).zeroOrMore
     val commentsAndSpaces: Movement = (spaces ~ comments).zeroOrMore

--- a/src/main/scala/scala/tools/refactoring/util/SourceWithMarker.scala
+++ b/src/main/scala/scala/tools/refactoring/util/SourceWithMarker.scala
@@ -300,7 +300,7 @@ object SourceWithMarker {
     /**
      * A specialized implementation that matches single characters
      *
-     * Note the we represent characters as ints to avoid needles boxing ([[Function1]] is not specialized for [[Char]]).
+     * Note the we represent characters as ints to avoid needless boxing ([[Function1]] is not specialized for [[Char]]).
      */
     class SingleCharMovement(private val acceptChar: Int => Boolean, private val forward: Boolean = true) extends Movement {
       final override def apply(sourceWithMarker: SourceWithMarker): Option[Int] = {

--- a/src/main/scala/scala/tools/refactoring/util/SourceWithMarker.scala
+++ b/src/main/scala/scala/tools/refactoring/util/SourceWithMarker.scala
@@ -291,6 +291,13 @@ object SourceWithMarker {
     }
   }
 
+  /**
+   * Various movements related to Scala code
+   *
+   * Take a look at the
+   * [[http://www.scala-lang.org/files/archive/spec/2.11/01-lexical-syntax.html  Scala Language Specification]]
+   * if you wonder about terms like ''plainid'', ''idrest'' or ''varid''.
+   */
   object Movements {
     import MovementHelpers._
 

--- a/src/main/scala/scala/tools/refactoring/util/SourceWithMarker.scala
+++ b/src/main/scala/scala/tools/refactoring/util/SourceWithMarker.scala
@@ -114,7 +114,7 @@ object SourceWithMarker {
    * The difference between a [[SimpleMovement]] and a [[Movement]] is that [[SimpleMovement]]
    * is missing the `backward` method. Apart from that, the documentation for [[Movement]] applies.
    * Note that ''movements'' can be combined with ''simple movements'', so there is no need to
-   * implement `backward` unless you need it.
+   * implement a full movement unless you need it.
    */
   trait SimpleMovement { self =>
     def apply(sourceWithMarker: SourceWithMarker): Option[Int]

--- a/src/main/scala/scala/tools/refactoring/util/SourceWithMarker.scala
+++ b/src/main/scala/scala/tools/refactoring/util/SourceWithMarker.scala
@@ -5,6 +5,7 @@ import java.util.Arrays
 import scala.collection.immutable.SortedMap
 import scala.language.implicitConversions
 import scala.reflect.internal.util.RangePosition
+import scala.collection.SeqView
 
 /**
  * Represents source code with a movable marker.
@@ -12,7 +13,7 @@ import scala.reflect.internal.util.RangePosition
  * @see [[SourceWithMarker.Movement]]
  * @see [[SourceWithMarker.Movements]]
  */
-final case class SourceWithMarker(source: Array[Char] = Array(), marker: Int = 0) {
+final case class SourceWithMarker(source: IndexedSeq[Char] = IndexedSeq(), marker: Int = 0) {
   import SourceWithMarker._
 
   assertLegalState()
@@ -75,11 +76,13 @@ final case class SourceWithMarker(source: Array[Char] = Array(), marker: Int = 0
     require(marker >= -1 && marker <= source.length, s"Marker out of bounds: $marker")
   }
 
-  private def nextChars(n: Int): Option[IndexedSeq[Char]] = {
+  private def emptyView = IndexedSeq.empty[Char].view(0, 0)
+
+  private def nextChars(n: Int): Option[SeqView[Char, IndexedSeq[Char]]] = {
     if (isDepleted) {
       None
     } else if (n == 0) {
-      Some(IndexedSeq())
+      Some(emptyView)
     } else {
       val m = marker + n
       if (n > 0 && m <= length) Some(source.view(marker + 1, m + 1))

--- a/src/main/scala/scala/tools/refactoring/util/SourceWithMarker.scala
+++ b/src/main/scala/scala/tools/refactoring/util/SourceWithMarker.scala
@@ -203,12 +203,12 @@ object SourceWithMarker {
   object Movements {
     import MovementHelpers._
 
-    def consumeChar(c: Char) = Movement { (sourceWithMarker, forward) =>
+    def chararcter(c: Char) = Movement { (sourceWithMarker, forward) =>
       if (sourceWithMarker.current == c) Some(nextMarker(sourceWithMarker.marker, forward))
       else None
     }
 
-    def consumeString(str: String) = Movement { (sourceWithMarker, forward) =>
+    def string(str: String) = Movement { (sourceWithMarker, forward) =>
       def strAt(i: Int) = {
         if (forward) str.charAt(i)
         else str.charAt(str.length - 1 - i)
@@ -229,12 +229,12 @@ object SourceWithMarker {
       go(sourceWithMarker.marker)
     }
 
-    val consumeSpace = Movement { (sourceWithMarker, forward) =>
+    val space = Movement { (sourceWithMarker, forward) =>
       if (sourceWithMarker.current.isWhitespace) Some(nextMarker(sourceWithMarker.marker, forward))
       else None
     }
 
-    val consumeComment = Movement { (sourceWithMarker, forward) =>
+    val comment = Movement { (sourceWithMarker, forward) =>
       @tailrec
       def go(m: Int, inSingleLineComment: Boolean = false, inMultilineComment: Int = 0, slashSeen: Boolean = false, starSeen: Boolean = false): Option[Int] = {
         if (wouldBeDepleted(m, sourceWithMarker)) {
@@ -278,7 +278,7 @@ object SourceWithMarker {
       else go(sourceWithMarker.marker)
     }
 
-    def consumeInBrackets(open: Char, close: Char) = Movement { (sourceWithMarker, forward) =>
+    def inBrackets(open: Char, close: Char) = Movement { (sourceWithMarker, forward) =>
       val (br1, br2) = if (forward) (open, close) else (close, open)
       if (sourceWithMarker.isDepleted || sourceWithMarker.current != br1) {
         None
@@ -304,14 +304,13 @@ object SourceWithMarker {
       }
     }
 
-    val space: Movement = consumeSpace
-    val spaces: Movement = consumeSpace.zeroOrMore
-    val comments: Movement = (consumeComment ~ spaces).zeroOrMore
+    val spaces: Movement = space.zeroOrMore
+    val comments: Movement = (comment ~ spaces).zeroOrMore
     val commentsAndSpaces: Movement = (spaces ~ comments).zeroOrMore
-    val bracketsWithContents = consumeInBrackets('[', ']')
+    val bracketsWithContents = inBrackets('[', ']')
 
-    implicit def charToMovement(c: Char) = consumeChar(c)
-    implicit def stringToMovement(str: String)  = consumeString(str)
+    implicit def charToMovement(c: Char) = chararcter(c)
+    implicit def stringToMovement(str: String)  = string(str)
   }
 
   object MovementHelpers {

--- a/src/main/scala/scala/tools/refactoring/util/SourceWithMarker.scala
+++ b/src/main/scala/scala/tools/refactoring/util/SourceWithMarker.scala
@@ -498,6 +498,7 @@ object SourceWithMarker {
     val comments: Movement = (comment ~ spaces).zeroOrMore
     val commentsAndSpaces: Movement = (spaces ~ comments).zeroOrMore
     val bracketsWithContents = inBrackets('[', ']')
+    val curlyBracesWithContents = inBrackets('{', '}')
 
     implicit def charToMovement(c: Char): Movement = chararcter(c)
     implicit def stringToMovement(str: String): Movement  = string(str)

--- a/src/main/scala/scala/tools/refactoring/util/SourceWithMarker.scala
+++ b/src/main/scala/scala/tools/refactoring/util/SourceWithMarker.scala
@@ -297,6 +297,11 @@ object SourceWithMarker {
   object Movements {
     import MovementHelpers._
 
+    /**
+     * A specialized implementation that matches single characters
+     *
+     * Note the we represent characters as ints to avoid needles boxing ([[Function1]] is not specialized for [[Char]]).
+     */
     class SingleCharMovement(private val acceptChar: Int => Boolean, private val forward: Boolean = true) extends Movement {
       final override def apply(sourceWithMarker: SourceWithMarker): Option[Int] = {
         if (sourceWithMarker.isDepleted || !acceptChar(sourceWithMarker.current)) None

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
@@ -2165,4 +2165,18 @@ class Blubb
     }
     """
   } applyRefactoring(renameTo("notBuggy"))
+
+  @Test
+  def testRenameInCaseClassWithCopy100254Ex8() = new FileSet {
+    """
+    case class Bug8(`i=j`: Int = 667, `i`: Int = 23) {
+      def /*(*/buggy/*)*/ = copy(`i=j`=666,`i`=1)
+    }
+    """ becomes
+    """
+    case class Bug8(`i=j`: Int = 667, `i`: Int = 23) {
+      def /*(*/notBuggy/*)*/ = copy(`i=j`=666,`i`=1)
+    }
+    """
+  } applyRefactoring(renameTo("notBuggy"))
 }

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
@@ -2062,4 +2062,21 @@ class Blubb
     }
     """
   } applyRefactoring(renameTo("xxx"))
+
+  /*
+   * See Assembla Ticket #1002540
+   */
+  @Test
+  def testRenameInCaseClassWithCopy1002540() = new FileSet {
+    """
+    case class Bug(i: Int = 1, j: Int = 2) {
+      def /*(*/buggy/*)*/ = copy(j = i)
+    }
+    """ becomes
+    """
+    case class Bug(i: Int = 1, j: Int = 2) {
+      def /*(*/notBuggy/*)*/ = copy(j = i)
+    }
+    """
+  } applyRefactoring(renameTo("notBuggy"))
 }

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
@@ -2179,4 +2179,24 @@ class Blubb
     }
     """
   } applyRefactoring(renameTo("notBuggy"))
+
+  @Test
+  def testRenameInCaseClassWithCopy100254Ex9() = new FileSet {
+    """
+    case class Bug9(i: Int, j: Int) {
+      def /*(*/buggy/*)*/ = copy(j = {
+        val i = 3
+        i
+      })
+    }
+    """ becomes
+    """
+    case class Bug9(i: Int, j: Int) {
+      def /*(*/notBuggy/*)*/ = copy(j = {
+        val i = 3
+        i
+      })
+    }
+    """
+  } applyRefactoring(renameTo("notBuggy"))
 }

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
@@ -2149,4 +2149,20 @@ class Blubb
     }
     """
   } applyRefactoring(renameTo("notBuggy"))
+
+  @Test
+  def testRenameInCaseClassWithCopy100254Ex7() = new FileSet {
+    """
+    case class Bug7(i: Int = 1, j: Int = 2) {
+      private val `i=3` = 666
+      def /*(*/buggy/*)*/ = copy(j = /*i*/`i=3`, i = /*j*/1)
+    }
+    """ becomes
+    """
+    case class Bug7(i: Int = 1, j: Int = 2) {
+      private val `i=3` = 666
+      def /*(*/notBuggy/*)*/ = copy(j = /*i*/`i=3`, i = /*j*/1)
+    }
+    """
+  } applyRefactoring(renameTo("notBuggy"))
 }

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
@@ -2067,7 +2067,7 @@ class Blubb
    * See Assembla Ticket #1002540
    */
   @Test
-  def testRenameInCaseClassWithCopy1002540() = new FileSet {
+  def testRenameInCaseClassWithCopy1002540Ex1() = new FileSet {
     """
     case class Bug(i: Int = 1, j: Int = 2) {
       def /*(*/buggy/*)*/ = copy(j = i)
@@ -2076,6 +2076,76 @@ class Blubb
     """
     case class Bug(i: Int = 1, j: Int = 2) {
       def /*(*/notBuggy/*)*/ = copy(j = i)
+    }
+    """
+  } applyRefactoring(renameTo("notBuggy"))
+
+  @Test
+  def testRenameInCaseClassWithCopy100254Ex2() = new FileSet {
+    """
+    case class Bug2(s1: String = "", s2: String = "") {
+      def /*(*/buggy/*)*/ = copy(s2 = "s1", s1 = "s2")
+    }
+    """ becomes
+    """
+    case class Bug2(s1: String = "", s2: String = "") {
+      def /*(*/notBuggy/*)*/ = copy(s2 = "s1", s1 = "s2")
+    }
+    """
+  } applyRefactoring(renameTo("notBuggy"))
+
+  @Test
+  def testRenameInCaseClassWithCopy100254Ex3() = new FileSet {
+    """
+    case class Bug3(s1: String = "", s2: String = "", ss1: String = "", ss2: String = "") {
+      def /*(*/buggy/*)*/ = copy(s2 = ss1, s1 = ss2)
+    }
+    """ becomes
+    """
+    case class Bug3(s1: String = "", s2: String = "", ss1: String = "", ss2: String = "") {
+      def /*(*/notBuggy/*)*/ = copy(s2 = ss1, s1 = ss2)
+    }
+    """
+  } applyRefactoring(renameTo("notBuggy"))
+
+  @Test
+  def testRenameInCaseClassWithCopy100254Ex4() = new FileSet {
+    """
+    case class Bug4(i: Int = 1, j: Int = 2, `i!`: Int = 3, `j!`: Int = 4) {
+      def /*(*/buggy/*)*/ = copy(j = `i!`, i = `j!`)
+    }
+    """ becomes
+    """
+    case class Bug4(i: Int = 1, j: Int = 2, `i!`: Int = 3, `j!`: Int = 4) {
+      def /*(*/notBuggy/*)*/ = copy(j = `i!`, i = `j!`)
+    }
+    """
+  } applyRefactoring(renameTo("notBuggy"))
+
+  @Test
+  def testRenameInCaseClassWithCopy100254Ex5() = new FileSet {
+    """
+    case class Bug5(i: Int = 1, j: Int = 2) {
+      def /*(*/buggy/*)*/ = copy(j = i, i = j)
+    }
+    """ becomes
+    """
+    case class Bug5(i: Int = 1, j: Int = 2) {
+      def /*(*/notBuggy/*)*/ = copy(j = i, i = j)
+    }
+    """
+  } applyRefactoring(renameTo("notBuggy"))
+
+  @Test
+  def testRenameInCaseClassWithCopy100254Ex6() = new FileSet {
+    """
+    case class Bug6(i: Int = 1, j: Int = 2) {
+      def /*(*/buggy/*)*/ = copy(j = /*i*/0, i = /*j*/1)
+    }
+    """ becomes
+    """
+    case class Bug6(i: Int = 1, j: Int = 2) {
+      def /*(*/notBuggy/*)*/ = copy(j = /*i*/0, i = /*j*/1)
     }
     """
   } applyRefactoring(renameTo("notBuggy"))

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
@@ -680,4 +680,26 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
     """
   } applyRefactoring organizeWithTypicalParams
 
+  /*
+   * See Assembla Ticket #1002540
+   */
+  @Test
+  def dontFailForCaseClassWithCopy1002540() = new FileSet {
+    """
+    package test
+    import java.net.URL
+
+    case class Bug(i: Int = 1, j: Int = 2) {
+      def buggy = copy(j = i)
+    }
+    """ becomes
+    """
+    package test
+
+    case class Bug(i: Int = 1, j: Int = 2) {
+      def buggy = copy(j = i)
+    }
+    """
+  } applyRefactoring organizeWithTypicalParams
+
 }

--- a/src/test/scala/scala/tools/refactoring/tests/util/SourceWithMarkerTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/util/SourceWithMarkerTest.scala
@@ -128,11 +128,6 @@ class SourceWithMarkerTest {
     assertTrue(src.moveMarker((("private" | "protected") ~ commentsAndSpaces ~ bracketsWithContents).backward).isDepleted)
   }
 
-  @Test(expected = classOf[IllegalArgumentException])
-  def testCtorWithTooLargeMarker() {
-    SourceWithMarker(IndexedSeq(), 1)
-  }
-
   val mvntsToTestAtEndOfString = {
     val mvnts =
       characterLiteral ::

--- a/src/test/scala/scala/tools/refactoring/tests/util/SourceWithMarkerTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/util/SourceWithMarkerTest.scala
@@ -130,7 +130,7 @@ class SourceWithMarkerTest {
 
   @Test(expected = classOf[IllegalArgumentException])
   def testCtorWithTooLargeMarker() {
-    SourceWithMarker(Array(), 1)
+    SourceWithMarker(IndexedSeq(), 1)
   }
 
   val mvntsToTestAtEndOfString = {
@@ -291,7 +291,6 @@ class SourceWithMarkerTest {
     }
   }
 
-  private implicit def stringToCharArray(str: String): Array[Char] = str.toCharArray
   private implicit class SourceWithMarkerOps(underlying: SourceWithMarker) {
     def withMarkerOnLastChar = underlying.copy(marker = underlying.source.length - 1)
   }

--- a/src/test/scala/scala/tools/refactoring/tests/util/SourceWithMarkerTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/util/SourceWithMarkerTest.scala
@@ -137,6 +137,88 @@ class SourceWithMarkerTest {
     assertTrue(SourceWithMarker().isDepleted)
   }
 
+  @Test
+  def testCharConst() {
+    val src1 = SourceWithMarker("(a='b',b=''',c='\'',e='s)")
+    val baseMvnt1 = '(' ~ "a=" ~ characterLiteral ~ ",b=" ~ characterLiteral ~ ",c=" ~ characterLiteral ~ ",e="
+
+    assertEquals("'", src1.moveMarker(baseMvnt1).current.toString)
+    assertEquals("(", src1.moveMarker(baseMvnt1 ~ characterLiteral).current.toString)
+    assertTrue(src1.moveMarker(baseMvnt1 ~ "'s)").isDepleted)
+
+    val src2 = SourceWithMarker("""'\222'x''';'\b'°'\\'''\"'::""")
+    val baseMvnt2 = (characterLiteral ~ any).zeroOrMore
+
+    assertEquals(":", src2.moveMarker(baseMvnt2).current.toString)
+    assertEquals("'", src2.moveMarker(baseMvnt2 ~ (any ~ characterLiteral ~ any).backward).current.toString)
+  }
+
+  @Test
+  def testNtimes() {
+    val src = SourceWithMarker("aaaa")
+    assertTrue(src.moveMarker('a'.nTimes(4)).isDepleted)
+    assertFalse(src.moveMarker('a'.nTimes(3)).isDepleted)
+  }
+
+  @Test
+  def testOpChar() {
+    val src = SourceWithMarker("+-/*:><!~^\u03f6.")
+    assertEquals("~", src.moveMarker(opChar.zeroOrMore ~ (opChar.nTimes(2) ~ '.').backward).current.toString)
+  }
+
+  @Test
+  def testUntilWithSimpleExamples() {
+    val src = SourceWithMarker("0123456789")
+    assertEquals("5", src.moveMarker(until("5")).current.toString)
+    assertEquals("0", src.moveMarker(until("5", skipping = digit)).current.toString)
+  }
+
+  @Test
+  def testStringLiteral() {
+    val trippleQuote = "\"\"\""
+
+    val src1 = SourceWithMarker(s"""$trippleQuote a $trippleQuote""")
+    assertTrue(src1.moveMarker(stringLiteral).isDepleted)
+
+    val src2 = SourceWithMarker(raw"""
+      $trippleQuote
+      asdfasdfadsf
+      ""
+      asdfasdf
+      $trippleQuote
+      "asdf\""
+      "\n"
+      "\t\"\"";
+    """)
+
+    val mvnt2 = (spaces ~ stringLiteral ~ spaces).atLeastOnce
+    assertEquals(";", src2.moveMarker(mvnt2).current.toString)
+  }
+
+  @Test
+  def testUntilWithTypicalExamples() {
+    def untilVal(name: String) = until(name ~ spaces ~ "=", skipping = characterLiteral | symbolLiteral | stringLiteral | comment)
+
+    val src1 = SourceWithMarker("(j = i, i = j)")
+    val src2 = SourceWithMarker("""(j = "i = 2;", i = "v = 2"/*k=2*/,k=l)""")
+
+    val trippleQuote = "\"\"\""
+    val src3 = SourceWithMarker(s"""(a = $trippleQuote
+      b = 0
+      c = 0
+      e = 0
+      $trippleQuote, b = 'd_=, c = 'd', d= 3)
+    )""")
+
+    assertEquals("i", src1.moveMarker(untilVal("j") ~ any.nTimes(4)).current.toString)
+    assertEquals("j", src1.moveMarker(untilVal("i") ~ any.nTimes(4)).current.toString)
+
+    assertEquals("v", src2.moveMarker(untilVal("i") ~ any.nTimes(5)).current.toString)
+    assertEquals("l", src2.moveMarker(untilVal("k") ~ any.nTimes(2)).current.toString)
+
+    assertEquals("3", src3.moveMarker(untilVal("d") ~ any.nTimes(3)).current.toString)
+  }
+
   private implicit def stringToCharArray(str: String): Array[Char] = str.toCharArray
   private implicit class SourceWithMarkerOps(underlying: SourceWithMarker) {
     def withMarkerOnLastChar = underlying.copy(marker = underlying.source.length - 1)

--- a/src/test/scala/scala/tools/refactoring/tests/util/SourceWithMarkerTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/util/SourceWithMarkerTest.scala
@@ -89,7 +89,7 @@ class SourceWithMarkerTest {
 
     val moveToBracketOpen = "protected" ~ commentsAndSpaces
     val moveToBracketClose = moveToBracketOpen ~ bracketsWithContents ~ '/'.backward
-    val moveToStartOfMultilineComment = moveToBracketClose ~ ']' ~ (new ConsumeComment) ~ spaces
+    val moveToStartOfMultilineComment = moveToBracketClose ~ ']' ~ (consumeComment) ~ spaces
     val moveToEndOfMultilineComment = moveToStartOfMultilineComment ~ comments ~ (spaces ~ 'o').backward
     val moveToVal = moveToBracketClose ~ ']' ~ commentsAndSpaces ~ "override" ~ commentsAndSpaces
 

--- a/src/test/scala/scala/tools/refactoring/tests/util/SourceWithMarkerTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/util/SourceWithMarkerTest.scala
@@ -89,7 +89,7 @@ class SourceWithMarkerTest {
 
     val moveToBracketOpen = "protected" ~ commentsAndSpaces
     val moveToBracketClose = moveToBracketOpen ~ bracketsWithContents ~ '/'.backward
-    val moveToStartOfMultilineComment = moveToBracketClose ~ ']' ~ (consumeComment) ~ spaces
+    val moveToStartOfMultilineComment = moveToBracketClose ~ ']' ~ (comment) ~ spaces
     val moveToEndOfMultilineComment = moveToStartOfMultilineComment ~ comments ~ (spaces ~ 'o').backward
     val moveToVal = moveToBracketClose ~ ']' ~ commentsAndSpaces ~ "override" ~ commentsAndSpaces
 

--- a/src/test/scala/scala/tools/refactoring/tests/util/SourceWithMarkerTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/util/SourceWithMarkerTest.scala
@@ -213,7 +213,8 @@ class SourceWithMarkerTest {
   def testUntilWithSimpleExamples() {
     val src = SourceWithMarker("0123456789")
     assertEquals("5", src.moveMarker(until("5")).current.toString)
-    assertEquals("0", src.moveMarker(until("5", skipping = digit)).current.toString)
+    assertEquals("5", src.moveMarker(until("5", skipping = digit)).current.toString)
+    assertEquals("0", src.moveMarker(until("5", skipping = digit.zeroOrMore)).current.toString)
   }
 
   @Test


### PR DESCRIPTION
##### Summary

As outlined in [Ticket #1002540](https://scala-ide-portfolio.assembla.com/spaces/scala-ide/tickets/1002540), the extraction of named arguments in `PimpedTrees.BlockExtractor.unapply.fixNamedArgumentCall` was overly simplistic, which led to tickets like [#1002540](https://scala-ide-portfolio.assembla.com/spaces/scala-ide/tickets/1002540). This PR can be divided roughly into two parts: The first part is about extending the functionality around `SourceWithMarker`. The second part puts the new functionality into use by fixing `PimpedTrees.BlockExtractor.unapply.fixNamedArgumentCall`.

##### The Big Picture

I'm well aware of the fact, that we wouldn't have to deal with these subtitles, if named parameters could be obtained from the ASTs. This topic has already been discussed, and I'm still planning to add this feature to the presentation compiler if no one else steps up sooner or later. At the moment I've other priorities though, since there are so many things within the library itself that need attention. Also, even if we had a tweaked presentation compiler right now, we still would need a sane fallback solution for older versions.

##### A few notes on `SimpleMovement`

When I started extending the APIs around `SourceWithMarker` it soon became clear that didn't need bidirectional movements as they are represented by `SourceWithMarker` for fixing  [Ticket #1002540](https://scala-ide-portfolio.assembla.com/spaces/scala-ide/tickets/1002540). Thus I had 3 choices:

1. Implement `Movement.backwards` for newly added classes, even though I wouldn't need it for the time being.
2. Implement the full `Movements` where backwards fails at runtime, like `def backwards = ???`
3. Introduce unidirectional movements, aka simple movements, that can be safely combined with regular movements.

Option 2. would have certainly been the easiest implementation wise, but having runtime failures for something that could clearly be proven wrong by static analysis didn't seam very appealing to me. I didn't go for option 1. because I didn't want to add unused code, just because of self imposed API constraints. Thus I went with 3. and introduced `SimpleMovement`. The disadvantage of this approach is that it complicates some parts of the code a bit, and also introduces some repetition here and there that I'm not particularly proud of. I suspect that this could be done more elegantly... so if you have any suggestions I would highly appreciate them!

##### Outlook

~~I'm planning to replace the implementation of `SourceUtils.countRelevantBrackets`, that has been correctly been named  'imperative monster', by something much shorter based on `SourceWithMarker`.~~
I tried replacing `SourceUtils.countRelevantBrackets` with an implementation based on `SourceWithMarker`. The code looks good and works, but maybe not surprisingly, it performs much worse that the 'imperative monster' we currently have. I was able to get the performance penalty down to about 300% (starting at 1700%) by applying various optimizations - most of them related to `SourceWithMarker`. I might get this down to 200%, but I don't think it's worth the effort. My suggestion is to leave the 'imperative monster' as is for the time being, even though 300% performance penalty might not matter for the code in question. The optimizations that have been performed to `SourceWithMarker` might still pay off in the future...

