### PR TITLE
Fixes Organize Imports in non-package blocks

### DIFF
--- a/src/main/scala/scala/tools/refactoring/analysis/CompilationUnitDependencies.scala
+++ b/src/main/scala/scala/tools/refactoring/analysis/CompilationUnitDependencies.scala
@@ -267,13 +267,10 @@ trait CompilationUnitDependencies extends CompilerApiExtensions with ScalaVersio
         imports.exists { imp =>
           def compareSyms = imp.expr.symbol == tree.symbol
 
-          imp.selectors match {
-            case List(singleSelector) =>
-              tree match {
-                case Select(q, n) =>
-                  q.symbol == imp.expr.symbol && (n == singleSelector.name || singleSelector.name == nme.WILDCARD)
-                case _ => compareSyms
-              }
+          val impSelectorNames = imp.selectors.map { _.name }
+          tree match {
+            case Select(q, n) =>
+              q.symbol == imp.expr.symbol && impSelectorNames.exists { name => name == nme.WILDCARD || name == n }
             case _ => compareSyms
           }
         }
@@ -481,7 +478,7 @@ trait CompilationUnitDependencies extends CompilerApiExtensions with ScalaVersio
 
     val deps = result.values.toList
 
-    deps.filterNot(_.symbol.isPackage).toList
+    deps.filterNot(_.symbol.hasPackageFlag).toList
   }
 }
 

--- a/src/main/scala/scala/tools/refactoring/implementations/OrganizeImports.scala
+++ b/src/main/scala/scala/tools/refactoring/implementations/OrganizeImports.scala
@@ -484,9 +484,10 @@ abstract class OrganizeImports extends MultiStageRefactoring with TreeFactory wi
 
     def organizeImportsInNonPackageBlocks(tree: Tree): Tree = new Transformer {
       override def transform(t: Tree) = t match {
-        case b @ Block(stats, expr) if !currentOwner.hasPackageFlag =>
+        case b @ Block(stats, _) if !currentOwner.hasPackageFlag =>
           val (imports, others) = stats.partition { _.isInstanceOf[Import] }
-          b.copy(stats = scala.Function.chain(participants)(imports.asInstanceOf[List[Import]]) ::: others)
+          b.copy(stats = scala.Function.chain(participants)(imports.asInstanceOf[List[Import]]) ::: others).replaces(b)
+        case skipPlainText: PlainText => skipPlainText
         case t => super.transform(t)
       }
     }.transform(tree)

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
@@ -1324,7 +1324,7 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
   } applyRefactoring organizeWithTypicalParams
 
   @Test
-  def importsScatteredInValAndVarShouldBeProcessedLikeForDef() = new FileSet {
+  def importsShouldNotBeModifiedInVarValLazyValAndLambda() = new FileSet {
     """
     package acme
 
@@ -1359,26 +1359,17 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
         import acme.Acme.B
         B + C + bar
       }
-    }
-    """ becomes {
-    """
-    /*<-*/
-    package test
-
-    class Bar {
-      var bar = {
-        import acme.Acme.A
-        import fake.Acme.D
-        val d = D
-        A + d
-      }
-      val foo = {
-        import acme.Acme.B
+      lazy val baz = {
         import fake.Acme.C
+        import acme.Acme.B
+        B + C + bar
+      }
+      def foe = List(1).map { _ =>
+        import fake.Acme.C
+        import acme.Acme.B
         B + C + bar
       }
     }
-    """
-    }
-  } applyRefactoring organizeWithTypicalParams
+    """ isNotModified
+    } applyRefactoring organizeWithTypicalParams
 }

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
@@ -1407,4 +1407,149 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
     }
     """ isNotModified
   } applyRefactoring organizeWithTypicalParams
