### PR TITLE
Don't remove return times on rename refactorings

### DIFF
--- a/src/main/scala/scala/tools/refactoring/sourcegen/ReusingPrinter.scala
+++ b/src/main/scala/scala/tools/refactoring/sourcegen/ReusingPrinter.scala
@@ -981,8 +981,17 @@ trait ReusingPrinter extends TreePrintingTraversals with AbstractPrinter {
 
       def existsTptInFile = tpt match {
         case tpt: TypeTree =>
-          lazy val textInFile = betweenStartAndEnd(tpt).asText
-          tpt.pos.isRange && (textInFile == tpt.toString() || textInFile == tpt.original.toString())
+          def tpeInFileIsUnit = betweenStartAndEnd(tpt).asText == "Unit"
+          def tpeIsUnit = tpt.toString == "Unit"
+
+          // This check handles the special case where a method with a non unit return type
+          // is overriden by a method without a return type, which is not legal Scala of course.
+          // It's not entirely clear to me why we need to handle this case, but there is a unit test
+          // that checks for this explicitly: ReusingPrinterTest.add_modifier_to_def_without_return_type
+          def tpeIsntFromOverrideWithMissingRetType = (tpeInFileIsUnit == tpeIsUnit)
+
+          tpt.pos.isRange && tpeIsntFromOverrideWithMissingRetType
+
         case _ => false
       }
 

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
@@ -2199,4 +2199,81 @@ class Blubb
     }
     """
   } applyRefactoring(renameTo("notBuggy"))
+
+  /*
+   * See Assembla Ticket 1002560
+   */
+  @Test
+  def testRenameTraitMethod1002560Ex1() = new FileSet {
+    """
+    package test
+
+    trait Bug {
+      def /*(*/renameMe/*)*/: Seq[Bug]
+    }
+    """ becomes
+    """
+    package test
+
+    trait Bug {
+      def /*(*/ups/*)*/: Seq[Bug]
+    }
+    """
+  } applyRefactoring(renameTo("ups"))
+
+  @Test
+  def testRenameTraitMethod1002560Ex2() = new FileSet {
+    """
+    trait Bug2 {
+      def /*(*/renameMe/*)*/: Map[Int, Int]
+    }
+    """ becomes
+    """
+    trait Bug2 {
+      def /*(*/ups/*)*/: Map[Int, Int]
+    }
+    """
+  } applyRefactoring(renameTo("ups"))
+
+  @Test
+  def testRenameTraitMethod1002560Ex3() = new FileSet {
+    """
+    trait Bug3 {
+      def /*(*/renameMe/*)*/: Seq[/**/Int]
+    }
+    """ becomes
+    """
+    trait Bug3 {
+      def /*(*/ups/*)*/: Seq[/**/Int]
+    }
+    """
+  } applyRefactoring(renameTo("ups"))
+
+  @Test
+  def testRenameTraitMethod1002560Ex4() = new FileSet {
+    """
+    trait Bug4 {
+      def /*(*/renameMe/*)*/: Seq[Int ]
+    }
+    """ becomes
+    """
+    trait Bug4 {
+      def /*(*/ups/*)*/: Seq[Int ]
+    }
+    """
+  } applyRefactoring(renameTo("ups"))
+
+  @Test
+  def testRenameTraitMethod1002560Ex5() = new FileSet {
+    """
+    trait Bug5 {
+      def /*(*/renameMe/*)*/: Seq[/**/ Int /* --- */ ]
+    }
+    """ becomes
+    """
+    trait Bug5 {
+      def /*(*/ups/*)*/: Seq[/**/ Int /* --- */ ]
+    }
+    """
+  } applyRefactoring(renameTo("ups"))
 }


### PR DESCRIPTION
This PR fixes [Ticket #1002560](https://www.assembla.com/spaces/scala-ide/tickets/1002560-rename-refactoring-removes-return-type). More information can be found in commit messages/comments.