### PR TITLE
Rename without tree printing

### DIFF
--- a/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
@@ -32,6 +32,22 @@ class RenameTest extends TestHelper with TestRefactoring {
   protected override def nestTestsInUniqueBasePackageByDefault = true
 
   /*
+   * See Assembla Ticket 1001966
+   */
+  @Test
+  def testRenameWithContextBounds1001966() = new FileSet {
+    """
+    trait Bar[T]
+    class /*(*/TryRenameMe/*)*/[T : Bar]
+    """ becomes
+    """
+    trait Bar[T]
+    class /*(*/Ups/*)*/[T : Bar]
+    """ -> TaggedAsGlobalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("Ups"))
+
+
+  /*
    * See Assembla Ticket 1002611
    */
   @Test

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
@@ -3241,4 +3241,49 @@ class Blubb
     case class Ups(buggy: Ups.Listings)
     """ -> TaggedAsGlobalRename;
   } prepareAndApplyRefactoring(prepareAndRenameTo("Ups"))
+
+  /*
+   * See Assembla Ticket 1002622
+   */
+  @Test
+  def testRenameWithDefaultArgsAndImplicits1002622() = new FileSet {
+    """
+    trait ImplicitVals {
+      implicit def x = 42
+    }
+
+    object Bug {
+      class Ret(x: Int) {
+        def withDefault(a: String = "") = a + x
+      }
+
+      def apply()(implicit x: Int) = {
+        new Ret(x)
+      }
+    }
+
+    class Bug extends ImplicitVals {
+      val /*(*/tryRenameMe/*)*/ = Bug().withDefault()
+    }
+    """ becomes
+    """
+    trait ImplicitVals {
+      implicit def x = 42
+    }
+
+    object Bug {
+      class Ret(x: Int) {
+        def withDefault(a: String = "") = a + x
+      }
+
+      def apply()(implicit x: Int) = {
+        new Ret(x)
+      }
+    }
+
+    class Bug extends ImplicitVals {
+      val /*(*/ups/*)*/ = Bug().withDefault()
+    }
+    """ -> TaggedAsGlobalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("ups"))
 }

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
@@ -3157,4 +3157,89 @@ class Blubb
     }
     """ -> TaggedAsGlobalRename;
   } prepareAndApplyRefactoring(prepareAndRenameTo("ups"))
+
+  /*
+   * See Assembla Ticket 1002643
+   */
+  @Test
+  def testRenameClassAddsParen1002643Ex1() = new FileSet {
+    """
+    object /*(*/TryRenameMe/*)*/ {
+      object Listings {
+        case class Info(plausiblePrices: Seq[(String, Double)] = Seq(), unplausiblePrices: Seq[(String, Double)] = Seq())
+      }
+
+      case class RegionInfo(regionName: String, listings: Listings.Info)
+
+      case class Listings(
+          forRegion: RegionInfo,
+          forSupRegion: Option[RegionInfo] = None,
+          forNeighbours: Seq[RegionInfo] = Seq())
+    }
+
+    case class TryRenameMe(
+        sqmPrice: Double,
+        regionName: String,
+        listingCategory: String,
+        listings: TryRenameMe.Listings)
+    """ becomes
+    """
+    object /*(*/Ups/*)*/ {
+      object Listings {
+        case class Info(plausiblePrices: Seq[(String, Double)] = Seq(), unplausiblePrices: Seq[(String, Double)] = Seq())
+      }
+
+      case class RegionInfo(regionName: String, listings: Listings.Info)
+
+      case class Listings(
+          forRegion: RegionInfo,
+          forSupRegion: Option[RegionInfo] = None,
+          forNeighbours: Seq[RegionInfo] = Seq())
+    }
+
+    case class Ups(
+        sqmPrice: Double,
+        regionName: String,
+        listingCategory: String,
+        listings: Ups.Listings)
+    """ -> TaggedAsGlobalRename;
+  } prepareAndApplyRefactoring(prepareAndRenameTo("Ups"))
+
+  @Test
+  def testRenameClassAddsParen1002643Ex2() = new FileSet {
+    """
+    object /*(*/TryRenameMeToo/*)*/ {
+      class Listings
+    }
+
+    case class TryRenameMeToo(
+        buggy: TryRenameMeToo.Listings)
+    """ becomes
+    """
+    object /*(*/Ups/*)*/ {
+      class Listings
+    }
+
+    case class Ups(
+        buggy: Ups.Listings)
+    """ -> TaggedAsGlobalRename;
+  } prepareAndApplyRefactoring(prepareAndRenameTo("Ups"))
+
+  @Test
+  def testRenameSimilarButNotAffected1002643() = new FileSet {
+    """
+    object /*(*/TryRenameMeToo/*)*/ {
+      class Listings
+    }
+
+    case class TryRenameMeToo(buggy: TryRenameMeToo.Listings)
+    """ becomes
+    """
+    object /*(*/Ups/*)*/ {
+      class Listings
+    }
+
+    case class Ups(buggy: Ups.Listings)
+    """ -> TaggedAsGlobalRename;
+  } prepareAndApplyRefactoring(prepareAndRenameTo("Ups"))
 }

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
@@ -2054,7 +2054,6 @@ class Blubb
    * Correctly renaming package private lazy vals is not as easy as one might hope,
    * because of their representation in the ASTs, both as "ValDef"s and "DefDef"s.
    */
