### PR TITLE
 Don't duplicate imports while grouping them

### DIFF
--- a/src/test/scala/scala/tools/refactoring/implementations/OrganizeImportsAlgosTest.scala
+++ b/src/test/scala/scala/tools/refactoring/implementations/OrganizeImportsAlgosTest.scala
@@ -1,0 +1,59 @@
+
+
+package scala.tools.refactoring.implementations
+
+import org.junit.Test
+import org.junit.Assert._
+
+class OrganizeImportsAlgosTest {
+  import OrganizeImports.Algos
+
+  @Test
+  def testGroupImportsWithTrivialExamples(): Unit = {
+    testGroupImports(Nil, Nil, Nil)
+    testGroupImports(List("org", "com"), Nil, Nil)
+    testGroupImports(Nil, List("com.github.Lausbub"), List(List("com.github.Lausbub")))
+  }
+
+  @Test
+  def testGroupImportsWithSimpleExamples(): Unit = {
+    testGroupImports(
+        groups = List("org"),
+        imports = List("org.junit.Test", "org.junit.Assert._", "language.postfixOps"),
+        expected = List(List("org.junit.Test", "org.junit.Assert._"), List("language.postfixOps")))
+
+    testGroupImports(
+        groups = List("java", "scala", "org"),
+        imports = List("java.lang.String", "java.lang.Long", "org.junit.Before", "scala.Option.option2Iterable", "language.implicitConversions"),
+        expected = List(List("java.lang.String", "java.lang.Long"), List("scala.Option.option2Iterable"), List("org.junit.Before"), List("language.implicitConversions")))
+  }
+
+  @Test
+  def testGroupImportsWithNastyExamples(): Unit = {
+    testGroupImports(
+        groups = List("a.c", "a"),
+        imports = List("a.b.X", "a.c.Y"),
+        expected = List(List("a.c.Y"), List("a.b.X")))
+
+    testGroupImports(
+        groups = List("a", "a.c"),
+        imports = List("a.b.X", "a.c.Y"),
+        expected = List(List("a.b.X"), List("a.c.Y")))
+
+    testGroupImports(
+        groups = List("a", "a.b", "ab"),
+        imports = List("a.A", "a.b.AB", "ab.Ab1", "ab.Ab2", "abc.Abc1", "abc.Abc2"),
+        expected = List(List("a.A"), List("a.b.AB"), List("ab.Ab1", "ab.Ab2"), List("abc.Abc1", "abc.Abc2")))
+  }
+
+  private def testGroupImports(groups: List[String], imports: List[String], expected: List[List[String]]): Unit = {
+    def getImportExpr(imp: String) = {
+      val lastDot = imp.lastIndexOf('.')
+      assert(lastDot >= 0)
+      imp.substring(0, lastDot)
+    }
+
+    val actual = Algos.groupImports(getImportExpr)(groups, imports)
+    assertEquals(expected, actual)
+  }
+}

--- a/src/test/scala/scala/tools/refactoring/tests/RefactoringTestSuite.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/RefactoringTestSuite.scala
@@ -10,6 +10,8 @@ import implementations.imports._
 import sourcegen._
 import transformation._
 import util._
+import scala.tools.refactoring.implementations.OrganizeImportsAlgosTest
+
 @RunWith(value = classOf[Suite])
 @Suite.SuiteClasses(value = Array(
     classOf[AddFieldTest],
@@ -72,5 +74,6 @@ import util._
     classOf[TreeTransformationsTest],
     classOf[UnionFindInitTest],
     classOf[UnionFindTest],
-    classOf[UnusedImportsFinderTest]))
+    classOf[UnusedImportsFinderTest],
+    classOf[OrganizeImportsAlgosTest]))
 class RefactoringTestSuite {}

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
@@ -818,4 +818,31 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
     }
     """
   } applyRefactoring organizeCustomized(groupPkgs = List("java", "java.util", "java.io"))
+
+  @Test
+  def organizeImportsWithDuplicateGroups() = new FileSet {
+    """
+    package test
+
+    import scala.util.Try
+    import java.util.Date
+    import scala.collection.immutable.Queue
+
+    class Bug {
+      def a: (Try[Date], Queue[Date]) = ???
+    }
+    """ becomes
+    """
+    package test
+
+    import java.util.Date
+
+    import scala.collection.immutable.Queue
+    import scala.util.Try
+
+    class Bug {
+      def a: (Try[Date], Queue[Date]) = ???
+    }
+    """
+  } applyRefactoring organizeCustomized(groupPkgs = List("java", "scala", "java"))
 }

--- a/src/test/scala/scala/tools/refactoring/tests/util/TestHelper.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/util/TestHelper.scala
@@ -214,9 +214,10 @@ trait TestHelper extends TestRules with Refactoring with CompilerProvider with c
 
     if (project.expectCompilingCode) {
       trees.foreach { tree =>
-        if (tree.find(_.isErroneous).isDefined) {
+        tree.find(_.isErroneous).foreach { erroneousTree =>
           val src = new String(tree.pos.source.content)
-          throw new AssertionError(s"Expected compiling code but got:\n---------------------\n$src")
+          val sep = "------------------------------------"
+          throw new AssertionError(s"Expected compiling code but got:\n$sep\n$src\n$sep\nErroneous tree: $erroneousTree")
         }
       }
     }


### PR DESCRIPTION
Fixes [#1002526](https://scala-ide-portfolio.assembla.com/spaces/scala-ide/tickets/1002526--quot-organize-imports-quot--duplicates-imports/details#). More details can be found in the commit messages.