### PR TITLE
Don't break imports when renaming objects

### DIFF
--- a/src/main/scala/scala/tools/refactoring/sourcegen/ReusingPrinter.scala
+++ b/src/main/scala/scala/tools/refactoring/sourcegen/ReusingPrinter.scala
@@ -371,7 +371,7 @@ trait ReusingPrinter extends TreePrintingTraversals with AbstractPrinter {
           if (qualifier.pos.isRange && tree.pos.start < qualifier.pos.start && nameOrig.nameString.endsWith(":")) {
             l ++ _n ++ " " ++ _q ++ r
           } else if (startsWithChar && endsWithChar && hasNoSeparator) {
-            l ++ _q ++ " " ++ _n ++ r
+            l ++ _q ++ (if (!qualifier.isInstanceOf[Select]) " " else ".") ++ _n ++ r
           } else if (qualifierHasNoDot && _n.leading.contains(".")) {
             l ++ "(" ++ _q ++ ")" ++ _n ++ r
           } else if (hasClosingParensBetweenQualifierAndSelector) {

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
@@ -29,6 +29,46 @@ class RenameTest extends TestHelper with TestRefactoring {
     prepareAndRenameTo(name)(pro).changes
   }
 
+  /*
+   * See Assembla Ticket 1002537
+   */
+  @Test
+  def testRenameObjectWithInnerClass1002537Ex1() = new FileSet {
+    """
+    package com.github.mlangc.experiments
+
+    object /*(*/RenameMe/*)*/ {
+      class Class
+    }
+    """ becomes
+    """
+    package com.github.mlangc.experiments
+
+    object /*(*/X/*)*/ {
+      class Class
+    }
+    """ -> TaggedAsGlobalRename;
+
+    """
+    package com.github.mlangc.experiments.bug
+
+    import com.github.mlangc.experiments.RenameMe.Class
+
+    class Bug {
+      def x: Class = ???
+    }
+    """ becomes
+    """
+    package com.github.mlangc.experiments.bug
+
+    import com.github.mlangc.experiments.X.Class
+
+    class Bug {
+      def x: Class = ???
+    }
+    """
+  } prepareAndApplyRefactoring(prepareAndRenameTo("X"))
+
   @Test
   def renameOverlapping() = new FileSet {
     """


### PR DESCRIPTION
Fixes [#1002537](https://www.assembla.com/spaces/scala-ide/tickets/1002537-wrong-refactor--gt--rename-behavior/details#)