### PR TITLE
Don't break code when renaming lazy vals

### DIFF
--- a/src/main/scala/scala/tools/refactoring/common/Selections.scala
+++ b/src/main/scala/scala/tools/refactoring/common/Selections.scala
@@ -85,30 +85,12 @@ trait Selections extends TreeTraverser with common.PimpedTrees {
      * fully contains a SymTree, if true, the first selected is returned. Otherwise
      * the result of findSelectedOfType[SymTree] is returned.
      */
-    lazy val selectedSymbolTree = eventuallyFixModifierPositionsForLazyVals((root filter (cond(_) {
+    lazy val selectedSymbolTree = (root filter (cond(_) {
       case t: SymTree => contains(t)
     }) filter (t => t.pos.start < t.pos.end) match {
       case (x: SymTree) :: _ => Some(x)
       case _ => None
-    }) orElse findSelectedOfType[SymTree])
-
-    /*
-     * See #1002392 if you wonder why we need this
-     */
-    private def eventuallyFixModifierPositionsForLazyVals(t: Option[SymTree]): Option[SymTree] = t.map {
-        case dd: DefDef if dd.mods.isLazy && dd.mods.positions.isEmpty =>
-          val vd = root.find {
-            case vd: ValDef if vd.mods.isLazy && !vd.mods.positions.isEmpty && dd.pos.point == vd.pos.point => true
-            case _ => false
-          }
-
-          vd.map { vd =>
-            val nDd = dd.copy()
-            nDd.mods.setPositions(vd.asInstanceOf[ValDef].mods.positions)
-            nDd.copyAttrs(dd)
-          }.getOrElse(dd)
-        case other => other
-      }
+    }) orElse findSelectedOfType[SymTree]
 
     /**
      * Finds a selected tree by its type.

--- a/src/main/scala/scala/tools/refactoring/implementations/Rename.scala
+++ b/src/main/scala/scala/tools/refactoring/implementations/Rename.scala
@@ -53,6 +53,32 @@ abstract class Rename extends MultiStageRefactoring with TreeAnalysis with analy
   }
 
   def perform(selection: Selection, prepared: PreparationResult, newName: RefactoringParameters): Either[RefactoringError, List[Change]] = {
+    /*
+     * A lazy val is represented by a ValDef and an associated DefDef that contains the initialization code.
+     * Unfortunately, the Scala compiler does not set modifier positions for the DefDef, which is a problem for us,
+     * because we are relying on the DefDef when printing out source code. The following function patches the affected
+     * DefDefs accordingly.
+     *
+     * See #1002392 and #1002502
+     */
+    def eventuallyFixModifierPositionsForLazyVals(t: Tree): Unit = t match {
+      case dd: DefDef if dd.mods.isLazy && dd.mods.positions.isEmpty =>
+        val vd = selection.root.find {
+          case vd: ValDef if vd.mods.isLazy && !vd.mods.positions.isEmpty && dd.pos.point == vd.pos.point => true
+          case _ => false
+        }
+
+        vd.foreach { vd =>
+          // Note that we patch the DefDef in place because we need the correctly set positions in the tree
+          // later in the refactoring process. A precursor of this code pretended to be pure, by copying
+          // dd and then calling 'mods.setPositions' on the copy. This had exactly the same (needed) side effects
+          // however, as the Modifier object affected by setPositions was the same anyway. If you are interested
+          // in the related discussion, take a look at https://github.com/scala-ide/scala-refactoring/pull/78.
+          dd.mods.setPositions(vd.asInstanceOf[ValDef].mods.positions)
+        }
+
+      case _ => ()
+    }
 
     trace("Selected tree is %s", prepared.selectedTree)
 
@@ -60,7 +86,10 @@ abstract class Rename extends MultiStageRefactoring with TreeAnalysis with analy
 
     val occurences = index.occurences(sym)
 
-    occurences foreach (s => trace("Symbol is referenced at %s", PositionDebugging.formatCompact(s.pos)))
+    occurences.foreach { s =>
+      trace("Symbol is referenced at %s", PositionDebugging.formatCompact(s.pos))
+      eventuallyFixModifierPositionsForLazyVals(s)
+    }
 
     val isInTheIndex = filter {
       case t: Tree => occurences contains t

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
@@ -2451,4 +2451,33 @@ class Blubb
     }
     """ -> TaggedAsGlobalRename
   } prepareAndApplyRefactoring(prepareAndRenameTo("renamed"))
+
+  /*
+   * See Assembla Ticket 1002502
+   */
+  @Test
+  def testRenameWithOverridingLazyVal1002502Ex1() = new FileSet {
+    """
+    package com.github.mlangc.experiments
+
+    abstract class Bug {
+      def /*(*/renameMe/*)*/: Int
+    }
+
+    class Buggy extends Bug {
+      lazy val renameMe = 99
+    }
+    """ becomes
+    """
+    package com.github.mlangc.experiments
+
+    abstract class Bug {
+      def /*(*/x/*)*/: Int
+    }
+
+    class Buggy extends Bug {
+      lazy val x = 99
+    }
+    """ -> TaggedAsGlobalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("x"))
 }


### PR DESCRIPTION
Fixes [Ticket 1002502](https://scala-ide-portfolio.assembla.com/spaces/scala-ide/tickets/1002502-rename-breaks-overriding-lazy-vals/details#). More details can be found in the comments.