### PR TITLE
Fix two problems with printing trees related to default arguments

### DIFF
--- a/src/main/scala-2_10/scala/tools/refactoring/ScalaVersionsAdapter.scala
+++ b/src/main/scala-2_10/scala/tools/refactoring/ScalaVersionsAdapter.scala
@@ -1,12 +1,19 @@
 package scala.tools.refactoring
 
-import scala.tools.refactoring.common.CompilerApiExtensions
-
 object ScalaVersionAdapters {
-
-  trait CompilerApiAdapters { self: common.InteractiveScalaCompiler =>
+  trait CompilerApiAdapters {
+    val global: scala.tools.nsc.Global
     import global._
 
     def annotationInfoTree(info: AnnotationInfo): Tree = info.original
+
+    def isImplementationArtifact(sym: Symbol): Boolean = {
+      sym.isImplementationArtifact || {
+        // Unfortunatley, for Scala-2.10, we can not rely on `isImplementationArtifact`
+        // as this method might return wrong results. To mitigate this, we fall back to
+        // the hack below:
+        sym.name.toString.contains("$")
+      }
+    }
   }
 }

--- a/src/main/scala-2_11/scala/tools/refactoring/ScalaVersionsAdapter.scala
+++ b/src/main/scala-2_11/scala/tools/refactoring/ScalaVersionsAdapter.scala
@@ -1,10 +1,14 @@
 package scala.tools.refactoring
 
 object ScalaVersionAdapters {
-
-  trait CompilerApiAdapters { self: common.InteractiveScalaCompiler =>
+  trait CompilerApiAdapters {
+    val global: scala.tools.nsc.Global
     import global._
 
     def annotationInfoTree(info: AnnotationInfo): Tree = info.tree
+
+    def isImplementationArtifact(sym: Symbol): Boolean = {
+      sym.isImplementationArtifact
+    }
   }
 }

--- a/src/main/scala/scala/tools/refactoring/common/PimpedTrees.scala
+++ b/src/main/scala/scala/tools/refactoring/common/PimpedTrees.scala
@@ -416,7 +416,8 @@ trait PimpedTrees {
         if (t samePos tree) t :: l else l
       }
 
-      cuRoot(tree.pos).map(find).getOrElse(Nil)
+      val root = cuRoot(tree.pos)
+      root.map(find).getOrElse(Nil)
     }
   }
 

--- a/src/main/scala/scala/tools/refactoring/sourcegen/Layout.scala
+++ b/src/main/scala/scala/tools/refactoring/sourcegen/Layout.scala
@@ -44,6 +44,9 @@ trait Layout {
     override val trailing = self
     override val post = r
   }