-  @Ignore
   @Test
   def testRenamePkgProtectedLazyVal() = new FileSet {
     """

--- a/src/test/scala/scala/tools/refactoring/tests/util/SourceWithMarkerTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/util/SourceWithMarkerTest.scala
@@ -286,17 +286,28 @@ class SourceWithMarkerTest {
     }
   }
 
+  private def runCoveredStringTest(input: String, start: Int, mvnt: SimpleMovement, shouldBeCovered: String): Unit = {
+    assertEquals(shouldBeCovered, Movement.coveredString(start, input, mvnt))
+  }
+
   @Test
   def testCoveredString(): Unit = {
-    def runTest(input: String, start: Int, mvnt: SimpleMovement, expected: String): Unit = {
-      assertEquals(expected, Movement.coveredString(start, input, mvnt))
-    }
+    runCoveredStringTest("", 0, any, "")
+    runCoveredStringTest("0", 0, any, "0")
+    runCoveredStringTest("1", 0, any.backward, "1")
+    runCoveredStringTest("1223", 1, '2'.zeroOrMore, "22")
+    runCoveredStringTest("1223", 1, '2'.zeroOrMore.backward, "2")
+  }
 
-    runTest("", 0, any, "")
-    runTest("0", 0, any, "0")
-    runTest("1", 0, any.backward, "1")
-    runTest("1223", 1, '2'.zeroOrMore, "22")
-    runTest("1223", 1, '2'.zeroOrMore.backward, "2")
+  @Test
+  def testScalaId(): Unit = {
+    def runIdTest(input: String, shouldBeCovered: String) = runCoveredStringTest(input, 0, Movements.id, shouldBeCovered)
+
+    runIdTest("", "")
+    runIdTest("x", "x")
+    runIdTest("privateval", "privateval")
+    runIdTest("val x = 3", "")
+    runIdTest("->", "->")
   }
 
   private implicit class SourceWithMarkerOps(underlying: SourceWithMarker) {


### PR DESCRIPTION
This PR implements the rename refactoring without tree printing, as discussed in Krakow. The implementation is more or less strait forward, and I think that the rename refactoring should now be more solid then ever before. The only fly in the ointment is that named arguments are still a problem, but I plan to look into this in the near future, since it really bugs me. Implementing this has been a very rewarding experience, and we should definitely continue to work in this direction (that is avoiding AST printing wherever possible).

Fixes [#1002643](https://www.assembla.com/spaces/scala-ide/tickets/1002643), [#1002622](https://www.assembla.com/spaces/scala-ide/tickets/1002622), [#1001966](https://www.assembla.com/spaces/scala-ide/tickets/1001966) and probably many undocumented bugs more.