### PR TITLE
 Fix a stupid error when setting modifier positions for lazy vals

### DIFF
--- a/src/main/scala/scala/tools/refactoring/analysis/SymbolExpanders.scala
+++ b/src/main/scala/scala/tools/refactoring/analysis/SymbolExpanders.scala
@@ -29,9 +29,11 @@ trait DependentSymbolExpanders extends TracingImpl {
     final def expand(s: Symbol): List[Symbol] = {
       doExpand(s).filterNot(_ == NoSymbol) \\ { res =>
         val debugInfo = {
-          if (res.map(_.pos).toSet == Set(NoPosition)) Seq()
+          val posSet = res.map(_.pos).toSet
+
+          if (posSet == Set(NoPosition)) Seq()
           else if (res == Seq(s)) Seq()
-          else res.map(elem => PositionDebugging.formatCompact(elem.pos))
+          else posSet.map(pos => PositionDebugging.formatCompact(pos))
         }
 
         if (debugInfo.nonEmpty) {

--- a/src/main/scala/scala/tools/refactoring/common/Selections.scala
+++ b/src/main/scala/scala/tools/refactoring/common/Selections.scala
@@ -98,7 +98,7 @@ trait Selections extends TreeTraverser with common.PimpedTrees {
     private def eventuallyFixModifierPositionsForLazyVals(t: Option[SymTree]): Option[SymTree] = t.map {
         case dd: DefDef if dd.mods.isLazy && dd.mods.positions.isEmpty =>
           val vd = root.find {
-            case vd: ValDef if vd.mods.isLazy && !vd.mods.positions.isEmpty && vd.pos.point == vd.pos.point => true
+            case vd: ValDef if vd.mods.isLazy && !vd.mods.positions.isEmpty && dd.pos.point == vd.pos.point => true
             case _ => false
           }
 

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
@@ -2376,4 +2376,79 @@ class Blubb
     }
     """ -> TaggedAsGlobalRename
   } prepareAndApplyRefactoring(prepareAndRenameTo("ups"))
+
+  /*
+   * See Assembla Ticket 1002569
+   */
+  @Test
+  def testRenameLazyConstants1002569Ex1() = new FileSet {
+    """
+    object Bug1 {
+      lazy val l = 1
+      lazy val /*(*/tryRenameMe/*)*/ = 2
+
+    }
+    """ becomes
+    """
+    object Bug1 {
+      lazy val l = 1
+      lazy val /*(*/renamed/*)*/ = 2
+
+    }
+    """ -> TaggedAsGlobalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("renamed"))
+
+  @Test
+  def testRenameLazyConstants1002569Ex2() = new FileSet {
+    """
+    package test
+
+    object Bug2 {
+      lazy val l1 = mkVal(1)
+      lazy val l2 = mkVal(2)
+      lazy val /*(*/tryRenameMe/*)*/ = mkVal(3)
+
+      def mkVal(i: Int) = i
+    }
+    """ becomes
+    """
+    package test
+
+    object Bug2 {
+      lazy val l1 = mkVal(1)
+      lazy val l2 = mkVal(2)
+      lazy val /*(*/renamed/*)*/ = mkVal(3)
+
+      def mkVal(i: Int) = i
+    }
+    """ -> TaggedAsGlobalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("renamed"))
+
+  @Test
+  def testRenameLazyConstants1002569Ex3() = new FileSet {
+    """
+    package com.github.mlangc.experiments
+
+    object Bystander {
+      lazy val l = "1"
+    }
+
+    object Bug3 {
+      lazy val l = 0
+      lazy val /*(*/tryRenameMe/*)*/ = 0
+    }
+    """ becomes
+    """
+    package com.github.mlangc.experiments
+
+    object Bystander {
+      lazy val l = "1"
+    }
+
+    object Bug3 {
+      lazy val l = 0
+      lazy val /*(*/renamed/*)*/ = 0
+    }
+    """ -> TaggedAsGlobalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("renamed"))
 }


### PR DESCRIPTION
This error was introduced in https://github.com/scala-ide/scala-refactoring/pull/78 although we discussed exactly this piece of code thoroughly ;-). Maybe there is compiler warning that would have pointed this out sooner?

Fixes [#1002569](https://www.assembla.com/spaces/scala-ide/tickets/1002569-renaming-lazy-constants-breaks-code#/activity/ticket:)