### PR TITLE
Don't confuse `_*` with an ordinary type when organizing imports 

### DIFF
--- a/src/main/scala/scala/tools/refactoring/analysis/CompilationUnitDependencies.scala
+++ b/src/main/scala/scala/tools/refactoring/analysis/CompilationUnitDependencies.scala
@@ -348,7 +348,7 @@ trait CompilationUnitDependencies extends CompilerApiExtensions with ScalaVersio
                 case _ => ()
               }
 
-            case t: Ident if t.name != nme.EMPTY_PACKAGE_NAME =>
+            case t: Ident if t.name != nme.EMPTY_PACKAGE_NAME && t.name != tpnme.WILDCARD_STAR  =>
               tryFindTpeAndSymFor(t) match {
                 case Some((tpe, sym)) =>
                   fakeSelectTree(tpe, sym, t) match {

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
@@ -9,6 +9,7 @@ import implementations.OrganizeImports
 import tests.util.TestHelper
 import tests.util.TestRefactoring
 import language.reflectiveCalls
+import language.postfixOps
 
 class OrganizeImportsTest extends OrganizeImportsBaseTest {
 
@@ -706,7 +707,7 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
    * See Assembla Ticket #1002142
    */
   @Test
-  def organizeImportsAndVarargs1002142Ex1() = new FileSet {
+  def organizeImportsAndVarargs1002142Ex1() = new FileSet(expectCompilingCode = true) {
     """
     package com.github.mlangc.experiments
 
@@ -716,17 +717,25 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
       def values: Seq[HashMap[Int, Int]] = ???
       List(values: _*)
     }
-    """ becomes
+    """ isNotModified
+  } applyRefactoring organizeWithTypicalParams
+
+  @Test
+  def organizeImportsAndVarargs1002142Ex2() = new FileSet(expectCompilingCode = true) {
     """
-    package com.github.mlangc.experiments
+    import scala.collection.mutable.HashMap
 
-    import scala.collection.immutable.HashMap
-
-    object TryOrganizeImportsHere {
-      def values: Seq[HashMap[Int, Int]] = ???
-      List(values: _*)
+    object Y {
+     def values: List[HashMap[Int, Int]] = ???
     }
+    """ isNotModified;
     """
+    object X {
+
+      val xs = Y.values
+      List(xs: _*)
+    }
+    """ isNotModified
   } applyRefactoring organizeWithTypicalParams
 
 }

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
@@ -702,4 +702,31 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
     """
   } applyRefactoring organizeWithTypicalParams
 
+  /*
+   * See Assembla Ticket #1002142
+   */
+  @Test
+  def organizeImportsAndVarargs1002142Ex1() = new FileSet {
+    """
+    package com.github.mlangc.experiments
+
+    import scala.collection.immutable.HashMap
+
+    object TryOrganizeImportsHere {
+      def values: Seq[HashMap[Int, Int]] = ???
+      List(values: _*)
+    }
+    """ becomes
+    """
+    package com.github.mlangc.experiments
+
+    import scala.collection.immutable.HashMap
+
+    object TryOrganizeImportsHere {
+      def values: Seq[HashMap[Int, Int]] = ???
+      List(values: _*)
+    }
+    """
+  } applyRefactoring organizeWithTypicalParams
+
 }


### PR DESCRIPTION
Fixes [Ticket #1002142](https://www.assembla.com/spaces/scala-ide/tickets/1002142-organize-imports-erroneously-creates-imports-for-_*#/activity/ticket:).