### PR TITLE
Do not depend on tree transformations for the add import refactoring 

### DIFF
--- a/src/main/scala/scala/tools/refactoring/implementations/AddImportStatement.scala
+++ b/src/main/scala/scala/tools/refactoring/implementations/AddImportStatement.scala
@@ -12,7 +12,7 @@ import scala.tools.refactoring.common.TextChange
 
 abstract class AddImportStatement extends Refactoring with InteractiveScalaCompiler {
 
-  val global: tools.nsc.interactive.Global
+  override val global: tools.nsc.interactive.Global
 
   def addImport(file: AbstractFile, fqName: String): List[TextChange] = addImports(file, List(fqName))
 
@@ -20,9 +20,7 @@ abstract class AddImportStatement extends Refactoring with InteractiveScalaCompi
 
     val astRoot = abstractFileToTree(file)
 
-    refactor((addImportTransformation(importsToAdd) apply astRoot).toList) collect {
-      case tc: TextChange => tc
-    }
+    addImportTransformation(importsToAdd.toSeq)(astRoot).toList
   }
 
   @deprecated("Use addImport(file, ..) instead", "0.4.0")

--- a/src/main/scala/scala/tools/refactoring/transformation/TreeTransformations.scala
+++ b/src/main/scala/scala/tools/refactoring/transformation/TreeTransformations.scala
@@ -189,9 +189,10 @@ trait TreeTransformations extends Transformations with TreeFactory {
     }
 
     def insertAfter(pos: Position) = {
-      val line = pos.source.lineToString(pos.source.offsetToLine(pos.start))
+      val lineNumber = pos.source.offsetToLine(pos.start)
+      val line = pos.source.lineToString(lineNumber)
       val indent = line.takeWhile(Character.isWhitespace)
-      val insertPos = pos.end
+      val insertPos = pos.source.lineToOffset(lineNumber) + line.length
       TextChange(pos.source, insertPos, insertPos, "\n" + importsAsSrc(indent))
     }
 

--- a/src/main/scala/scala/tools/refactoring/transformation/TreeTransformations.scala
+++ b/src/main/scala/scala/tools/refactoring/transformation/TreeTransformations.scala
@@ -5,7 +5,7 @@
 package scala.tools.refactoring
 package transformation
 
