### PR TITLE
Fix for t1002619

### DIFF
--- a/src/main/scala/scala/tools/refactoring/sourcegen/SourceUtils.scala
+++ b/src/main/scala/scala/tools/refactoring/sourcegen/SourceUtils.scala
@@ -118,7 +118,6 @@ trait SourceUtils {
     (openingBraces, closingBraces)
   }
 
-
   def stripFromCode(source: String, c: Char) = {
 
     val (rest, comments) = splitComment(source)

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/AddImportStatementTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/AddImportStatementTest.scala
@@ -439,4 +439,23 @@ object T
       class X
       """)
   }
+
+  @Test
+  def doNotAddOpeningParenOnImportWhenOpeningParenIsMissingInDocument() = {
+    addImport(("java.io", "InputStream"), """
+      object X {
+        def f is: InputStream)
+      }
+
+      class X
+      """, """
+      import java.io.InputStream
+
+      object X {
+        def f is: InputStream)
+      }
+
+      class X
+      """)
+  }
 }

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/AddImportStatementTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/AddImportStatementTest.scala
@@ -19,7 +19,7 @@ class AddImportStatementTest extends TestHelper {
   def addImport(imp: (String, String), src: String, expected: String) = global.ask { () =>
 
     val refactoring = new AddImportStatement  {
-      val global = outer.global
+      override val global = outer.global
       val file = addToCompiler(UniqueNames.basename(), src)
       val change = addImport(file, imp._1 + "." + imp._2)
     }
@@ -304,7 +304,6 @@ object T
     """)
   }
 
-
   /*
    * See Assembla ticket #1002088
    */
@@ -417,5 +416,24 @@ object T
       val a: ActionX = null
     }
     """)
+  }
+
+  @Test
+  def doNotAddClosingParenOnImportWhenClosingParenIsMissingInDocument() = {
+    addImport(("java.io", "InputStream"), """
+      object X {
+        def f(is: InputStream
+      }
+
+      class X
+      """, """
+      import java.io.InputStream
+
+      object X {
+        def f(is: InputStream
+      }
+
+      class X
+      """)
   }
 }

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/AddImportStatementTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/AddImportStatementTest.scala
@@ -418,6 +418,9 @@ object T
     """)
   }
 
+  /*
+   * See Assembla Ticket #1002619
+   */
   @Test
   def doNotAddClosingParenOnImportWhenClosingParenIsMissingInDocument() = {
     addImport(("java.io", "InputStream"), """

--- a/src/test/scala/scala/tools/refactoring/tests/sourcegen/SourceUtilsTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/sourcegen/SourceUtilsTest.scala
@@ -133,7 +133,6 @@ class SourceUtilsTest {
           """
       ) :: Nil
 
-
       testCases.foreach((testSplitComment _).tupled)
   }
 


### PR DESCRIPTION
This is a fix for [#1002619](https://scala-ide-portfolio.assembla.com/spaces/scala-ide/tickets/1002619-overlapping-text-edits-on-code-completion/details#). It is a complicated fix, since the document is broken.