### PR TITLE
 Generate correct version for nightly builds

### DIFF
--- a/META-INF/MANIFEST.MF
+++ b/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Scala Refactoring
 Bundle-SymbolicName: org.scala-refactoring.library
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.9.1.qualifier
 Require-Bundle: org.junit;bundle-version="4.11.0",
  org.scala-lang.scala-library
 Export-Package: scala.tools.refactoring,scala.tools.refactoring.analys

--- a/build.sbt
+++ b/build.sbt
@@ -39,12 +39,12 @@ useGpg := true
 
 fork := true
 
-publishTo <<= version { (v: String) =>
-  val nexus = "https://oss.sonatype.org/"
-  if (v.trim.endsWith("SNAPSHOT"))
-    Some("snapshots" at nexus + "content/repositories/snapshots")
+publishTo <<= isSnapshot { isSnapshot =>
+  val nexus = "https://oss.sonatype.org"
+  if (isSnapshot)
+    Some("snapshots" at s"$nexus/content/repositories/snapshots")
   else
-    Some("releases"  at nexus + "service/local/staging/deploy/maven2")
+    Some("releases"  at s"$nexus/service/local/staging/deploy/maven2")
 }
 
 publishArtifact in Test := false
@@ -76,11 +76,10 @@ pomExtra := (
 
 credentials += Credentials(Path.userHome / ".m2" / "credentials")
 
-libraryDependencies += {
-  "org.scala-lang" % "scala-compiler" % scalaVersion.value
-}
-
-libraryDependencies += "com.novocode" % "junit-interface" % "0.10" % "test"
+libraryDependencies ++= Seq(
+  "org.scala-lang"  % "scala-compiler"    % scalaVersion.value,
+  "com.novocode"    % "junit-interface"   % "0.10"              % "test"
+)
 
 parallelExecution in Test := false
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "org.scala-refactoring.library"
 
-version := "0.9.0-SNAPSHOT"
+version := "0.9.1-SNAPSHOT"
 
 scalaVersion := "2.11.7"
 

--- a/build.sbt
+++ b/build.sbt
@@ -84,8 +84,22 @@ libraryDependencies += "com.novocode" % "junit-interface" % "0.10" % "test"
 
 parallelExecution in Test := false
 
-// sbt doesn't automatically load the content of the MANIFST.MF file, therefore we have to do it here by ourselves
+// sbt doesn't automatically load the content of the MANIFST.MF file, therefore
+// we have to do it here by ourselves Furthermore, the version format in the
+// MANIFEST.MF is `x.y.z.qualifier` but we need to replace the `qualifier` part
+// with a unique identifier otherwise OSGi can't find out which nightly build
+// is newest and therefore not all caches are updated with the correct version
+// of a nightly.
 packageOptions in Compile in packageBin += {
-  val m = Using.fileInputStream(new java.io.File("META-INF/MANIFEST.MF"))(in => new java.util.jar.Manifest(in))
+  val m = Using.fileInputStream(new java.io.File("META-INF/MANIFEST.MF")) { in =>
+    val manifest = new java.util.jar.Manifest(in)
+    val attr = manifest.getMainAttributes
+    val key = "Bundle-Version"
+    val versionSuffix = scalaBinaryVersion.value.replace('.', '_')
+    val date = new java.text.SimpleDateFormat("yyyyMMddHHmm").format(new java.util.Date)
+    val sha = "git rev-parse --short HEAD".!!.trim
+    attr.putValue(key, attr.getValue(key).replace("qualifier", s"$versionSuffix-$date-$sha"))
+    manifest
+  }
   Package.JarManifest(m)
 }


### PR DESCRIPTION
See the ticket for a discussion about why we need this.

Fixes [#1002653](https://www.assembla.com/spaces/scala-ide/tickets/1002653-broken-upgrades-in-the-ide--scala-refactoring-dependency-is-not-versioned/details#)