### PR TITLE
 Be more careful when printing type parameter lists

### DIFF
--- a/src/main/scala/scala/tools/refactoring/sourcegen/LayoutHelper.scala
+++ b/src/main/scala/scala/tools/refactoring/sourcegen/LayoutHelper.scala
@@ -296,10 +296,9 @@ trait LayoutHelper {
   def splitLayoutBetweenSiblings(parent: Tree, left: Tree, right: Tree): (Layout, Layout) = {
 
     def mergeLayoutWithComment(l: Seq[Char], c: Seq[Char]) = l.zip(c).map {
-      case (' ', _1) => _1
-      case (_1, ' ') => _1
-      case ('\n', '\n') => '\n'
-      case ('\r', '\r') => '\r'
+      case (' ', cc) => cc
+      case (ll, ' ') => ll
+      case (a, b) if a == b => a
     }.mkString
 
     def split(layout: String): (String, String, String) = {
@@ -309,27 +308,27 @@ trait LayoutHelper {
        * kinds of layout that contain an @. */
       def layoutDoesNotIncludeAnnotation = !layout.contains("@")
 
-      (layout match {
-        case Else(l, r)             => Some((l, r, "else"))
-        case Match(l, r)            => Some((l, r, "match"))
-        case StartComment(l, r)     => Some((l, r, "StartComment"))
-        case Class(l, r)            => Some((l, r, "Class"))
-        case Colon(l, r)            => Some((l, r, "Colon"))
-        case EmptyParens(l, r)      => Some((l, r, "EmptyParens"))
-        case OpeningBrace(l, r)     => Some((l, r, "OpeningBrace"))
-        case Arrow(l, r)            => Some((l, r, "`=>`"))
-        case ClosingBrace(l, r) if layoutDoesNotIncludeAnnotation => Some((l, r, "ClosingBrace"))
-        case Equals(l, r)       if layoutDoesNotIncludeAnnotation => Some((l, r, "Equals"))
-        case ImportStatementNewline(l, r) => Some((l, r, "ImportStatement Newline"))
-        case ImportStatement(l, r)  => Some((l, r, "ImportStatement"))
-        case ClosingCurlyBrace(l, r)=> Some((l, r, "ClosingCurlyBrace"))
-        case NewLine(l, r)          => Some((l, r, "NewLine"))
-        case CommaSpace(l, r)       => Some((l, r, "CommaSpace"))
-        case Comma(l, r)                => Some((l, r, "Comma"))
-        case Dot(l, r)                  => Some((l, r, "Dot"))
-        case OpeningSquareBracket(l, r) => Some((l, r, "OpeningSquareBracket"))
-        case s                          => Some((s, "", "NoMatch"))
-      }).get
+      layout match {
+        case Else(l, r)             => (l, r, "else")
+        case Match(l, r)            => (l, r, "match")
+        case StartComment(l, r)     => (l, r, "StartComment")
+        case Class(l, r)            => (l, r, "Class")
+        case Colon(l, r)            => (l, r, "Colon")
+        case EmptyParens(l, r)      => (l, r, "EmptyParens")
+        case OpeningBrace(l, r)     => (l, r, "OpeningBrace")
+        case Arrow(l, r)            => (l, r, "`=>`")
+        case ClosingBrace(l, r) if layoutDoesNotIncludeAnnotation => (l, r, "ClosingBrace")
+        case Equals(l, r)       if layoutDoesNotIncludeAnnotation => (l, r, "Equals")
+        case ImportStatementNewline(l, r) => (l, r, "ImportStatement Newline")
+        case ImportStatement(l, r)  => (l, r, "ImportStatement")
+        case ClosingCurlyBrace(l, r)=> (l, r, "ClosingCurlyBrace")
+        case NewLine(l, r)          => (l, r, "NewLine")
+        case CommaSpace(l, r)       => (l, r, "CommaSpace")
+        case Comma(l, r)                => (l, r, "Comma")
+        case Dot(l, r)                  => (l, r, "Dot")
+        case OpeningSquareBracket(l, r) => (l, r, "OpeningSquareBracket")
+        case s                          => (s, "", "NoMatch")
+      }
     }
 
     (fixValDefPosition(left), fixValDefPosition(right)) match {

--- a/src/main/scala/scala/tools/refactoring/sourcegen/LayoutHelper.scala
+++ b/src/main/scala/scala/tools/refactoring/sourcegen/LayoutHelper.scala
@@ -287,7 +287,7 @@ trait LayoutHelper {
   private val Equals = """(?ms)(.*?=\s?)(.*)""".r
   private val ClosingBrace = """(?ms)(.*?)\)(.*)""".r
   private val ClosingCurlyBrace = """(?ms)(.*?\}\s*)(\r?\n.*)""".r
-  private val Comma = """(.*?),(.*)""".r
+  private val Comma = """(?ms)(.*?),(.*)""".r
   private val CommaSpace = """(.*?), (.*)""".r
   private val NewLine = """(?ms)(.*?)(\r?\n.*)""".r
   private val ImportStatementNewline = """(?ms)(.*)(\r?\n.*?import.*)""".r
@@ -322,11 +322,10 @@ trait LayoutHelper {
         case ImportStatementNewline(l, r) => (l, r, "ImportStatement Newline")
         case ImportStatement(l, r)  => (l, r, "ImportStatement")
         case ClosingCurlyBrace(l, r)=> (l, r, "ClosingCurlyBrace")
-        case NewLine(l, r)          => (l, r, "NewLine")
-        case CommaSpace(l, r)       => (l, r, "CommaSpace")
         case Comma(l, r)                => (l, r, "Comma")
         case Dot(l, r)                  => (l, r, "Dot")
         case OpeningSquareBracket(l, r) => (l, r, "OpeningSquareBracket")
+        case NewLine(l, r)          => (l, r, "NewLine")
         case s                          => (s, "", "NoMatch")
       }
     }
@@ -414,8 +413,8 @@ trait LayoutHelper {
          * We remove all leading or trailing commas, they always need to be re-introduced by the printers.
          */
         def removeLeadingOrTrailingComma(s: String) = {
-          val CommaAtStart = "(?ms),\\s?(.*)".r
-          val CommaAtEnd   = "(?ms)(.*),\\s?".r
+          val CommaAtStart = """(?ms),(\s*)""".r
+          val CommaAtEnd   = """(?ms)(\s*),\s*""".r
           s match {
             case CommaAtStart(rest) => rest
             case CommaAtEnd(rest) => rest

--- a/src/main/scala/scala/tools/refactoring/sourcegen/LayoutHelper.scala
+++ b/src/main/scala/scala/tools/refactoring/sourcegen/LayoutHelper.scala
@@ -287,6 +287,11 @@ trait LayoutHelper {
   private val Equals = """(?ms)(.*?=\s?)(.*)""".r
   private val ClosingBrace = """(?ms)(.*?)\)(.*)""".r
   private val ClosingCurlyBrace = """(?ms)(.*?\}\s*)(\r?\n.*)""".r
+
+  // Here to make IndividualSourceGenTest.changeMethodInvocation3 happy;
+  // I'm not sure if I like this, because I'd prefer splitting at ",".
+  private val NewlineComma = """(?ms)(.*?)(\r?\n\s*,.*)""".r
+
   private val Comma = """(?ms)(.*?),(.*)""".r
   private val CommaSpace = """(.*?), (.*)""".r
   private val NewLine = """(?ms)(.*?)(\r?\n.*)""".r
@@ -322,6 +327,7 @@ trait LayoutHelper {
         case ImportStatementNewline(l, r) => (l, r, "ImportStatement Newline")
         case ImportStatement(l, r)  => (l, r, "ImportStatement")
         case ClosingCurlyBrace(l, r)=> (l, r, "ClosingCurlyBrace")
+        case NewlineComma(l, r)         => (l, r, "NewlineComma")
         case Comma(l, r)                => (l, r, "Comma")
         case Dot(l, r)                  => (l, r, "Dot")
         case OpeningSquareBracket(l, r) => (l, r, "OpeningSquareBracket")

--- a/src/main/scala/scala/tools/refactoring/sourcegen/LayoutHelper.scala
+++ b/src/main/scala/scala/tools/refactoring/sourcegen/LayoutHelper.scala
@@ -287,11 +287,6 @@ trait LayoutHelper {
   private val Equals = """(?ms)(.*?=\s?)(.*)""".r
   private val ClosingBrace = """(?ms)(.*?)\)(.*)""".r
   private val ClosingCurlyBrace = """(?ms)(.*?\}\s*)(\r?\n.*)""".r
-
-  // Here to make IndividualSourceGenTest.changeMethodInvocation3 happy;
-  // I'm not sure if I like this, because I'd prefer splitting at ",".
-  private val NewlineComma = """(?ms)(.*?)(\r?\n\s*,.*)""".r
-
   private val Comma = """(?ms)(.*?),(.*)""".r
   private val CommaSpace = """(.*?), (.*)""".r
   private val NewLine = """(?ms)(.*?)(\r?\n.*)""".r
@@ -327,7 +322,6 @@ trait LayoutHelper {
         case ImportStatementNewline(l, r) => (l, r, "ImportStatement Newline")
         case ImportStatement(l, r)  => (l, r, "ImportStatement")
         case ClosingCurlyBrace(l, r)=> (l, r, "ClosingCurlyBrace")
-        case NewlineComma(l, r)         => (l, r, "NewlineComma")
         case Comma(l, r)                => (l, r, "Comma")
         case Dot(l, r)                  => (l, r, "Dot")
         case OpeningSquareBracket(l, r) => (l, r, "OpeningSquareBracket")

--- a/src/main/scala/scala/tools/refactoring/sourcegen/PrettyPrinter.scala
+++ b/src/main/scala/scala/tools/refactoring/sourcegen/PrettyPrinter.scala
@@ -480,7 +480,7 @@ trait PrettyPrinter extends TreePrintingTraversals with AbstractPrinter {
           p(impl)
       }
 
-      Fragment(mods_ + keyword + name) ++ pp(tparams, before = "[", separator = ", ", after = "]") ++ body.ifNotEmpty {
+      Fragment(mods_ + keyword + name) ++ pp(tparams, before = "[", separator = "," ++ Requisite.Blank, after = "]") ++ body.ifNotEmpty {
         case body if body.asText.startsWith("{") =>
           Layout(" ") ++ body
         case body =>
@@ -584,7 +584,7 @@ trait PrettyPrinter extends TreePrintingTraversals with AbstractPrinter {
         // Finalize this fragment so that the anywhere-requisite gets applied here
         // and does not match on ] that might come later (see testNewDefDefWithOriginalContent3
         // and testDefDefWithTypeParams).
-        pp(tparams, before = "[", after = anywhere("]"), separator = ", ").toLayout
+        pp(tparams, before = "[", after = anywhere("]"), separator = "," ++ Requisite.Blank).toLayout
       }
 
       // if there's existing layout, the type parameter's layout might already contain "()"

--- a/src/main/scala/scala/tools/refactoring/sourcegen/ReusingPrinter.scala
+++ b/src/main/scala/scala/tools/refactoring/sourcegen/ReusingPrinter.scala
@@ -269,7 +269,7 @@ trait ReusingPrinter extends TreePrintingTraversals with AbstractPrinter with Sc
     }
 
     override def UnApply(tree: UnApply, fun: Tree, args: List[Tree])(implicit ctx: PrintingContext) = {
-      l ++ p(fun) ++ pp(args, separator = ", ", before = "(", after = ")") ++ r
+      l ++ p(fun) ++ pp(args, separator = ",", before = "(", after = ")") ++ r
     }
 
     override def Match(tree: Match, selector: Tree, cases: List[Tree])(implicit ctx: PrintingContext) = {
@@ -702,7 +702,7 @@ trait ReusingPrinter extends TreePrintingTraversals with AbstractPrinter with Sc
         } else {
           val arguments = args.init
           val ret = args.last
-          l ++ pp(arguments, before = "(", separator = ", ", after = Requisite.anywhere(")")) ++ p(ret) ++ r
+          l ++ pp(arguments, before = "(", separator = ",", after = Requisite.anywhere(")")) ++ p(ret) ++ r
         }
       }
 
@@ -721,7 +721,7 @@ trait ReusingPrinter extends TreePrintingTraversals with AbstractPrinter with Sc
             else ("[", "]")
           }
 
-          l ++ p(tpt) ++ pp(args, before = beforeArgs, separator = ", ", after = afterArgs) ++ r
+          l ++ p(tpt) ++ pp(args, before = beforeArgs, separator = Requisite.allowSurroundingWhitespace(","), after = afterArgs) ++ r
       }
     }
 
@@ -1023,14 +1023,14 @@ trait ReusingPrinter extends TreePrintingTraversals with AbstractPrinter with Sc
           case (x: TypeDef) :: Nil =>
             p(x)
           case (x: TypeDef) :: (y: TypeDef) :: rest =>
-            p(x) ++ ", " ++ mergeTypeParameters(y :: rest)
+            p(x) ++ "," ++ mergeTypeParameters(y :: rest)
           case (x: TypeDef) :: rest =>
             val (bounds, next) = rest.span(!_.isInstanceOf[TypeDef])
             val current = pp(x :: bounds, separator = ": ")
             if (next.isEmpty) {
               current
             } else {
-              current ++ ", " ++ mergeTypeParameters(next)
+              current ++ "," ++ mergeTypeParameters(next)
             }
           case _ =>
             EmptyFragment
@@ -1096,7 +1096,7 @@ trait ReusingPrinter extends TreePrintingTraversals with AbstractPrinter with Sc
     this: TreePrinting with PrintingUtils =>
 
     override def SuperConstructorCall(tree: SuperConstructorCall, clazz: global.Tree, args: List[global.Tree])(implicit ctx: PrintingContext) = {
-      l ++ p(clazz) ++ pp(args, separator = ", ", before = "(", after = ")") ++ r
+      l ++ p(clazz) ++ pp(args, separator = ",", before = "(", after = ")") ++ r
     }
 
     override def Super(tree: Super, qual: Tree, mix: Name)(implicit ctx: PrintingContext) = {

--- a/src/main/scala/scala/tools/refactoring/sourcegen/ReusingPrinter.scala
+++ b/src/main/scala/scala/tools/refactoring/sourcegen/ReusingPrinter.scala
@@ -716,7 +716,12 @@ trait ReusingPrinter extends TreePrintingTraversals with AbstractPrinter with Sc
         case EmptyTree =>
           printFunctionType()
         case _ =>
-          l ++ p(tpt) ++ pp(args, before = "[", separator = ", ", after = "]") ++ r
+          val (beforeArgs, afterArgs) = {
+            if (!tpt.pos.isRange) ("", "") //<-- No brackets for tuples like (X, Y) - see #1001932
+            else ("[", "]")
+          }
+
+          l ++ p(tpt) ++ pp(args, before = beforeArgs, separator = ", ", after = afterArgs) ++ r
       }
     }
 

--- a/src/main/scala/scala/tools/refactoring/sourcegen/ReusingPrinter.scala
+++ b/src/main/scala/scala/tools/refactoring/sourcegen/ReusingPrinter.scala
@@ -74,7 +74,9 @@ trait ReusingPrinter extends TreePrintingTraversals with AbstractPrinter with Sc
         } else {
           Fragment(leadingParent, printedFragment.toLayout, trailingParent)
         }
-      } \\ (trace("Result " + getSimpleClassName(t) + ": %s", _))
+      } \\ { res =>
+        trace("Result " + getSimpleClassName(t) + ": %s", res)
+      }
 
       indentedFragment
     }

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
@@ -2977,4 +2977,35 @@ class Blubb
     }
     """
   } prepareAndApplyRefactoring(prepareAndRenameTo("ups"))
+
+  /*
+   * See Assembla Ticket 1001932
+   */
+  @Test
+  def testRenameAddsErroneusBrackets1001932() = new FileSet {
+    """
+    class /*(*/RenameMe/*)*/ {
+      def testFn: (List[RenameMe], Int) = ???
+    }
+    """ becomes
+    """
+    class /*(*/Hanswurst/*)*/ {
+      def testFn: (List[Hanswurst], Int) = ???
+    }
+    """ -> TaggedAsGlobalRename;
+  } prepareAndApplyRefactoring(prepareAndRenameTo("Hanswurst"))
+
+  @Test
+  def testSimilarButNotAffectedBy1001932() = new FileSet {
+    """
+    class /*(*/RenameMe/*)*/ {
+      def testFn: Tuple2[List[RenameMe], Int] = ???
+    }
+    """ becomes
+    """
+    class /*(*/Hanswurst/*)*/ {
+      def testFn: Tuple2[List[Hanswurst], Int] = ???
+    }
+    """ -> TaggedAsGlobalRename;
+  } prepareAndApplyRefactoring(prepareAndRenameTo("Hanswurst"))
 }

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
@@ -3008,4 +3008,76 @@ class Blubb
     }
     """ -> TaggedAsGlobalRename;
   } prepareAndApplyRefactoring(prepareAndRenameTo("Hanswurst"))
+
+  /*
+   * See Assembla Ticket 1002618
+   */
+  @Test
+  def testRenameBreaksCodeInGenericWithComments1002618Ex1() = new FileSet {
+    """
+    trait /*(*/RenameMe/*)*/ {
+      def works1: Map[Int, RenameMe]
+      def works2: Map[Int, /**/RenameMe]
+      def works3: Map[/**/ Int/**/, /**/RenameMe /**/ ]
+
+      def breaksFormat1: Map[Int,RenameMe]
+
+      def breaksCompile1: Map[Int,/**/RenameMe]
+      def breaksCompile2: Map[Int,/**/ RenameMe]
+
+      def breaksCompile3: Map[Int,/**/
+        RenameMe]
+    }
+    """ becomes
+    """
+    trait /*(*/Ups/*)*/ {
+      def works1: Map[Int, Ups]
+      def works2: Map[Int, /**/Ups]
+      def works3: Map[/**/ Int/**/, /**/Ups /**/ ]
+
+      def breaksFormat1: Map[Int,Ups]
+
+      def breaksCompile1: Map[Int,/**/Ups]
+      def breaksCompile2: Map[Int,/**/ Ups]
+
+      def breaksCompile3: Map[Int,/**/
+        Ups]
+    }
+    """ -> TaggedAsGlobalRename;
+  } prepareAndApplyRefactoring(prepareAndRenameTo("Ups"))
+
+  @Test
+  def testRenameBreaksCodeInGenericWithComments1002618Ex2() = new FileSet {
+    """
+    trait /*(*/RenameMe/*)*/ {
+      def works1: (Int, RenameMe)
+      def works2: (Int, /**/RenameMe)
+      def works3: (/**/ Int/**/, /**/RenameMe /**/ )
+
+      def breaksFormat1: (Int,RenameMe)
+
+      def breaksCompile1: (Int,/**/RenameMe)
+      def breaksCompile2: (Int,/**/ RenameMe)
+
+      def breaksCompile3: (Int,/**/
+        RenameMe)
+    }
+    """ becomes
+    """
+    trait /*(*/Ups/*)*/ {
+      def works1: (Int, Ups)
+      def works2: (Int, /**/Ups)
+      def works3: (/**/ Int/**/, /**/Ups /**/ )
+
+      def breaksFormat1: (Int,Ups)
+
+      def breaksCompile1: (Int,/**/Ups)
+      def breaksCompile2: (Int,/**/ Ups)
+
+      def breaksCompile3: (Int,/**/
+        Ups)
+    }
+    """ -> TaggedAsGlobalRename;
+  } prepareAndApplyRefactoring(prepareAndRenameTo("Ups"))
+
 }

--- a/src/test/scala/scala/tools/refactoring/tests/sourcegen/IndividualSourceGenTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/sourcegen/IndividualSourceGenTest.scala
@@ -1136,8 +1136,8 @@ class A(a: Int) {
     package abc
     object primitive {
       def append[A](li1: List[A], li2: List[A]) = Nil
-      ▒
-      List("Def").append(List("asd"))
+       List("Def").append(List("asd")
+          )
     }
     """), generateText(result.get))
   }


### PR DESCRIPTION
Fixes [#1001932](https://www.assembla.com/spaces/scala-ide/tickets/1001932-refactoring-name-change-adds-extraneous-square-brackets/details#) and [#1002618](https://www.assembla.com/spaces/scala-ide/tickets/1002618-rename-class-breaks-code-in-generic-when-comments-spaces-are-involved/details#). More details can be found in the commit messages.

Note that I'm not sure if I'm happy with the last commit, that adds a tweak for a single test (that would still generate compiling code without it). I'd really like to hear your opinions on that!