### PR TITLE
 Consider exotic but legal places for comments and spaces

### DIFF
--- a/src/main/scala/scala/tools/refactoring/common/PimpedTrees.scala
+++ b/src/main/scala/scala/tools/refactoring/common/PimpedTrees.scala
@@ -258,7 +258,15 @@ trait PimpedTrees {
             } else if (t.name.decode != t.name.toString) {
               t.pos withEnd (t.pos.start + nameString.length)
             } else {
-              t.pos withEnd (t.pos.start + t.name.length)
+              t.pos match {
+                case rpos: RangePosition =>
+                  val nameStart = SourceWithMarker.atStartOf(rpos).moveMarker(commentsAndSpaces ~ '.'.optional ~ commentsAndSpaces)
+                  val nameEnd = nameStart.moveMarker(id)
+                  t.pos.withStart(nameStart.marker).withEnd(nameEnd.marker)
+                case opos =>
+                   logError(s"Expected RangePosition but got $opos", new AssertionError)
+                   opos
+              }
             }
 
           case t @ Bind(name, body) =>

--- a/src/main/scala/scala/tools/refactoring/sourcegen/ReusingPrinter.scala
+++ b/src/main/scala/scala/tools/refactoring/sourcegen/ReusingPrinter.scala
@@ -620,8 +620,8 @@ trait ReusingPrinter extends TreePrintingTraversals with AbstractPrinter with Sc
                 case pos: RangePosition =>
                   // If fun is part of an expression involving default arguments, it might be
                   // necessary to manually make sure that parenthesis and '.' is printed out.
-                  // See #1002564
-                  val parensAndSep = commentsAndSpaces ~ '(' ~ commentsAndSpaces ~ ')' ~ '.'.optional
+                  // See #1002564 and #1002611
+                  val parensAndSep = commentsAndSpaces ~ '(' ~ commentsAndSpaces ~ ')' ~ ( commentsAndSpaces ~ '.' ~ commentsAndSpaces).optional
                   Layout(Movement.coveredStringStartingAtEndOf(pos, parensAndSep))
                 case _ => NoLayout
               }

--- a/src/main/scala/scala/tools/refactoring/sourcegen/ReusingPrinter.scala
+++ b/src/main/scala/scala/tools/refactoring/sourcegen/ReusingPrinter.scala
@@ -46,7 +46,7 @@ trait ReusingPrinter extends TreePrintingTraversals with AbstractPrinter with Sc
 
       val (leadingParent, trailingParent) = surroundingLayoutFromParentsAndSiblings(t)
 
