### PR TITLE
Don't add imports to the wrong package

### DIFF
--- a/src/main/scala/scala/tools/refactoring/implementations/ImportsHelper.scala
+++ b/src/main/scala/scala/tools/refactoring/implementations/ImportsHelper.scala
@@ -11,7 +11,7 @@ trait ImportsHelper extends TracingImpl {
   import global._
 
   def addRequiredImports(importsUser: Option[Tree], targetPackageName: Option[String]) = traverseAndTransformAll {
-    locatePackageLevelImports &> transformation[(PackageDef, List[Import], List[Tree]), Tree] {
+    findBestPackageForImports &> transformation[(PackageDef, List[Import], List[Tree]), Tree] {
       case (pkg, existingImports, rest) => {
         val user = importsUser getOrElse pkg
         val targetPkgName = targetPackageName getOrElse pkg.nameString

--- a/src/main/scala/scala/tools/refactoring/implementations/OrganizeImports.scala
+++ b/src/main/scala/scala/tools/refactoring/implementations/OrganizeImports.scala
@@ -430,7 +430,7 @@ abstract class OrganizeImports extends MultiStageRefactoring with TreeFactory wi
 
     val participants = importStrategy ::: params.options
 
-    val organizeImports = locatePackageLevelImports &> transformation[(PackageDef, List[Import], List[Tree]), Tree] {
+    val organizeImports = findBestPackageForImports &> transformation[(PackageDef, List[Import], List[Tree]), Tree] {
       case (p, existingImports, others) =>
         val imports = scala.Function.chain(participants)(existingImports)
         p copy (stats = imports ::: others) replaces p

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/AddImportStatementTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/AddImportStatementTest.scala
@@ -387,4 +387,35 @@ object T
       }
       """)
   }
+
+  /*
+   * See Assembla Ticket #1002399
+   */
+  @Test
+  def importIsInsertedInWrongPackage1002399() = {
+    addImport(("a.b.c.actions", "ActionX"), """
+    package a.b.c
+
+    package actions {
+      class ActionX
+    }
+
+    class X {
+      val a: ActionX = null
+    }
+    """,
+    """
+    package a.b.c
+
+    import a.b.c.actions.ActionX
+
+    package actions {
+      class ActionX
+    }
+
+    class X {
+      val a: ActionX = null
+    }
+    """)
+  }
 }


### PR DESCRIPTION
Fixes [#1002399](https://scala-ide-portfolio.assembla.com/spaces/scala-ide/tickets/1002399-organize-imports-inserts-import-in-wrong-package-declaration). More details can be found in the comment that has been added to `TreeTransformations`.