-import language.implicitConversions
+import scala.tools.refactoring.common.TextChange
 
 trait TreeTransformations extends Transformations with TreeFactory {
 
@@ -13,7 +13,7 @@ trait TreeTransformations extends Transformations with TreeFactory {
 
   import global._
 
-  def traverse(tree: Tree, f: Tree => Tree): Tree = {
+  override def traverse(tree: Tree, f: Tree => Tree): Tree = {
 
     /**
      * Hooks into the Scala compiler's Transformer but applies only
@@ -177,40 +177,79 @@ trait TreeTransformations extends Transformations with TreeFactory {
     case t: global.Tree => t.pos = global.NoPosition; t
   }
 
-  def addImportTransformation(importsToAdd: Iterable[String]): Transformation[Tree, Tree] = {
-
-    import global._
-
-    def importTrees = {
-      val SplitAtDot = "(.*)\\.(.*?)".r
-      importsToAdd.map {
-        case SplitAtDot(pkg, name) => mkImportFromStrings(pkg, name)
-      }.toList
+  def addImportTransformation(importsToAdd: Seq[String]): Transformation[Tree, TextChange] = {
+    def splitImports(p: PackageDef, stats: List[Tree]) = {
+      val (imports, others) = stats partition (_.isInstanceOf[Import])
+      (p, imports map (_.asInstanceOf[Import]), others)
     }
 
-    val addImportStatement = once(findBestPackageForImports &> transformation[(PackageDef, List[Import], List[Tree]), Tree] {
+    def importsAsSrc(indent: String) = {
+      def escaped(imp: String) = imp.split('.').map(escapeScalaKeywordsForImport).mkString(".")
+      importsToAdd.map(imp ⇒ s"${indent}import ${escaped(imp)}").mkString("\n")
+    }
 
-      // For an empty PackageDef, with no exiting imports but with an Impl that has an annotation, we need to
-      // modify positions so that the annotation, which is not in the AST, doesn't get assigned to the PackageDef
-      // but to the Impl
-      case (p @ PackageDef(Ident(nme.EMPTY_PACKAGE_NAME), _), Nil, others @ (impl :: _)) if !impl.symbol.annotations.isEmpty =>
+    def insertAfter(pos: Position) = {
+      val line = pos.source.lineToString(pos.source.offsetToLine(pos.start))
+      val indent = line.takeWhile(Character.isWhitespace)
+      val insertPos = pos.end
+      TextChange(pos.source, insertPos, insertPos, "\n" + importsAsSrc(indent))
+    }
 
-        // The `pid` is invisible anyway, but by erasing its position we make sure
-        // it doesn't get any layout associated
-        val ignoredPid = p.pid setPos NoPosition
+    def insertBefore(pos: Position) = {
+      val lineNumber = pos.source.offsetToLine(pos.start)
+      val line = pos.source.lineToString(lineNumber)
+      val indent = line.takeWhile(Character.isWhitespace)
+      val insertPos = pos.source.lineToOffset(lineNumber)
+      TextChange(pos.source, insertPos, insertPos, importsAsSrc(indent) + "\n")
+    }
 
-        // The empty PackageDef starts at the position of its first child, so the annotation of the Impl
-        // is outside its parent's range. The Source Generator can't handle this, so we let the PackageDef
-        // start at position 0 so that the annotation gets associated to the child.
-        val pos = p.pos withStart 0
+    /*
+     * `foundPackage` is a big fat hack to remember the `PackageDef` that is
+     * found in `findBestPackageForImports`. For some reason the transformation
+     * is run multiple times, even though, the `once` call later should prevent
+     * that. Therefore the `PackageDef` that is returned by
+     * `findBestPackageForImports` is not the same as the one that is found
+     * inside of it (and I don't really understand why).
+     */
+    var foundPackage: PackageDef = null
+    val findBestPackageForImports = {
+      def isPackageDef(tree: Tree) = tree.isInstanceOf[PackageDef]
 
-        p copy (pid = ignoredPid, stats = (importTrees ::: others)) setPos pos
+      def isBestPlaceForImports(trees: List[Tree]) = {
+        val (pkgDefs, otherTrees) = trees.partition(isPackageDef)
+        otherTrees.nonEmpty || pkgDefs.size >= 2
+      }
 
-      case (p, imports, others) =>
-        p copy (stats = (imports ::: importTrees ::: others)) replaces p
-    })
+      transformation[Tree, Tree] {
+        case p @ PackageDef(_, stats) if isBestPlaceForImports(stats) =>
+          if (foundPackage == null)
+            foundPackage = p
+          p
+      }
+    }
 
     // first try it at the top level to avoid traversing the complete AST
-    addImportStatement |> topdown(matchingChildren(addImportStatement))
+    val insertLocation = findBestPackageForImports |> topdown(matchingChildren(findBestPackageForImports))
+
+    val addImportStatement = once(insertLocation) &> transformation { case _ ⇒
+      splitImports(foundPackage, foundPackage.stats) match {
+        // For an empty PackageDef, with no exiting imports but with an Impl that has an annotation, we need to
+        // modify positions so that the annotation, which is not in the AST, doesn't get assigned to the PackageDef
+        // but to the Impl
+        case (p @ PackageDef(Ident(nme.EMPTY_PACKAGE_NAME), _), Nil, others @ (impl :: _)) if !impl.symbol.annotations.isEmpty ⇒
+          // The empty PackageDef starts at the position of its first child, so the annotation of the Impl
+          // is outside its parent's range. The Source Generator can't handle this, so we let the PackageDef
+          // start at position 0 so that the annotation gets associated to the child.
+          val pos = p.pos withStart 0
+          insertBefore(pos)
+        case (p, imports, others) ⇒
+          if (imports.nonEmpty)
+            insertAfter(imports.last.pos)
+          else
+            insertBefore(others.head.pos)
+      }
+    }
+
+    addImportStatement
   }
 }

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/MoveClassTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/MoveClassTest.scala
@@ -13,7 +13,7 @@ class MoveClassTest extends TestHelper with TestRefactoring {
 
   private def createRefactoring(pro: FileSet) = {
     new TestRefactoringImpl(pro) {
-      val refactoring = new MoveClass with TestProjectIndex
+      override val refactoring = new MoveClass with TestProjectIndex
     }
   }
 
@@ -666,7 +666,6 @@ class MoveClassTest extends TestHelper with TestRefactoring {
       package a.b.c
 
       import x.y.ToMove
-
       class User extends ToMove
     """
   } applyRefactoring(moveTo("x.y"))
@@ -875,7 +874,6 @@ class MoveClassTest extends TestHelper with TestRefactoring {
     }
     """ becomes """
     import bar.Bar64
-
     class Foo64 {
       import Bar64.instance
 
@@ -934,7 +932,6 @@ class MoveClassTest extends TestHelper with TestRefactoring {
       package c
 
       import x.y.ToMove
-
       trait Xy {
         val other: ToMove
       }

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/AddImportStatementTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/AddImportStatementTest.scala
@@ -486,4 +486,49 @@ class AddImportStatementTest extends TestHelper {
       }
       """)
   }
