### PR TITLE
 Enable inline refactoring for private values 

### DIFF
--- a/src/main/scala/scala/tools/refactoring/implementations/InlineLocal.scala
+++ b/src/main/scala/scala/tools/refactoring/implementations/InlineLocal.scala
@@ -28,8 +28,7 @@ abstract class InlineLocal extends MultiStageRefactoring with ParameterlessRefac
 
     selectedValue match {
       case Some(t) if (t.symbol.isPrivate || t.symbol.isLocal)
-        && !t.symbol.isMutable && !t.symbol.isValueParameter
-        && t.symbol.enclMethod != NoSymbol => Right(t)
+        && !t.symbol.isMutable && !t.symbol.isValueParameter => Right(t)
       case Some(t) =>
         Left(PreparationError("The selected value cannot be inlined."))
       case None =>

--- a/src/main/scala/scala/tools/refactoring/implementations/InlineLocal.scala
+++ b/src/main/scala/scala/tools/refactoring/implementations/InlineLocal.scala
@@ -13,9 +13,9 @@ abstract class InlineLocal extends MultiStageRefactoring with ParameterlessRefac
 
   import global._
 
-  type PreparationResult = ValDef
+  override type PreparationResult = ValDef
 
-  def prepare(s: Selection) = {
+  override def prepare(s: Selection) = {
 
     val selectedValue = s.findSelectedOfType[RefTree] match {
       case Some(t) =>
@@ -26,9 +26,12 @@ abstract class InlineLocal extends MultiStageRefactoring with ParameterlessRefac
       case None => s.findSelectedOfType[ValDef]
     }
 
+    def isInliningAllowed(sym: Symbol) =
+      (sym.isPrivate || sym.isLocal) && !sym.isMutable && !sym.isValueParameter
+
     selectedValue match {
-      case Some(t) if (t.symbol.isPrivate || t.symbol.isLocal)
-        && !t.symbol.isMutable && !t.symbol.isValueParameter => Right(t)
+      case Some(t) if isInliningAllowed(t.symbol) =>
+        Right(t)
       case Some(t) =>
         Left(PreparationError("The selected value cannot be inlined."))
       case None =>
@@ -36,7 +39,7 @@ abstract class InlineLocal extends MultiStageRefactoring with ParameterlessRefac
     }
   }
 
-  def perform(selection: Selection, selectedValue: PreparationResult): Either[RefactoringError, List[Change]] = {
+  override def perform(selection: Selection, selectedValue: PreparationResult): Either[RefactoringError, List[Change]] = {
 
     trace("Selected: %s", selectedValue)
 
@@ -57,7 +60,6 @@ abstract class InlineLocal extends MultiStageRefactoring with ParameterlessRefac
     val references = index references selectedValue.symbol
 
     val replaceReferenceWithRhs = {
-
 
       val replacement = selectedValue.rhs match {
         // inlining `list.filter _` should not include the `_`

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/InlineLocalTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/InlineLocalTest.scala
@@ -576,4 +576,24 @@ object Test extends App {
     }
     """ becomes ""
   } applyRefactoring(inline)
+
+  @Test
+  def inlinePrivateValue() = new FileSet {
+    """
+    class A {
+      /*(*/private val n = 1/*)*/
+
+      val x = n + 1
+
+      def f = n
+    }
+    """ becomes """
+    class A {
+
+      val x = 1 + 1
+
+      def f = 1
+    }
+    """
+  } applyRefactoring(inline)
 }

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/InlineLocalTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/InlineLocalTest.scala
@@ -15,7 +15,7 @@ class InlineLocalTest extends TestHelper with TestRefactoring {
   outer =>
 
   def inline(pro: FileSet) = new TestRefactoringImpl(pro) {
-    val refactoring = new InlineLocal with TestProjectIndex
+    override val refactoring = new InlineLocal with TestProjectIndex
     val changes = performRefactoring()
   }.changes
 


### PR DESCRIPTION
I don't know why it was disabled for private values, seems to be an
oversight to me.

Fixes #1002648