### PR TITLE
Don't omit closing paren after rename operation

### DIFF
--- a/src/main/scala/scala/tools/refactoring/sourcegen/ReusingPrinter.scala
+++ b/src/main/scala/scala/tools/refactoring/sourcegen/ReusingPrinter.scala
@@ -1006,7 +1006,12 @@ trait ReusingPrinter extends TreePrintingTraversals with AbstractPrinter with Sc
       val parameters = {
         // The `)` is always removed from the layout, so if we have an empty
         // parameter list and `()` in the source, we need to insert it here.
-        if (vparamss == List(List()) && modsAndName.asText.endsWith("(")) {
+        def modsAndNameEndsWithOpenParen = {
+          val srcAtEnd = SourceWithMarker(modsAndName.asText).withMarkerAtLastChar
+          srcAtEnd.moveMarkerBack(commentsAndSpaces).currentOption == Some('(')
+        }
+
+        if (vparamss == List(List()) && modsAndNameEndsWithOpenParen) {
           Fragment(")")
         } else {
           tree.explicitVParamss.map { vparams =>

--- a/src/main/scala/scala/tools/refactoring/util/SourceWithMarker.scala
+++ b/src/main/scala/scala/tools/refactoring/util/SourceWithMarker.scala
@@ -25,7 +25,16 @@ final case class SourceWithMarker(source: IndexedSeq[Char] = IndexedSeq(), marke
     moveMarker(movement.backward)
   }
 
+  def withMarkerAtLastChar: SourceWithMarker = {
+    copy(marker = source.size - 1)
+  }
+
   def current: Char = source(marker)
+
+  def currentOption: Option[Char] = {
+    if (isDepleted) None
+    else Some(source(marker))
+  }
 
   def isInRange(i: Int): Boolean = {
     i >= 0 && i < source.length

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
@@ -3080,4 +3080,81 @@ class Blubb
     """ -> TaggedAsGlobalRename;
   } prepareAndApplyRefactoring(prepareAndRenameTo("Ups"))
 
+  @Test
+  def testRenameFunWithMultlineParen1002620Ex1() = new FileSet {
+    """
+    class Bug {
+      def /*(*/renameMe/*)*/(
+          ) = 1
+    }
+    """ becomes
+    """
+    class Bug {
+      def /*(*/ups/*)*/(
+          ) = 1
+    }
+    """ -> TaggedAsGlobalRename;
+  } prepareAndApplyRefactoring(prepareAndRenameTo("ups"))
+
+  @Test
+  def testRenameFunWithMultlineParen1002620Ex2() = new FileSet {
+    """
+    class Bug {
+      def /*(*/renameMe/*)*/(//..
+          //..
+          ) = 1
+    }
+    """ becomes
+    """
+    class Bug {
+      def /*(*/ups/*)*/(//..
+          //..
+          ) = 1
+    }
+    """ -> TaggedAsGlobalRename;
+  } prepareAndApplyRefactoring(prepareAndRenameTo("ups"))
+
+  @Test
+  def testRenameFunWithMultlineParen1002620Ex3() = new FileSet {
+    """
+    class Bug {
+      def /*(*/renameMe/*)*/( /*....*/ //..
+          //..
+          /* :-) :-() :-)*/
+
+          /*
+           * ???
+           */
+
+          ) = 1
+    }
+    """ becomes
+    """
+    class Bug {
+      def /*(*/ups/*)*/( /*....*/ //..
+          //..
+          /* :-) :-() :-)*/
+
+          /*
+           * ???
+           */
+
+          ) = 1
+    }
+    """ -> TaggedAsGlobalRename;
+  } prepareAndApplyRefactoring(prepareAndRenameTo("ups"))
+
+  @Test
+  def testRenameSimilarButNotAffectedBy1002620() = new FileSet {
+    """
+    class Bug {
+      def /*(*/renameMe/*)*/() = 1
+    }
+    """ becomes
+    """
+    class Bug {
+      def /*(*/ups/*)*/() = 1
+    }
+    """ -> TaggedAsGlobalRename;
+  } prepareAndApplyRefactoring(prepareAndRenameTo("ups"))
 }


### PR DESCRIPTION
Fixes [#1002620](https://www.assembla.com/spaces/scala-ide/tickets/1002620-renaming-a-function-id-with-multi-line-parentheses/details#)