### PR TITLE
Do not throw exception when imports are collapsed to wildcard import

### DIFF
--- a/src/main/scala/scala/tools/refactoring/sourcegen/PrettyPrinter.scala
+++ b/src/main/scala/scala/tools/refactoring/sourcegen/PrettyPrinter.scala
@@ -132,11 +132,11 @@ trait PrettyPrinter extends TreePrintingTraversals with AbstractPrinter {
       }
 
       val arrowReq = new Requisite {
-        def isRequired(l: Layout, r: Layout) = {
+        override def isRequired(l: Layout, r: Layout) = {
           !(l.contains("=>") || r.contains("=>"))
         }
 
-        def getLayout = Layout(" => ")
+        override def getLayout = Layout(" => ")
       }
 
       Layout("case ") ++ patFrag ++ p(guard, before = " if ") ++ p(body, before = arrowReq)
@@ -416,6 +416,13 @@ trait PrettyPrinter extends TreePrintingTraversals with AbstractPrinter {
           Layout("import ") ++ Fragment(expr_) ++ Requisite.allowSurroundingWhitespace(".") ++ Fragment(selectors_)
       }
     }
+
+    override def ImportSelectorTree(tree: ImportSelectorTree, name: NameTree, rename: Tree)(implicit ctx: PrintingContext) = {
+      if (rename.isEmpty)
+        Fragment(name.nameString)
+      else
+        Fragment(s"${name.nameString} => ${rename.nameString}")
+    }
   }
 
   trait PackagePrinters {
@@ -601,12 +608,12 @@ trait PrettyPrinter extends TreePrintingTraversals with AbstractPrinter {
         // so we have to check several places: if the parameter list is empty, it could
         // even be part of the tparams.
         val colon = new Requisite {
-          def isRequired(l: Layout, r: Layout) = {
+          override def isRequired(l: Layout, r: Layout) = {
             !(l.contains(":") || r.contains(":") || {
               (tparams_.withoutComments + params_.withoutComments).matches(".*:\\s*")
             })
           }
-          def getLayout = Layout(": ")
+          override def getLayout = Layout(": ")
         }
         // Finalize the layout so the `:` won't be searched in the rhs.
         p(tpt, before = colon).toLayout

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
@@ -1962,4 +1962,37 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
     """.replace("$", "")
     }
   } applyRefactoring organizeCustomized(dependencies = Dependencies.RecomputeAndModify)
+
+  @Test
+  def shouldNotThrowAnExceptionWhenImportsAreCollapsedToWildcardImport() = new FileSet {
+    """
+    package a.b
+    class C1
+    class C2
+    """ isNotModified
+
+    """
+    /*<-*/
+    package d.e
+
+    import a.b.C1
+    import a.b.C2
+
+    object X {
+      val c1 = new C1
+      val c2 = new C2
+    }
+    """ becomes
+    """
+    /*<-*/
+    package d.e
+
+    import a.b._
+
+    object X {
+      val c1 = new C1
+      val c2 = new C2
+    }
+    """
+  } applyRefactoring organizeCustomized(dependencies = Dependencies.RecomputeAndModify, useWildcards = Set("a.b"))
 }


### PR DESCRIPTION
It is kind of difficult to describe why this exception is thrown and the
fact that it took me an entire working day to fix it should speak for
itself. But I will try nevertheless to give a description:

The problem starts in the class `OrganizeImports.AlwaysUseWildcards`. If
the "collapse to wildcard import" option is enabled, this class replaces
all imports that are matched by a wildcard import with such a wildcard
import. Even though the wildcard import is generated it has positions
since the position of the first matching import are set to it. This
means that `ReusingPrinter` is used to print the import. However, in
order to print import selectors the refactoring logic needs to generate
its own trees, called `ImportSelectorTree`. This is necessary, since
import selectors are not trees by default and therefore it wouldn't be
easily possible to print them through the current tree printing
algorithm. Since the `ImportSelectorTree` is synthetic, it doesn't have
positions and is therefore forwarded to `PrettyPrinter`, therefore
`PrettyPrinter` contains the bug fix.

I didn't add the same logic to ReusingPrinter, since I don't see how
such an implementation could ever be called there (there can't be a
reusing part in a synthetic tree). Furthermore, the fix is more
powerful, than what the test can cover. In theory it can even print
rename imports but I was not able to come up with a test case that would
invoke this logic, therefore we have no guarantee that this part of the
implementation is correct or even necessary.

Fixes #1002654