-      val printedFragment = if (ctx.changeSet hasChanged t) {
+      val printedFragment = if (ctx.changeSet.hasChanged(t)) {
         super.dispatchToPrinter(t, newCtx)
       } else if (t.pos.isTransparent) {
         trace("Not in change set but transparent, continue printing...")

--- a/src/main/scala/scala/tools/refactoring/sourcegen/ReusingPrinter.scala
+++ b/src/main/scala/scala/tools/refactoring/sourcegen/ReusingPrinter.scala
@@ -621,7 +621,8 @@ trait ReusingPrinter extends TreePrintingTraversals with AbstractPrinter with Sc
                   // If fun is part of an expression involving default arguments, it might be
                   // necessary to manually make sure that parenthesis and '.' is printed out.
                   // See #1002564 and #1002611
-                  val parensAndSep = commentsAndSpaces ~ '(' ~ commentsAndSpaces ~ ')' ~ ( commentsAndSpaces ~ '.' ~ commentsAndSpaces).optional
+                  val cs = commentsAndSpaces
+                  val parensAndSep = cs ~ '(' ~ cs ~ ')' ~ (cs ~ '.' ~ cs).optional
                   Layout(Movement.coveredStringStartingAtEndOf(pos, parensAndSep))
                 case _ => NoLayout
               }

--- a/src/main/scala/scala/tools/refactoring/util/SourceWithMarker.scala
+++ b/src/main/scala/scala/tools/refactoring/util/SourceWithMarker.scala
@@ -77,7 +77,15 @@ object SourceWithMarker {
     SourceWithMarker(pos.source.content, pos.start - 1)
   }
 
+  def atStartOf(pos: RangePosition): SourceWithMarker = {
+    SourceWithMarker(pos.source.content, pos.start)
+  }
+
   def afterEndOf(pos: RangePosition): SourceWithMarker = {
+    SourceWithMarker(pos.source.content, pos.end + 1)
+  }
+
+  def atEndOf(pos: RangePosition): SourceWithMarker = {
     SourceWithMarker(pos.source.content, pos.end + 1)
   }
 

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
@@ -32,6 +32,123 @@ class RenameTest extends TestHelper with TestRefactoring {
   protected override def nestTestsInUniqueBasePackageByDefault = true
 
   /*
+   * See Assembla Ticket 1002611
+   */
+  @Test
+  def testRenameWithDefaultArgs1002611Ex1() = new FileSet {
+    """
+    object X extends App {
+      O() /*Please*/ . /*let me survive!*/ /*(*/renameMe/*)*/meth()
+    }
+
+    class C {
+      def meth(j: Int = 0) = j
+    }
+
+    class O {
+      def renameMe: C = ???
+    }
+
+    object O {
+      def apply(): O = ???
+    }
+    """ becomes
+    """
+    object X extends App {
+      O() /*Please*/ . /*let me survive!*/ /*(*/ups/*)*/meth()
+    }
+
+    class C {
+      def meth(j: Int = 0) = j
+    }
+
+    class O {
+      def ups: C = ???
+    }
+
+    object O {
+      def apply(): O = ???
+    }
+    """ -> TaggedAsGlobalRename;
+  } prepareAndApplyRefactoring(prepareAndRenameTo("ups"))
+
+  @Test
+  def testRenameWithDefaultArgs1002611Ex2() = new FileSet {
+    """
+    object X extends App {
+      O()./**/test/**/ /*Please don't forget about me!!!!*/ /*(*/.renameMe/*)*/()
+    }
+
+    class C {
+      def renameMe(j: Int = 0) = j
+    }
+
+    class O {
+      def test: C = ???
+    }
+
+    object O {
+      def apply(): O = ???
+    }
+    """ becomes
+    """
+    object X extends App {
+      O()./**/test/**/ /*Please don't forget about me!!!!*/ /*(*/.ups/*)*/()
+    }
+
+    class C {
+      def ups(j: Int = 0) = j
+    }
+
+    class O {
+      def test: C = ???
+    }
+
+    object O {
+      def apply(): O = ???
+    }
+    """ -> TaggedAsGlobalRename;
+  } prepareAndApplyRefactoring(prepareAndRenameTo("ups"))
+
+  @Test
+  def testRenameWithDefaultArgs1002611Ex3() = new FileSet {
+    """
+    object X extends App {
+      O(). /*let me survive!*/ /*(*/renameMe/*)*/meth()
+    }
+
+    class C {
+      def meth(j: Int = 0) = j
+    }
+
+    class O {
+      def renameMe: C = ???
+    }
+
+    object O {
+      def apply(): O = ???
+    }
+    """ becomes
+    """
+    object X extends App {
+      O(). /*let me survive!*/ /*(*/ups/*)*/meth()
+    }
+
+    class C {
+      def meth(j: Int = 0) = j
+    }
+
+    class O {
+      def ups: C = ???
+    }
+
+    object O {
+      def apply(): O = ???
+    }
+    """ -> TaggedAsGlobalRename;
+  } prepareAndApplyRefactoring(prepareAndRenameTo("ups"))
+
+  /*
    * See Assembla Ticket 1002537
    */
   @Test

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
@@ -148,6 +148,44 @@ class RenameTest extends TestHelper with TestRefactoring {
     """ -> TaggedAsGlobalRename;
   } prepareAndApplyRefactoring(prepareAndRenameTo("ups"))
 
+  @Test
+  def testRenameSimilarButNotAffectedBy1002611Ex1() = new FileSet {
+    """
+    object X extends App {
+      O()./**/test/**/ /*Please don't forget about me!!!!*/ /*(*/.renameMe/*)*/(0)
+    }
+
+    class C {
+      def renameMe(j: Int) = j
+    }
+
+    class O {
+      def test: C = ???
+    }
+
+    object O {
+      def apply(): O = ???
+    }
+    """ becomes
+    """
+    object X extends App {
+      O()./**/test/**/ /*Please don't forget about me!!!!*/ /*(*/.ups/*)*/(0)
+    }
+
+    class C {
+      def ups(j: Int) = j
+    }
+
+    class O {
+      def test: C = ???
+    }
+
+    object O {
+      def apply(): O = ???
+    }
+    """ -> TaggedAsGlobalRename;
+  } prepareAndApplyRefactoring(prepareAndRenameTo("ups"))
+
   /*
    * See Assembla Ticket 1002537
    */

--- a/src/test/scala/scala/tools/refactoring/tests/util/TestHelper.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/util/TestHelper.scala
@@ -29,7 +29,7 @@ import scala.tools.refactoring.util.UniqueNames
 object TestHelper {
   case class PrepResultWithChanges(prepResult: Option[Either[MultiStageRefactoring#PreparationError, Rename#PreparationResult]], changes: List[Change])
 
-  private val PtnIndentedLine = """(\s*)[^\s].*""".r
+  private val IndentedLine = """(\s*)[^\s].*""".r
 }
 
 trait TestHelper extends TestRules with Refactoring with CompilerProvider with common.InteractiveScalaCompiler with TracingImpl {
@@ -92,7 +92,7 @@ trait TestHelper extends TestRules with Refactoring with CompilerProvider with c
       basePackage.map { pkg =>
         def wrapInPkg(src: Source) = {
           val initialIndent = src.code.lines.collectFirst {
-            case PtnIndentedLine(indent) => indent
+            case IndentedLine(indent) => indent
           }.getOrElse("")
 
           src.copy(code = s"${initialIndent}package $pkg\n\n${src.code}")

--- a/src/test/scala/scala/tools/refactoring/tests/util/TestHelper.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/util/TestHelper.scala
@@ -81,7 +81,7 @@ trait TestHelper extends TestRules with Refactoring with CompilerProvider with c
    * A project to test multiple compilation units. Add all
    * sources using "add" before using any of the lazy vals.
    */
-  abstract class FileSet(baseName: String = UniqueNames.srcDir(), val expectCompilingCode: Boolean = true, val basePackage: Option[String] = defaultFileSetBasePackage) {
+  abstract class FileSet(baseName: String = UniqueNames.basename(), val expectCompilingCode: Boolean = true, val basePackage: Option[String] = defaultFileSetBasePackage) {
     private val srcs = ListBuffer[(Source, Source)]()
 
     object TaggedAsGlobalRename

--- a/src/test/scala/scala/tools/refactoring/tests/util/TestHelper.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/util/TestHelper.scala
@@ -28,6 +28,8 @@ import scala.tools.refactoring.util.UniqueNames
 
 object TestHelper {
   case class PrepResultWithChanges(prepResult: Option[Either[MultiStageRefactoring#PreparationError, Rename#PreparationResult]], changes: List[Change])
+
+  private val PtnIndentedLine = """(\s*)[^\s].*""".r
 }
 
 trait TestHelper extends TestRules with Refactoring with CompilerProvider with common.InteractiveScalaCompiler with TracingImpl {
@@ -89,7 +91,11 @@ trait TestHelper extends TestRules with Refactoring with CompilerProvider with c
     private def eventuallyNestInBasePgk(src1: Source, src2: Source): (Source, Source) = {
       basePackage.map { pkg =>
         def wrapInPkg(src: Source) = {
-          src.copy(code = s"package $pkg\n\n${src.code}")
+          val initialIndent = src.code.lines.collectFirst {
+            case PtnIndentedLine(indent) => indent
+          }.getOrElse("")
+
+          src.copy(code = s"${initialIndent}package $pkg\n\n${src.code}")
         }
 
         (wrapInPkg(src1), wrapInPkg(src2))


### PR DESCRIPTION
This PR contains a fix for [#1002611](https://www.assembla.com/spaces/scala-ide/tickets/1002611-rename-refactoring-breaks-when-default-arguments-and-comments-spaces-are-involved/details#), as well as some mostly cosmetic changes.