+
+  def isEmpty: Boolean = asText.isEmpty
+  def nonEmpty: Boolean = !isEmpty
 }
 
 case object NoLayout extends Layout {

--- a/src/main/scala/scala/tools/refactoring/util/CompilerProvider.scala
+++ b/src/main/scala/scala/tools/refactoring/util/CompilerProvider.scala
@@ -73,13 +73,8 @@ trait TreeCreationMethods {
 
   val global: scala.tools.nsc.interactive.Global
 
-  val randomFileName = {
-    val r = new java.util.Random
-    () => "file" + r.nextInt
-  }
-
   protected def treeFromString(src: String, isJava: Boolean = false): global.Tree = {
-    val file = new BatchSourceFile(randomFileName() + (if (isJava) ".java" else ""), src)
+    val file = new BatchSourceFile(UniqueNames.basename() + (if (isJava) ".java" else ""), src)
     treeFrom(file)
   }
 

--- a/src/main/scala/scala/tools/refactoring/util/Memoized.scala
+++ b/src/main/scala/scala/tools/refactoring/util/Memoized.scala
@@ -7,6 +7,10 @@ package util
 
 object Memoized {
 
+   // Use this switch to temporarily turn of memoization for
+   // debugging purposes:
+  private val MemonizationEnabled = true
+
   /**
    *
    * Create a function that memoizes its results in a WeakHashMap.
@@ -26,42 +30,48 @@ object Memoized {
    * @param toMem The function we want to memoize.
    */
   def on[X, Y, Z](mkKey: X => Y)(toMem: X => Z): X => Z = {
+    if (!MemonizationEnabled) {
+      toMem
+    } else {
+      val cache = new java.util.WeakHashMap[Y, Z]
 
-    val cache = new java.util.WeakHashMap[Y, Z]
-
-    { (x: X) =>
-      val k = mkKey(x)
-      if(cache.containsKey(k)) {
-        val n = cache.get(k)
-        if(n == null) {
-          toMem(x)
+      (x: X) => {
+        val k = mkKey(x)
+        if(cache.containsKey(k)) {
+          val n = cache.get(k)
+          if(n == null) {
+            toMem(x)
+          } else {
+            n
+          }
         } else {
+          val n = toMem(x)
+          cache.put(k, n)
           n
         }
-      } else {
-        val n = toMem(x)
-        cache.put(k, n)
-        n
       }
     }
   }
 
   def apply[X, Z](toMem: X => Z): X => Z = {
+    if (!MemonizationEnabled) {
+      toMem
+    } else {
+      val cache = new java.util.WeakHashMap[X, Z]
 
-    val cache = new java.util.WeakHashMap[X, Z]
-
-    { (x: X) =>
-      if(cache.containsKey(x)) {
-        val n = cache.get(x)
-        if(n == null) {
-          toMem(x)
+      (x: X) => {
+        if(cache.containsKey(x)) {
+          val n = cache.get(x)
+          if(n == null) {
+            toMem(x)
+          } else {
+            n
+          }
         } else {
+          val n = toMem(x)
+          cache.put(x, n)
           n
         }
-      } else {
-        val n = toMem(x)
-        cache.put(x, n)
-        n
       }
     }
   }

--- a/src/main/scala/scala/tools/refactoring/util/SourceWithMarker.scala
+++ b/src/main/scala/scala/tools/refactoring/util/SourceWithMarker.scala
@@ -119,6 +119,13 @@ object SourceWithMarker {
     }
   }
 
+  implicit class SimpleMovementOps(val underlying: SimpleMovement) extends AnyVal {
+    def consumes(str: IndexedSeq[Char]): Boolean = {
+      val srcWithMarker = SourceWithMarker(str).moveMarker(underlying)
+      srcWithMarker.marker > -1 && srcWithMarker.isDepleted
+    }
+  }
+
   private object SimpleMovementHelpers {
     def sequence[MovementT <: SimpleMovement](mvnt1: MovementT, mvnt2: MovementT)(sourceWithMarker: SourceWithMarker): Option[Int] = {
       mvnt1(sourceWithMarker).map(newMarker => sourceWithMarker.copy(marker = newMarker)).flatMap(mvnt2.apply)

--- a/src/main/scala/scala/tools/refactoring/util/SourceWithMarker.scala
+++ b/src/main/scala/scala/tools/refactoring/util/SourceWithMarker.scala
@@ -92,13 +92,13 @@ object SourceWithMarker {
   trait SimpleMovement { self =>
     def apply(sourceWithMarker: SourceWithMarker): Option[Int]
 
-    final def ~(other: SimpleMovement): SimpleMovement = SimpleMovementOps.sequence(this, other) _
-    final def |(other: SimpleMovement): SimpleMovement = SimpleMovementOps.or(this, other) _
-    def zeroOrMore: SimpleMovement = SimpleMovementOps.repeat(this) _
+    final def ~(other: SimpleMovement): SimpleMovement = SimpleMovementHelpers.sequence(this, other) _
+    final def |(other: SimpleMovement): SimpleMovement = SimpleMovementHelpers.or(this, other) _
+    def zeroOrMore: SimpleMovement = SimpleMovementHelpers.repeat(this) _
     def atLeastOnce: SimpleMovement = this ~ this.zeroOrMore
-    def nTimes(n: Int): SimpleMovement = SimpleMovementOps.nTimes(this, n) _
-    def butNot(other: SimpleMovement): SimpleMovement = SimpleMovementOps.butNot(this, other) _
-    def optional: SimpleMovement = SimpleMovementOps.optional(this) _
+    def nTimes(n: Int): SimpleMovement = SimpleMovementHelpers.nTimes(this, n) _
+    def butNot(other: SimpleMovement): SimpleMovement = SimpleMovementHelpers.butNot(this, other) _
+    def optional: SimpleMovement = SimpleMovementHelpers.optional(this) _
     def atMostNtimes(n: Int): SimpleMovement = optional.nTimes(n)
   }
 
@@ -119,7 +119,7 @@ object SourceWithMarker {
     }
   }
 
-  private object SimpleMovementOps {
+  private object SimpleMovementHelpers {
     def sequence[MovementT <: SimpleMovement](mvnt1: MovementT, mvnt2: MovementT)(sourceWithMarker: SourceWithMarker): Option[Int] = {
       mvnt1(sourceWithMarker).map(newMarker => sourceWithMarker.copy(marker = newMarker)).flatMap(mvnt2.apply)
     }
@@ -209,7 +209,7 @@ object SourceWithMarker {
 
     final def ~(other: Movement) = Movement { (sourceWithMarker, forward) =>
       if (forward) {
-        SimpleMovementOps.sequence(self, other)(sourceWithMarker)
+        SimpleMovementHelpers.sequence(self, other)(sourceWithMarker)
       } else {
        other.backward.apply(sourceWithMarker).map(newMarker => sourceWithMarker.copy(marker = newMarker)).flatMap(self.backward.apply)
       }
@@ -222,14 +222,14 @@ object SourceWithMarker {
 
     final override def zeroOrMore = Movement { (sourceWithMarker, forward) =>
       val mvnt = if (forward) self else self.backward
-      SimpleMovementOps.repeat(mvnt)(sourceWithMarker)
+      SimpleMovementHelpers.repeat(mvnt)(sourceWithMarker)
     }
 
     final override def atLeastOnce: Movement = this ~ this.zeroOrMore
 
     final override def nTimes(n: Int) = Movement { (sourceWithMarker, forward) =>
       val mvnt = if  (forward) self else self.backward
-      SimpleMovementOps.nTimes(mvnt, n)(sourceWithMarker)
+      SimpleMovementHelpers.nTimes(mvnt, n)(sourceWithMarker)
     }
 
     final def butNot(mvnt: Movement) = Movement { (sourceWithMarker, forward) =>
@@ -238,11 +238,11 @@ object SourceWithMarker {
         else (self.backward, mvnt.backward)
       }
 
-      SimpleMovementOps.butNot(actualSelf, actualMvnt)(sourceWithMarker)
+      SimpleMovementHelpers.butNot(actualSelf, actualMvnt)(sourceWithMarker)
     }
 
     final override def optional = Movement { (sourceWithMarker, forward) =>
-      SimpleMovementOps.optional(if (forward) self else self.backward)(sourceWithMarker)
+      SimpleMovementHelpers.optional(if (forward) self else self.backward)(sourceWithMarker)
     }
 
     final override def atMostNtimes(n: Int) = optional.nTimes(n)

--- a/src/main/scala/scala/tools/refactoring/util/SourceWithMarker.scala
+++ b/src/main/scala/scala/tools/refactoring/util/SourceWithMarker.scala
@@ -261,6 +261,21 @@ object SourceWithMarker {
     def ifNotDepleted(impl: (SourceWithMarker, Boolean) => Option[Int]): Movement = {
       Movement((s, f) => MovementHelpers.doIfNotDepleted(s)(impl(s, f)))
     }
+
+    def coveredStringStartingAtEndOf(pos: RangePosition, mvnt: SimpleMovement): String = {
+      coveredString(pos.end, pos.source.content, mvnt)
+    }
+
+    def coveredString(pos: Int, src: IndexedSeq[Char], mvnt: SimpleMovement): String = {
+      val srcStart = SourceWithMarker(src, pos)
+      val srcEnd = srcStart.moveMarker(mvnt)
+      val (start, end) = (srcStart.marker, srcEnd.marker)
+      val (actualStart, actualEnd) = {
+        if (start <= end) (start, end)
+        else (end + 1, start + 1)
+      }
+      src.slice(actualStart, actualEnd).mkString("")
+    }
   }
 
   /**
@@ -494,6 +509,8 @@ object SourceWithMarker {
     val symbolLiteral = ''' ~ plainid
 
     val literalIdentifier = '`' ~ any.butNot('`').atLeastOnce ~ '`'
+
+    val id = plainid | literalIdentifier
 
     val spaces: Movement = space.zeroOrMore
     val comments: Movement = (comment ~ spaces).zeroOrMore

--- a/src/main/scala/scala/tools/refactoring/util/UniqueNames.scala
+++ b/src/main/scala/scala/tools/refactoring/util/UniqueNames.scala
@@ -4,11 +4,15 @@ import java.util.UUID
 
 object UniqueNames {
   def scalaFile(): String = {
-    s"${uid()}.scala"
+    s"${basename()}.scala"
   }
 
   def srcDir(): String = {
     s"src-${uid()}"
+  }
+
+  def basename(): String = {
+    uid()
   }
 
   def scalaPackage(): String = {

--- a/src/main/scala/scala/tools/refactoring/util/UniqueNames.scala
+++ b/src/main/scala/scala/tools/refactoring/util/UniqueNames.scala
@@ -1,0 +1,26 @@
+package scala.tools.refactoring.util
+
+import java.util.UUID
+
+object UniqueNames {
+  def scalaFile(): String = {
+    s"${uid()}.scala"
+  }
+
+  def srcDir(): String = {
+    s"src-${uid()}"
+  }
+
+  def scalaPackage(): String = {
+    uid()
+  }
+
+  private def uid(): String = {
+    def longToName(l: Long) = {
+      java.lang.Long.toString(l, Character.MAX_RADIX).replace("-", "_")
+    }
+
+    val rid = UUID.randomUUID()
+    "uid" + longToName(rid.getLeastSignificantBits) + longToName(rid.getMostSignificantBits)
+  }
+}

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/AddFieldTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/AddFieldTest.scala
@@ -5,8 +5,8 @@ import common.Change
 import org.junit.Assert.assertEquals
 import tests.util.TestHelper
 import scala.tools.refactoring.implementations._
-
 import language.reflectiveCalls
+import scala.tools.refactoring.util.UniqueNames
 
 class AddFieldTest extends TestHelper {
   outer =>
@@ -15,7 +15,7 @@ class AddFieldTest extends TestHelper {
     global.ask { () =>
       val refactoring = new AddField {
         val global = outer.global
-        val file = addToCompiler(randomFileName(), src)
+        val file = addToCompiler(UniqueNames.basename(), src)
         val change = addField(file, className, valName, isVar, returnType, target)
       }
       assertEquals(expected, Change.applyChanges(refactoring.change, src))

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/AddMethodTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/AddMethodTest.scala
@@ -6,8 +6,8 @@ import implementations.AddMethod
 import org.junit.Assert.assertEquals
 import tests.util.TestHelper
 import scala.tools.refactoring.implementations._
-
 import language.reflectiveCalls
+import scala.tools.refactoring.util.UniqueNames
 
 class AddMethodTest extends TestHelper {
   outer =>
@@ -16,7 +16,7 @@ class AddMethodTest extends TestHelper {
     global.ask { () =>
       val refactoring = new AddMethod {
         val global = outer.global
-        val file = addToCompiler(randomFileName(), src)
+        val file = addToCompiler(UniqueNames.basename(), src)
         val change = addMethod(file, className, methodName, parameters, typeParameters, returnType, target)
       }
       assertEquals(expected, Change.applyChanges(refactoring.change, src))

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
@@ -29,6 +29,8 @@ class RenameTest extends TestHelper with TestRefactoring {
     prepareAndRenameTo(name)(pro).changes
   }
 
+  protected override def nestTestsInUniqueBasePackageByDefault = true
+
   /*
    * See Assembla Ticket 1002537
    */
@@ -2623,7 +2625,7 @@ class Blubb
   @Test
   def testRenameWithDefaultArgs1002564Ex3() = new FileSet {
     """
-    package test.uniq1
+    package test
 
     object Bug {
       class Class {
@@ -2635,7 +2637,7 @@ class Blubb
     }
     """ becomes
     """
-    package test.uniq1
+    package test
 
     object Bug {
       class Class {

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
@@ -2557,6 +2557,38 @@ class Blubb
   } prepareAndApplyRefactoring(prepareAndRenameTo("test2"))
 
   @Test
+  def testRenameSimilarTo1002564Ex1WithoutDefaultArgs() = new FileSet {
+    """
+    object X extends App {
+      O().test.meth()
+    }
+    class C {
+      def meth() = 0
+    }
+    class O {
+      def /*(*/test/*)*/: C = ???
+    }
+    object O {
+      def apply(): O = ???
+    }
+    """ becomes
+    """
+    object X extends App {
+      O().test2.meth()
+    }
+    class C {
+      def meth() = 0
+    }
+    class O {
+      def /*(*/test2/*)*/: C = ???
+    }
+    object O {
+      def apply(): O = ???
+    }
+    """ -> TaggedAsGlobalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("test2"))
+
+  @Test
   def testRenameWithDefaultArgs1002564Ex2() = new FileSet {
     """
     object X extends App {
@@ -2598,8 +2630,8 @@ class Blubb
         def /*(*/renameMe/*)*/(i: Int = 42) = i
       }
 
-      def c = new Class
-      c.renameMe()
+      def cl = new Class
+      cl.renameMe()
     }
     """ becomes
     """
@@ -2610,9 +2642,48 @@ class Blubb
         def /*(*/ohNo/*)*/(i: Int = 42) = i
       }
 
-      def c = new Class
-      c.ohNo()
+      def cl = new Class
+      cl.ohNo()
     }
     """ -> TaggedAsGlobalRename
   } prepareAndApplyRefactoring(prepareAndRenameTo("ohNo"))
+
+  @Test
+  def testRenameWithDefaultArgs1002564Ex4() = new FileSet {
+    """
+    object X3 {
+      O3().test.meth(0)
+    }
+
+    class C3 {
+      def meth(i: Int = 0, j: Int = 1) = i + j
+    }
+
+    class O3 {
+      def /*(*/test/*)*/: C3 = ???
+    }
+
+    object O3 {
+      def apply(): O3 = ???
+    }
+    """ becomes
+    """
+    object X3 {
+      O3().test2.meth(0)
+    }
+
+    class C3 {
+      def meth(i: Int = 0, j: Int = 1) = i + j
+    }
+
+    class O3 {
+      def /*(*/test2/*)*/: C3 = ???
+    }
+
+    object O3 {
+      def apply(): O3 = ???
+    }
+    """ -> TaggedAsGlobalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("test2"))
+
 }

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
@@ -2623,7 +2623,7 @@ class Blubb
   @Test
   def testRenameWithDefaultArgs1002564Ex3() = new FileSet {
     """
-    package test
+    package test.uniq1
 
     object Bug {
       class Class {
@@ -2635,7 +2635,7 @@ class Blubb
     }
     """ becomes
     """
-    package test
+    package test.uniq1
 
     object Bug {
       class Class {

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
@@ -2520,4 +2520,99 @@ class Blubb
     }
     """ -> TaggedAsGlobalRename
   } prepareAndApplyRefactoring(prepareAndRenameTo("x"))
+
+  /*
+   * See Assembla Ticket 1002564
+   */
+  @Test
+  def testRenameWithDefaultArgs1002564Ex1() = new FileSet {
+    """
+    object X extends App {
+      O().test.meth()
+    }
+    class C {
+      def meth(j: Int = 0) = j
+    }
+    class O {
+      def /*(*/test/*)*/: C = ???
+    }
+    object O {
+      def apply(): O = ???
+    }
+    """ becomes
+    """
+    object X extends App {
+      O().test2.meth()
+    }
+    class C {
+      def meth(j: Int = 0) = j
+    }
+    class O {
+      def /*(*/test2/*)*/: C = ???
+    }
+    object O {
+      def apply(): O = ???
+    }
+    """ -> TaggedAsGlobalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("test2"))
+
+  @Test
+  def testRenameWithDefaultArgs1002564Ex2() = new FileSet {
+    """
+    object X extends App {
+      O().test.meth()
+    }
+    class C {
+      def /*(*/meth/*)*/(j: Int = 0) = j
+    }
+    class O {
+      def test: C = ???
+    }
+    object O {
+      def apply(): O = ???
+    }
+    """ becomes
+    """
+    object X extends App {
+      O().test.meth2()
+    }
+    class C {
+      def /*(*/meth2/*)*/(j: Int = 0) = j
+    }
+    class O {
+      def test: C = ???
+    }
+    object O {
+      def apply(): O = ???
+    }
+    """ -> TaggedAsGlobalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("meth2"))
+
+  @Test
+  def testRenameWithDefaultArgs1002564Ex3() = new FileSet {
+    """
+    package test
+
+    object Bug {
+      class Class {
+        def /*(*/renameMe/*)*/(i: Int = 42) = i
+      }
+
+      def c = new Class
+      c.renameMe()
+    }
+    """ becomes
+    """
+    package test
+
+    object Bug {
+      class Class {
+        def /*(*/ohNo/*)*/(i: Int = 42) = i
+      }
+
+      def c = new Class
+      c.ohNo()
+    }
+    """ -> TaggedAsGlobalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("ohNo"))
 }

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/AddImportStatementTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/AddImportStatementTest.scala
@@ -10,8 +10,8 @@ import tests.util.TestHelper
 import common.Change
 import org.junit.Assert._
 import scala.tools.refactoring.common.TextChange
-
 import language.reflectiveCalls
+import scala.tools.refactoring.util.UniqueNames
 
 class AddImportStatementTest extends TestHelper {
   outer =>
@@ -20,7 +20,7 @@ class AddImportStatementTest extends TestHelper {
 
     val refactoring = new AddImportStatement  {
       val global = outer.global
-      val file = addToCompiler(randomFileName(), src)
+      val file = addToCompiler(UniqueNames.basename(), src)
       val change = addImport(file, imp._1 + "." + imp._2)
     }
 

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/UnusedImportsFinderTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/UnusedImportsFinderTest.scala
@@ -7,6 +7,7 @@ package tests.implementations.imports
 
 import implementations.UnusedImportsFinder
 import tests.util.TestHelper
+import scala.tools.refactoring.util.UniqueNames
 
 class UnusedImportsFinderTest extends TestHelper {
   outer =>
@@ -18,7 +19,7 @@ class UnusedImportsFinderTest extends TestHelper {
 
         val global = outer.global
 
-        val unit = global.unitOfFile(addToCompiler(randomFileName(), src))
+        val unit = global.unitOfFile(addToCompiler(UniqueNames.basename(), src))
 
         def compilationUnitOfFile(f: AbstractFile) = Some(unit)
 

--- a/src/test/scala/scala/tools/refactoring/tests/util/SourceWithMarkerTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/util/SourceWithMarkerTest.scala
@@ -4,6 +4,9 @@ import org.junit.Assert._
 import scala.tools.refactoring.util.SourceWithMarker
 import scala.language.implicitConversions
 import scala.util.control.NonFatal
+import scala.tools.refactoring.util.SourceWithMarker.SimpleMovement
+import scala.tools.refactoring.util.SourceWithMarker.Movements
+import scala.tools.refactoring.util.SourceWithMarker.Movement
 
 class SourceWithMarkerTest {
   import SourceWithMarker.Movements._
@@ -281,6 +284,19 @@ class SourceWithMarkerTest {
    shouldNotDeplete.foreach { mvnt =>
       assertFalse(src.moveMarker(mvnt).isDepleted)
     }
+  }
+
+  @Test
+  def testCoveredString(): Unit = {
+    def runTest(input: String, start: Int, mvnt: SimpleMovement, expected: String): Unit = {
+      assertEquals(expected, Movement.coveredString(start, input, mvnt))
+    }
+
+    runTest("", 0, any, "")
+    runTest("0", 0, any, "0")
+    runTest("1", 0, any.backward, "1")
+    runTest("1223", 1, '2'.zeroOrMore, "22")
+    runTest("1223", 1, '2'.zeroOrMore.backward, "2")
   }
 
   private implicit class SourceWithMarkerOps(underlying: SourceWithMarker) {


### PR DESCRIPTION
Fixes [#1002564](https://www.assembla.com/spaces/scala-ide/tickets/1002564-rename-refactoring-is-broken-in-case-the-renamed-method-has-default-arguments).