+
+  /**
+   * See Assembla Ticket #1001848
+   */
+  @Test
+  def doNotRemoveComments() = {
+    addImport(("scala.collection.mutable", "ListBuffer"), """
+      // comment
+      import java.io.File // comment
+      // comment
+
+      import scala.collection.mutable.Buffer // comment
+      import scala.collection.mutable.HashMap // comment
+      // comment
+
+      // comment
+      object Y {
+
+        val a = Buffer
+        val b = HashMap
+        val c = ListBuffer
+
+        val d = new File("")
+      }
+      """, """
+      // comment
+      import java.io.File // comment
+      // comment
+
+      import scala.collection.mutable.Buffer // comment
+      import scala.collection.mutable.HashMap // comment
+      import scala.collection.mutable.ListBuffer
+      // comment
+
+      // comment
+      object Y {
+
+        val a = Buffer
+        val b = HashMap
+        val c = ListBuffer
+
+        val d = new File("")
+      }
+      """)
+  }
 }

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/AddImportStatementTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/AddImportStatementTest.scala
@@ -34,7 +34,6 @@ class AddImportStatementTest extends TestHelper {
     """,
     """
       import whatever.`type`.Bla
-
       object Main
     """)
   }
@@ -43,26 +42,28 @@ class AddImportStatementTest extends TestHelper {
   def importAnnotationOnClassWithoutPackage() = {
     addImport(("scala.annotation.unchecked", "uncheckedStable"),
     """
-      @uncheckedStable
-      class T
-    """,
-    """import scala.annotation.unchecked.uncheckedStable
-@uncheckedStable
-class T
-    """)
+      |@uncheckedStable
+      |class T
+    """.stripMargin.trim,
+    """
+      |import scala.annotation.unchecked.uncheckedStable
+      |@uncheckedStable
+      |class T
+    """.stripMargin.trim)
   }
 
   @Test
   def importAnnotationOnObjectWithoutPackage() = {
     addImport(("scala.annotation.unchecked", "uncheckedStable"),
     """
-      @uncheckedStable
-      object T
-    """,
-    """import scala.annotation.unchecked.uncheckedStable
-@uncheckedStable
-object T
-    """)
+      |@uncheckedStable
+      |object T
+    """.stripMargin.trim,
+    """
+      |import scala.annotation.unchecked.uncheckedStable
+      |@uncheckedStable
+      |object T
+    """.stripMargin.trim)
   }
 
   @Test
@@ -106,7 +107,6 @@ object T
     """,
     """
       import collection.mutable.ListBuffer
-
       object Main {val lb = ListBuffer(1)}
     """)
   }
@@ -122,7 +122,6 @@ object T
       package xy
 
       import collection.mutable.ListBuffer
-
       object Main {val lb = ListBuffer(1)}
     """)
   }
@@ -151,6 +150,7 @@ object T
     """,
     """
       import collection.mutable.HashMap
+
       import collection.mutable.HashMap
       import collection.mutable.ListBuffer
 
@@ -175,6 +175,7 @@ object T
       package pckg
 
       import collection.mutable.HashMap
+
       import collection.mutable.HashMap
       import collection.mutable.ListBuffer
 
@@ -200,11 +201,11 @@ object T
 
       import collection.mutable.HashMap
 
+      package pckg
+
       import collection.mutable.HashMap
       import collection.mutable.HashMap
       import collection.mutable.ListBuffer
-
-      package pckg
 
       object Main {}
     """)
@@ -221,7 +222,6 @@ object T
       package just.some.pkg
 
       import collection.mutable.ListBuffer
-
       object Main {val lb = ListBuffer(1)}
     """)
   }
@@ -241,7 +241,6 @@ object T
       package pkg
 
       import collection.mutable.ListBuffer
-
       object Main {val lb = ListBuffer(1)}
     """)
   }
@@ -263,7 +262,6 @@ object T
       package pkg {
 
       import collection.mutable.ListBuffer
-
       object Main {val lb = ListBuffer(1)}
 
       }
