### PR TITLE
Avoid tree printing in organize imports logic

### DIFF
--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
@@ -1927,4 +1927,39 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
     """
     }
   } applyRefactoring organizeWithTypicalParams
+
+  @Test
+  def shouldNotThrowAnExceptionForComplexExpressionsInMethodBody() = new FileSet {
+    """
+    /*<-*/
+    package test
+
+    object X {
+      val m = Map[String, String]()
+
+      def f = {
+        import scala.util.Try
+        for ((a, b) ← m)
+          println((a,b))
+        0
+      }
+    }
+    """ becomes {
+    """
+    /*<-*/
+    package test
+
+    object X {
+      val m = Map[String, String]()
+
+      def f = {
+        $
+        for ((a, b) ← m)
+          println((a,b))
+        0
+      }
+    }
+    """.replace("$", "")
+    }
+  } applyRefactoring organizeCustomized(dependencies = Dependencies.RecomputeAndModify)
 }


### PR DESCRIPTION
Tree printing is buggy and in this case it led to an exception because
some synthetic tree of a for comprehension was printed. In order to
avoid the exception we no longer call the tree printing logic at all.
Instead we compare symbols and their names, which leads along the way
to even better performance.

Fix #1002476

-------

Review by @wpopielarski 

There is still whitespace printed at the location where the import was (instead of completely removing the line), I couldn't figure out so far why that is the case. Anyone an idea?