### PR TITLE
Prevents import removal for existential type

### DIFF
--- a/src/main/scala/scala/tools/refactoring/common/TreeTraverser.scala
+++ b/src/main/scala/scala/tools/refactoring/common/TreeTraverser.scala
@@ -164,8 +164,13 @@ trait TreeTraverser {
               handleAnnotations(at.annotations)
               traverse(t.original)
 
-            case (ExistentialType(quantified, TypeRef(_, sym, _)), ExistentialTypeTree(AppliedTypeTree(tpt, _), _)) =>
-              fakeSelectTree(sym.tpe, sym, tpt) foreach traverse
+            case (ExistentialType(quantified, TypeRef(typ, sym, args)), ExistentialTypeTree(AppliedTypeTree(tpt, argsTrees), _)) =>
+              argsTrees.foreach {
+                traverse
+              }
+              fakeSelectTree(sym.tpe, sym, tpt).foreach {
+                traverse
+              }
 
             case (tpe: TypeRef, ident: Ident)
                 if tpe.sym.pos == NoPosition || (tpe.sym.pos != NoPosition && tpe.sym.pos.source != t.pos.source) =>

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
@@ -1784,4 +1784,147 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
     """
     }
   } applyRefactoring organizeWithTypicalParams
+
+  @Test
+  def shouldDiscoverArgTypeInExistentialTypeOfMethodDeclarationAndNotRemoveItFromImports() = new FileSet {
+    """
+    /*<-*/
+    package test
+
+    import scala.util.Either
+    import scala.util.Try
+
+    trait A {
+      def foo: (Try[Unit], _)
+    }
+    """ becomes {
+    """
+    /*<-*/
+    package test
+
+    import scala.util.Try
+
+    trait A {
+      def foo: (Try[Unit], _)
+    }
+    """
+    }
+  } applyRefactoring organizeWithTypicalParams
+
+  @Test
+  def shouldDiscoverArgTypeInExistentialTypeOfClassDeclarationAndNotRemoveItFromImports() = new FileSet {
+    """
+    /*<-*/
+    package test
+
+    import scala.util.Either
+    import scala.util.Try
+
+    class TestTE(val a: (Try[_], _))
+    """ becomes {
+    """
+    /*<-*/
+    package test
+
+    import scala.util.Try
+
+    class TestTE(val a: (Try[_], _))
+    """
+    }
+  } applyRefactoring organizeWithTypicalParams
+
+  @Test
+  def shouldDiscoverArgTypeInInnerExistentialTypeOfClassDeclarationAndNotRemoveItFromImports() = new FileSet {
+    """
+    /*<-*/
+    package test
+
+    import scala.util.Either
+    import scala.util.Try
+
+    class TestTE(val a: (Try[_], Int))
+    """ becomes {
+    """
+    /*<-*/
+    package test
+
+    import scala.util.Try
+
+    class TestTE(val a: (Try[_], Int))
+    """
+    }
+  } applyRefactoring organizeWithTypicalParams
+
+  @Test
+  def shouldDiscoverArgTypeInExistentialTypeOfHigherKindedTypeAndNotRemoveItFromImports() = new FileSet {
+    """
+    /*<-*/
+    package test
+
+    import scala.util.Either
+    import scala.util.Try
+
+    trait Test[Try, B]
+    class ParamCheck[A]
+    class Verify extends ParamCheck[Test[_, Either[_, _]]]
+    """ becomes {
+    """
+    /*<-*/
+    package test
+
+    import scala.util.Either
+
+    trait Test[Try, B]
+    class ParamCheck[A]
+    class Verify extends ParamCheck[Test[_, Either[_, _]]]
+    """
+    }
+  } applyRefactoring organizeWithTypicalParams
+
+  @Test
+  def shouldDiscoverArgTypeInExistentialTypeOfDeepInHigherKindedTypeAndNotRemoveItFromImports() = new FileSet {
+    """
+    /*<-*/
+    package test
+
+    import scala.util.Either
+    import scala.util.Try
+
+    trait Test[Try, B]
+    class ParamCheck[A]
+    class Verify extends ParamCheck[Test[_, Either[_, Try[_]]]]
+    """ becomes {
+    """
+    /*<-*/
+    package test
+
+    import scala.util.Either
+    import scala.util.Try
+
+    trait Test[Try, B]
+    class ParamCheck[A]
+    class Verify extends ParamCheck[Test[_, Either[_, Try[_]]]]
+    """
+    }
+  } applyRefactoring organizeWithTypicalParams
+
+  @Test
+  def shouldNotDiscoverArgTypeInExistentialTypeOfClassDeclarationAndRemoveItFromImports() = new FileSet {
+    """
+    /*<-*/
+    package test
+
+    import scala.util.Either
+    import scala.util.Try
+
+    class TestTE(val a: (_, _))
+    """ becomes {
+    """
+    /*<-*/
+    package test
+
+    class TestTE(val a: (_, _))
+    """
+    }
+  } applyRefactoring organizeWithTypicalParams
 }


### PR DESCRIPTION
in case of
```
import scala.util.Try

class Test(val a: (Try[_], _))
```
the Organize Imports action removes `import scala.util.Try`.

For more found cases refer to tests.

fixes #1002621