+
+  @Test
+  def unusedImportsInDefShouldBeRemoved() = new FileSet {
+    """
+    package acme
+
+    object Acme {
+      val A = 5
+      val B = 6
+    }
+    """ isNotModified
+
+    """
+    package fake
+
+    object Acme {
+      val C = 7
+      val D = 11
+    }
+    """ isNotModified
+
+    """
+    /*<-*/
+    package test
+
+    class Bar {
+      def foo = {
+        import fake.Acme.D
+        val d = D
+        import acme.Acme.A
+        def k = {
+          import fake.Acme.C
+          import acme.Acme.B
+          B + d
+        }
+      }
+    }
+    """ becomes {
+    """
+    /*<-*/
+    package test
+
+    class Bar {
+      def foo = {
+        import fake.Acme.D
+        val d = D
+        def k = {
+          import acme.Acme.B
+          B + d
+        }
+      }
+    }
+    """
+    }
+  } applyRefactoring organizeWithTypicalParams
+
+  @Test
+  def unusedImportsInDefInImportSelectorsShouldBeRemoved() = new FileSet {
+    """
+    package acme
+
+    object Acme {
+      val A = 5
+      val B = 6
+    }
+    """ isNotModified
+
+    """
+    package fake
+
+    object Acme {
+      val C = 7
+      val D = 11
+    }
+    """ isNotModified
+
+    """
+    /*<-*/
+    package test
+
+    class Bar {
+      def foo = {
+        import fake.Acme.{C, D}
+        val d = D
+      }
+    }
+    """ becomes {
+    """
+    /*<-*/
+    package test
+
+    class Bar {
+      def foo = {
+        import fake.Acme.D
+        val d = D
+      }
+    }
+    """
+    }
+  } applyRefactoring organizeWithTypicalParams
+
+  @Test
+  def unusedRenamedImportsInDefInImportSelectorsShouldBeRemoved() = new FileSet {
+    """
+    package acme
+
+    object Acme {
+      val A = 5
+      val B = 6
+    }
+    """ isNotModified
+
+    """
+    package fake
+
+    object Acme {
+      val C = 7
+      val D = 11
+    }
+    """ isNotModified
+
+    """
+    /*<-*/
+    package test
+
+    class Bar {
+      def foo = {
+        import fake.Acme.{C => V, D => U}
+        val d = U
+      }
+    }
+    """ becomes {
+    """
+    /*<-*/
+    package test
+
+    class Bar {
+      def foo = {
+        import fake.Acme.{D => U}
+        val d = D
+      }
+    }
+    """
+    }
+  } applyRefactoring organizeWithTypicalParams
 }

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
@@ -1374,7 +1374,7 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
     } applyRefactoring organizeWithTypicalParams
 
   @Test
-  def importsScatteredInSameLineOfDefShouldBeRearranged() = new FileSet {
+  def importsScatteredInSameLineOfDefShouldNotBeRearranged() = new FileSet {
     """
     package acme
 
@@ -1405,24 +1405,6 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
         A + B + C
       }
     }
-    """ becomes {
-    """
-    /*<-*/
-    package test
-
-    class Bar {
-      def foo = {
-        import fake.Acme.C
-        import fake.Acme.D
-        C + D}
-      def k = {
-        import acme.Acme.A
-        import acme.Acme.B
-        import fake.Acme.C
-        A + B + C
-      }
-    }
-    """
-    }
+    """ isNotModified
   } applyRefactoring organizeWithTypicalParams
 }

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
@@ -1372,4 +1372,57 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
     }
     """ isNotModified
     } applyRefactoring organizeWithTypicalParams
+
+  @Test
+  def importsScatteredInSameLineOfDefShouldBeRearranged() = new FileSet {
+    """
+    package acme
+
+    object Acme {
+      val A = 5
+      val B = 6
+    }
+    """ isNotModified
+
+    """
+    package fake
+
+    object Acme {
+      val C = 7
+      val D = 11
+    }
+    """ isNotModified
+
+    """
+    /*<-*/
+    package test
+
+    class Bar {
+      def foo = {import fake.Acme.D; import fake.Acme.C; C + D}
+      def k = {
+        import fake.Acme.C; import acme.Acme.A
+        import acme.Acme.B
+        A + B + C
+      }
+    }
+    """ becomes {
+    """
+    /*<-*/
+    package test
+
+    class Bar {
+      def foo = {
+        import fake.Acme.C
+        import fake.Acme.D
+        C + D}
+      def k = {
+        import acme.Acme.A
+        import acme.Acme.B
+        import fake.Acme.C
+        A + B + C
+      }
+    }
+    """
+    }
+  } applyRefactoring organizeWithTypicalParams
 }

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
@@ -1171,4 +1171,50 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
     }
     """ isNotModified
   } applyRefactoring organizeCustomized(dependencies = Dependencies.RecomputeAndModify)
+
+  @Test
+  def organizeImportsInDefShouldSortImports() = new FileSet {
+    """
+    package acme
+
+    object Acme {
+      val A = 5
+      val B = 6
+    }
+    """ isNotModified
+
+    """
+    package fake
+
+    object Acme {
+      val C = 7
+    }
+    """ isNotModified
+
+    """
+    /*<-*/
+    package test
+
+    class Bar {
+      def foo = {
+        import fake.Acme.C
+        import acme.Acme.{B, A}
+        A + B + C
+      }
+    }
+    """ becomes {
+    """
+    /*<-*/
+    package test
+
+    class Bar {
+      def foo = {
+        import acme.Acme.{A, B}
+        import fake.Acme.C
+        A + B + C
+      }
+    }
+    """
+    }
+  } applyRefactoring organizeWithTypicalParams
 }


### PR DESCRIPTION
Organize Imports is not able to rearrange imports in blocks of
codes which are not top level package one. So it is not rearrange
following imports in snippet below:
```
package acme.foo

class Foo {
  def foo() = {
    import acme.ctes.Ctes.C
    import acme.ctes.Ctes.{ B, A }

    C + B + A
  }
}
```
with this fix it should turn to:
```
package acme.foo

class Foo {
  def foo() = {
    import acme.ctes.Ctes.{ A, B }
    import acme.ctes.Ctes.C

    C + B + A
  }
}
```
Fixes #1001078