### PR TITLE
Treat nested imports more carefully

### DIFF
--- a/src/main/scala/scala/tools/refactoring/analysis/CompilationUnitDependencies.scala
+++ b/src/main/scala/scala/tools/refactoring/analysis/CompilationUnitDependencies.scala
@@ -250,7 +250,7 @@ trait CompilationUnitDependencies extends CompilerApiExtensions with ScalaVersio
             case List(singleSelector) =>
               tree match {
                 case Select(q, n) =>
-                  compareSyms || (q.symbol == imp.expr.symbol && (n == singleSelector.name || singleSelector.name == nme.WILDCARD))
+                  q.symbol == imp.expr.symbol && (n == singleSelector.name || singleSelector.name == nme.WILDCARD)
                 case _ => compareSyms
               }
             case _ => compareSyms
@@ -365,7 +365,7 @@ trait CompilationUnitDependencies extends CompilerApiExtensions with ScalaVersio
                   && t.name != nme.WILDCARD
                   && hasStableQualifier(t)
                   && !t.symbol.isLocal
-                  && !isRelativeToLocalImports(qual)
+                  && !isRelativeToLocalImports(t)
                   && !isDefinedLocallyAndQualifiedWithEnclosingPackage(t)) {
                 addToResult(t)
               }

--- a/src/main/scala/scala/tools/refactoring/analysis/CompilationUnitDependencies.scala
+++ b/src/main/scala/scala/tools/refactoring/analysis/CompilationUnitDependencies.scala
@@ -431,7 +431,7 @@ trait CompilationUnitDependencies extends CompilerApiExtensions with ScalaVersio
             localImports = localImportsForParent
           }
 
-          if (popPkgDefStack && pkgDefStack.nonEmpty) {
+          if (popPkgDefStack) {
             pkgDefStack = pkgDefStack.tail
           }
         }

--- a/src/test/scala/scala/tools/refactoring/tests/analysis/CompilationUnitDependenciesTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/analysis/CompilationUnitDependenciesTest.scala
@@ -244,8 +244,7 @@ class CompilationUnitDependenciesTest extends TestHelper with CompilationUnitDep
 
   @Test
   def localImport() = assertDependencies(
-    """scala.this.Predef.println
-       x.B""",
+    """scala.this.Predef.println""",
     """
       class A {
         val B = new {

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
@@ -845,4 +845,113 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
     }
     """
   } applyRefactoring organizeCustomized(groupPkgs = List("java", "scala", "java"))
+
+  /*
+   * See Assembla Ticket 1002613
+   */
+  @Test
+  def organizeImportsRemovesNeededImport1002613Ex1() = new FileSet {
+    """
+    package test
+
+    import java.util.Collections
+
+    class Bug {
+      import Collections.emptyList
+
+      def test = emptyList
+    }
+    """ isNotModified
+  } applyRefactoring organizeWithTypicalParams
+
+  @Test
+  def organizeImportsRemovesNeededImport1002613Ex2() = new FileSet {
+    """
+    package test
+
+    import java.util.Collections
+
+    class Bug {
+      import java.util.Collections.emptyList
+
+      def test = emptyList
+    }
+    """ becomes
+    """
+    package test
+
+    class Bug {
+      import java.util.Collections.emptyList
+
+      def test = emptyList
+    }
+    """
+  } applyRefactoring organizeWithTypicalParams
+
+  @Test
+  def organizeImportsRemovesNeededImport1002613Ex3() = new FileSet {
+    """
+    package test
+
+    import java.util.Collections.emptyList
+
+    class Bug {
+      import java.util.Collections.emptyList
+
+      def test = emptyList
+    }
+    """ becomes
+    """
+    package test
+
+    class Bug {
+      import java.util.Collections.emptyList
+
+      def test = emptyList
+    }
+    """
+  } applyRefactoring organizeWithTypicalParams
+
+  @Test
+  def organizeImportsRemovesNeededImport1002613Ex4() = new FileSet {
+    """
+    package test
+
+    import java.util.Collections
+
+    class Bug {
+      def test = {
+        import Collections.emptyList
+        emptyList
+      }
+    }
+    """ isNotModified
+  } applyRefactoring organizeWithTypicalParams
+
+  @Test
+  def organizeImportsSimilarButNotAffectedBy1002613Ex1() = new FileSet {
+    """
+    package test
+
+    import java.util.Collections.emptyList
+
+    class Bug {
+      import java.util.Collections
+      import Collections.emptyList
+
+      def test = emptyList
+    }
+    """ becomes
+    """
+    package test
+
+    class Bug {
+      import java.util.Collections
+      import Collections.emptyList
+
+      def test = emptyList
+    }
+    """
+  } applyRefactoring organizeWithTypicalParams
+
 }

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
@@ -954,4 +954,48 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
     """
   } applyRefactoring organizeWithTypicalParams
 
+  @Test
+  def organizeImportsWithSimilarImportsAtDifferentScopesEx1() = new FileSet {
+    """
+    package com.github.mlangc.experiments
+
+    import java.util.Arrays
+
+    class Bug4 {
+      import java.util.Collections
+
+      def test1 = Arrays.asList(1, 2)
+      def test2 = Collections.emptyList
+    }
+    """ isNotModified
+  } applyRefactoring organizeWithTypicalParams
+
+  @Test
+  def organizeImportsWithSimilarImportsAtDifferentScopesEx2() = new FileSet {
+    """
+    package com.github.mlangc.experiments
+
+    import java.util.Arrays
+    import java.util.Collections
+
+    class Bug4 {
+      import java.util.Collections
+
+      def test1 = Arrays.asList(1, 2)
+      def test2 = Collections.emptyList
+    }
+    """ becomes
+    """
+    package com.github.mlangc.experiments
+
+    import java.util.Arrays
+
+    class Bug4 {
+      import java.util.Collections
+
+      def test1 = Arrays.asList(1, 2)
+      def test2 = Collections.emptyList
+    }
+    """
+  } applyRefactoring organizeWithTypicalParams
 }


### PR DESCRIPTION
This PR is mostly concerned with compilation unit dependency calculation and fixes [Ticket #1002613](https://www.assembla.com/spaces/scala-ide/tickets/1002613). I think that additional tweaks will be needed, so feel free to come up with test cases that fail with the current implementation ;-).