@@ -289,7 +287,6 @@ object T
     """
       package just
       package some
-
       import collection.mutable.ListBuffer
       package pkg1 {
 
@@ -321,7 +318,6 @@ object T
       """,
       """
       import scala.util.matching.Regex
-
       object X
 
       class Y {
@@ -353,7 +349,6 @@ object T
       """,
       """
       import scala.util.matching.Regex
-
       object X
 
       ")"
@@ -377,7 +372,6 @@ object T
       """,
       """
       import scala.collection.mutable.LinkedHashSet
-
       object DummyObject
 
       class WrongFormatting {
@@ -407,7 +401,6 @@ object T
     package a.b.c
 
     import a.b.c.actions.ActionX
-
     package actions {
       class ActionX
     }
@@ -431,7 +424,6 @@ object T
       class X
       """, """
       import java.io.InputStream
-
       object X {
         def f(is: InputStream
       }
@@ -450,12 +442,48 @@ object T
       class X
       """, """
       import java.io.InputStream
-
       object X {
         def f is: InputStream)
       }
 
       class X
+      """)
+  }
+
+  /**
+   * See Assembla Ticket #1002514
+   */
+  @Test
+  def doNotRemoveExistingImportGroups() = {
+    addImport(("scala.collection.mutable", "ListBuffer"), """
+      import java.io.File
+
+      import scala.collection.mutable.Buffer
+      import scala.collection.mutable.HashMap
+
+      object Y {
+
+        val a = Buffer
+        val b = HashMap
+        val c = ListBuffer
+
+        val d = new File("")
+      }
+      """, """
+      import java.io.File
+
+      import scala.collection.mutable.Buffer
+      import scala.collection.mutable.HashMap
+      import scala.collection.mutable.ListBuffer
+
+      object Y {
+
+        val a = Buffer
+        val b = HashMap
+        val c = ListBuffer
+
+        val d = new File("")
+      }
       """)
   }
 }


### PR DESCRIPTION
This is a similar change to the rename refactoring. The overall idea is
to not depend on any tree transformations when an import is added to a
file. Theoretically, doing any transformations on the tree is the
optimal solution but only if the tree is a concrete syntax tree. The
scalac trees however are abstract syntax trees and therefore don't do
what we want. For the add import refactoring, they remove all the
formatting of the imports, especially removed new lines are a concern.

This commit therefore replaces the tree transformations by generating
textual code changes. This way, the refactoring is only doing a minimal
change, which in our case is to add one or multiple imports. A side
effect is that some functionality is lost but I consider that as a good
change. Formerly, the add import refactoring also did some minor
cleanups to the regions around imports. It added newlines, which means
that an import that got added to a code snippet like the following

```
  class A {
    val f = new File
  }
```

did result in this:

```
  import java.io.File

  class A {
    val f = new File
  }
```

Whereas after the refactorings of this commit the extra newline is no
longer printed:

```
  import java.io.File
  class A {
    val f = new File
  }
```

This may not look better but it makes the implementation easier because
we don't have to check if a newline already exists. Also, conceptually
it is the job of the organize imports refactoring to take care of such a
cleanup. The add import refactoring should only do a minimal change and
that is exactly what it is doing right now.

Fix #1002514

--------

@misto @mlangc Do you understand why I had to write this code:

```scala
var foundPackage: PackageDef = null
val findBestPackageForImports = {
  ...
  transformation[Tree, Tree] {
    case p @ PackageDef(_, stats) if isBestPlaceForImports(stats) =>
      if (foundPackage == null)
        foundPackage = p
      p
  }
}

// first try it at the top level to avoid traversing the complete AST
val insertLocation = findBestPackageForImports |> topdown(matchingChildren(findBestPackageForImports))

val addImportStatement = once(insertLocation) &> transformation { case _ ⇒
  splitImports(foundPackage, foundPackage.stats) match {
    case (p, imports, others) ⇒
```

I would like to write this code:
```scala
val findBestPackageForImports = {
  ...
  transformation[Tree, Tree] {
    case p @ PackageDef(_, stats) if isBestPlaceForImports(stats) =>
      splitImports(p, stats)
  }
}

// first try it at the top level to avoid traversing the complete AST
val insertLocation = findBestPackageForImports |> topdown(matchingChildren(findBestPackageForImports))

val addImportStatement = once(insertLocation) &> transformation {
  case (p, imports, others) ⇒
```

But the `once` block isn't doing what I would expect it to do. I expected, that it ensures that the transformation block in `findBestPackageForImports` is called only once, but it isn't and the found `PackageDef` is a different one in `addImportStatement`. Another problem is that I can't pass a transformation into `matchingChildren` that is not `Tree => Tree`