### PR TITLE
Consider named parameters during rename refactorings

### DIFF
--- a/src/main/scala/scala/tools/refactoring/analysis/GlobalIndexes.scala
+++ b/src/main/scala/scala/tools/refactoring/analysis/GlobalIndexes.scala
@@ -30,7 +30,8 @@ trait GlobalIndexes extends Indexes with DependentSymbolExpanders with Compilati
           Companion with
           LazyValAccessor with
           OverridesInSuperClasses with
-          ClassVals {
+          ClassVals with
+          CaseClassVals {
 
             val cus = compilationUnits
           }

--- a/src/main/scala/scala/tools/refactoring/analysis/GlobalIndexes.scala
+++ b/src/main/scala/scala/tools/refactoring/analysis/GlobalIndexes.scala
@@ -29,7 +29,8 @@ trait GlobalIndexes extends Indexes with DependentSymbolExpanders with Compilati
           SuperConstructorParameters with
           Companion with
           LazyValAccessor with
-          OverridesInSuperClasses {
+          OverridesInSuperClasses with
+          ClassVals {
 
             val cus = compilationUnits
           }

--- a/src/main/scala/scala/tools/refactoring/analysis/SymbolExpanders.scala
+++ b/src/main/scala/scala/tools/refactoring/analysis/SymbolExpanders.scala
@@ -104,7 +104,7 @@ trait DependentSymbolExpanders extends TracingImpl {
     }
 
     private def findRelatedCtorParamSymbol(s: Symbol): Option[Symbol] = s match {
-      case ts: TermSymbol if ts.isVal && ts.owner.isClass && ts.pos.isRange =>
+      case ts: TermSymbol if ts.isVal && ts.owner.isClass =>
         declaration(s.owner).flatMap(findRelatedCtorParamSymbolIn(_, s))
       case _ => None
     }
@@ -115,10 +115,7 @@ trait DependentSymbolExpanders extends TracingImpl {
           def correspondsToVal(param: Tree) = {
             val (pSym, vSym) = (param.symbol, valSym)
             val (pPos, vPos) = (param.symbol.pos, valSym.pos)
-
-            // Note that we intentionally look at 'start' only, because ends might differ
-            // if default arguments are involved.
-            pSym != vSym && pPos.start == vPos.start
+            pSym != vSym && pPos.isDefined && vPos.isDefined && pPos.point == vPos.point
           }
 
           val res = dd.vparamss.flatten.collectFirst {

--- a/src/main/scala/scala/tools/refactoring/analysis/SymbolExpanders.scala
+++ b/src/main/scala/scala/tools/refactoring/analysis/SymbolExpanders.scala
@@ -16,7 +16,6 @@ import scala.tools.refactoring.common.PositionDebugging
  * methods in subclasses.
  */
 trait DependentSymbolExpanders extends TracingImpl {
-
   this: Indexes with common.CompilerAccess =>
 
   import global._
@@ -112,15 +111,7 @@ trait DependentSymbolExpanders extends TracingImpl {
     private def findRelatedCtorParamSymbolIn(parent: Tree, valSym: Symbol): Option[Symbol] = {
       parent.foreach {
         case dd: DefDef if dd.symbol.isConstructor =>
-          def correspondsToVal(param: Tree) = {
-            val (pSym, vSym) = (param.symbol, valSym)
-            val (pPos, vPos) = (param.symbol.pos, valSym.pos)
-            pSym != vSym && pPos.isDefined && vPos.isDefined && pPos.point == vPos.point
-          }
-
-          val res = dd.vparamss.flatten.collectFirst {
-            case p if correspondsToVal(p) => p.symbol
-          }
+          val res = findParamSymbolAssociatedWithValSymbol(dd, valSym)
 
           if (res.nonEmpty) {
             return res
@@ -130,6 +121,65 @@ trait DependentSymbolExpanders extends TracingImpl {
       }
 
       None
+    }
+  }
+
+  private def findParamSymbolAssociatedWithValSymbol(dd: DefDef, valSym: Symbol): Option[Symbol] = {
+    def correspondsToVal(param: Tree) = {
+      val (pSym, vSym) = (param.symbol, valSym)
+      val (pPos, vPos) = (param.symbol.pos, valSym.pos)
+      pSym != vSym && pPos.isDefined && vPos.isDefined && pPos.point == vPos.point
+    }
+
+    dd.vparamss.flatten.collectFirst {
+      case p if correspondsToVal(p) => p.symbol
+    }
+  }
+
+  /**
+   * Associates case class vals with the parameters of generated apply and copy methods
+   */
+  trait CaseClassVals extends SymbolExpander { this: IndexLookup =>
+    protected abstract override def doExpand(s: Symbol) = {
+      findRelatedApplyAndCopyParamSymbols(s) ::: super.doExpand(s)
+    }
+
+    private def findRelatedApplyAndCopyParamSymbols(s: Symbol): List[Symbol] = {
+      if (s.isVal && s.owner.isCaseClass) {
+        // TODO: The documentation of `companionModule` mentions that special
+        // handling is needed for classes owned by methods. This needs to be
+        // investigated!
+        List(s.owner, s.owner.companionModule).flatMap { parentSymbol =>
+          declaration(parentSymbol).flatMap(findRelatedApplyOrCopyParamSymbolIn(_, s))
+        }
+      } else {
+        Nil
+      }
+    }
+
+    private def findRelatedApplyOrCopyParamSymbolIn(parent: Tree, valSym: Symbol): Option[Symbol] = {
+      parent.foreach {
+        case dd: DefDef if isCaseApplyOrCopy(dd.symbol) =>
+          return findParamSymbolAssociatedWithValSymbol(dd, valSym)
+        case _ => ()
+      }
+
+      None
+    }
+
+    private def isCaseApplyOrCopy(s: Symbol) = {
+      /*
+       *  Unfortunately Symbol.isCaseCopy is not available for Scala-2.10
+       */
+      def isCaseCopy = {
+        s.isMethod && s.owner.isCase && s.isSynthetic && s.name == nme.copy
+      }
+
+      def isCaseApply = {
+        s.isCaseApplyOrUnapply && !s.nameString.contains("unapply")
+      }
+
+      isCaseCopy || isCaseApply
     }
   }
 

--- a/src/main/scala/scala/tools/refactoring/common/EnrichedTrees.scala
+++ b/src/main/scala/scala/tools/refactoring/common/EnrichedTrees.scala
@@ -670,7 +670,7 @@ trait EnrichedTrees {
 
       case _: Literal | _: Ident | _: ModifierTree | _: NameTree | _: This | _: Super => Nil
 
-      case Apply(fun, args) =>
+      case ApplyExtractor(fun, args) =>
         fun :: args
 
       case t @ Select(qualifier, selector) if selector.toString.startsWith("unary_") =>

--- a/src/main/scala/scala/tools/refactoring/common/EnrichedTrees.scala
+++ b/src/main/scala/scala/tools/refactoring/common/EnrichedTrees.scala
@@ -1215,6 +1215,17 @@ trait EnrichedTrees extends TracingImpl {
    *
    * Also reshapes some trees: multiple assignments are
    * removed and named argument trees are created.
+   *
+   * Note that this extractor is needed primarily for tree printing. The rename refactoring for example,
+   * that doesn't use tree printing, would work with
+   * {{{
+   *   object BlockExtractor {
+   *     def unapply(t: Block) = {
+   *       Some(t.expr :: t.stats)
+   *     }
+   *   }
+   * }}}
+   * as well.
    */
   object BlockExtractor {
     private def findParamAssignment(argsSource: String, paramName: String): Option[Int] = {

--- a/src/main/scala/scala/tools/refactoring/common/EnrichedTrees.scala
+++ b/src/main/scala/scala/tools/refactoring/common/EnrichedTrees.scala
@@ -1033,6 +1033,13 @@ trait EnrichedTrees extends TracingImpl {
     symbolLiteral |
     curlyBracesWithContents
 
+  /**
+   * Extracts information from `ApplyNodes`
+   *
+   * The main feature of this extractor is that reverses the desugarings the compiler performs for named arguments
+   * by creating [[scala.tools.refactoring.common.EnrichedTrees.NamedArgument]] instances as necessary. Apart
+   * from that, this object is meant to mimic the regular [[scala.reflect.api.Trees.ApplyExtractor]].
+   */
   object ApplyExtractor {
 
     def mightHaveNamedArguments(t: Tree) = t match {

--- a/src/main/scala/scala/tools/refactoring/common/TreeTraverser.scala
+++ b/src/main/scala/scala/tools/refactoring/common/TreeTraverser.scala
@@ -34,7 +34,7 @@ trait TreeTraverser extends TracingImpl {
   protected trait TraversalTracing extends global.Traverser {
     private var indent = 0
 
-    protected def traceIndividualVisits = false
+    protected def traceIndividualVisits = true
 
     override def traverse(t: Tree) = {
       def doTraverse() = {

--- a/src/main/scala/scala/tools/refactoring/common/TreeTraverser.scala
+++ b/src/main/scala/scala/tools/refactoring/common/TreeTraverser.scala
@@ -64,11 +64,11 @@ trait TreeTraverser extends TracingImpl {
 
       if (indent == 0) {
         context(s"Starting traversal in $sourceFileAsString at $treeAsString initiated from\n$explainStack\n") {
-          val start = System.currentTimeMillis()
+          val start = System.nanoTime()
           doTraverse()
-          val stop = System.currentTimeMillis()
-          val millis = stop - start
-          trace(s"Finished traversal after ${millis}ms")
+          val stop = System.nanoTime()
+          val millis = (stop - start) * 1e-6
+          trace(f"Finished traversal after $millis%.1fms")
         }
       } else {
         if (traceIndividualVisits) {

--- a/src/main/scala/scala/tools/refactoring/common/TreeTraverser.scala
+++ b/src/main/scala/scala/tools/refactoring/common/TreeTraverser.scala
@@ -370,8 +370,10 @@ trait TreeTraverser extends TracingImpl {
           stats foreach traverse
 
         case ApplyExtractor(fun, args) =>
-          traverse(fun)
-          args foreach traverse
+          args.foreach {
+            case arg: NamedArgument => f(arg.symbol, arg)
+            case _ => ()
+          }
 
         case t: DefTree if t.symbol != NoSymbol =>
           f(t.symbol, t)

--- a/src/main/scala/scala/tools/refactoring/common/TreeTraverser.scala
+++ b/src/main/scala/scala/tools/refactoring/common/TreeTraverser.scala
@@ -366,9 +366,6 @@ trait TreeTraverser extends TracingImpl {
 
           f(t.symbol, t)
 
-        case BlockExtractor(stats) =>
-          stats foreach traverse
-
         case ApplyExtractor(fun, args) =>
           args.foreach {
             case arg: NamedArgument => f(arg.symbol, arg)

--- a/src/main/scala/scala/tools/refactoring/common/TreeTraverser.scala
+++ b/src/main/scala/scala/tools/refactoring/common/TreeTraverser.scala
@@ -309,12 +309,12 @@ trait TreeTraverser {
 
           f(t.symbol, t)
 
-//        case BlockExtractor(stats) =>
-//          stats foreach traverse
-//
-//        case ApplyExtractor(fun, args) =>
-//          traverse(fun)
-//          args foreach traverse
+        case BlockExtractor(stats) =>
+          stats foreach traverse
+
+        case ApplyExtractor(fun, args) =>
+          traverse(fun)
+          args foreach traverse
 
         case t: DefTree if t.symbol != NoSymbol =>
           f(t.symbol, t)

--- a/src/main/scala/scala/tools/refactoring/common/TreeTraverser.scala
+++ b/src/main/scala/scala/tools/refactoring/common/TreeTraverser.scala
@@ -6,7 +6,7 @@ package scala.tools.refactoring
 package common
 
 
-trait TreeTraverser {
+trait TreeTraverser extends TracingImpl {
 
   this: CompilerAccess with common.EnrichedTrees =>
 
@@ -25,11 +25,68 @@ trait TreeTraverser {
   }
 
   /**
+   * Use [[TraversalTracing]] for debugging and [[PlainTraversals]] for production
+   */
+  protected type TraversalInstrumentation = PlainTraversals
+
+  protected trait PlainTraversals extends global.Traverser
+
+  protected trait TraversalTracing extends global.Traverser {
+    private var indent = 0
+
+    protected def traceIndividualVisits = false
+
+    override def traverse(t: Tree) = {
+      def doTraverse() = {
+        indent += 2
+        try {
+          super.traverse(t)
+        } finally {
+          indent -= 2
+        }
+      }
+
+      def treeAsString = t.summaryString
+
+      def sourceFileAsString = t.pos match {
+        case null | NoPosition => "<no-source-file>"
+        case properPos => properPos.source.file.name
+      }
+
+      def explainStack = {
+        def stackElemToString(elem: StackTraceElement) = {
+          s"${elem.getFileName}:${elem.getLineNumber}"
+        }
+
+        val stackTrace = Thread.currentThread().getStackTrace.drop(3).take(5)
+        stackTrace.map("  -- " + stackElemToString(_)).mkString("\n")
+      }
+
+      if (indent == 0) {
+        context(s"Starting traversal in $sourceFileAsString at $treeAsString initiated from\n$explainStack\n") {
+          val start = System.currentTimeMillis()
+          doTraverse()
+          val stop = System.currentTimeMillis()
+          val millis = stop - start
+          trace(s"Finished traversal after ${millis}ms")
+        }
+      } else {
+        if (traceIndividualVisits) {
+          val leadingSpaces = " " * indent
+          trace(s"$leadingSpaces visiting $treeAsString")
+        }
+
+        doTraverse()
+      }
+    }
+  }
+
+  /**
    *  A traverser that creates fake trees for various
    *  type trees so they can be treated as if they were
    *  regular trees.
    */
-  trait TraverserWithFakedTrees extends global.Traverser {
+  trait TraverserWithFakedTrees extends global.Traverser with TraversalInstrumentation {
 
     def fakeSelectTreeFromType(tpe: Type, sym: Symbol, pos: Position) = {
       // we fake our own Select(Ident(..), ..) tree from the type
@@ -182,14 +239,14 @@ trait TreeTraverser {
     }
   }
 
-  class FilterTreeTraverser(p: Tree => Boolean) extends global.FilterTreeTraverser(p) with Traverser
+  class FilterTreeTraverser(p: Tree => Boolean) extends global.FilterTreeTraverser(p) with Traverser with TraversalInstrumentation
 
   def filterTree(t: Tree, traverser: global.FilterTreeTraverser) = {
     traverser.traverse(t)
     traverser.hits.toList
   }
 
-  class TreeWithSymbolTraverser(f: (Symbol, Tree) => Unit) extends Traverser {
+  class TreeWithSymbolTraverser(f: (Symbol, Tree) => Unit) extends Traverser with TraversalInstrumentation {
 
     override def traverse(t: Tree) = {
 

--- a/src/main/scala/scala/tools/refactoring/implementations/Rename.scala
+++ b/src/main/scala/scala/tools/refactoring/implementations/Rename.scala
@@ -46,13 +46,8 @@ abstract class Rename extends MultiStageRefactoring with TreeAnalysis with analy
           val relatedCtor = s.root.find {
             case dd: DefDef if dd.symbol.isConstructor && !dd.mods.isPrivate && !dd.mods.isPrivateLocal =>
               val relatedParam = dd.vparamss.flatten.find { p =>
-                (p.symbol.pos, t.symbol.pos) match {
-                  case (p1: RangePosition, p2: RangePosition) =>
-                    // Note that p1.end and p2.end might differ if default arguments are involved,
-                    // even for related symbols.
-                    p1.start == p2.start
-                  case _ => false
-                }
+                val (p1, p2) = (p.symbol.pos, t.symbol.pos)
+                p1.isDefined && p2.isDefined && p1.point == p2.point
               }
 
               relatedParam.nonEmpty

--- a/src/main/scala/scala/tools/refactoring/util/SourceWithMarker.scala
+++ b/src/main/scala/scala/tools/refactoring/util/SourceWithMarker.scala
@@ -14,12 +14,16 @@ final case class SourceWithMarker(source: IndexedSeq[Char] = IndexedSeq(), marke
   import SourceWithMarker._
 
   def moveMarker(movement: SimpleMovement): SourceWithMarker = {
-    if (isDepleted) this
-    else movement(this).map(m => copy(marker = m)).getOrElse(this)
+    applyMovement(movement).getOrElse(this)
   }
 
   def moveMarkerBack(movement: Movement): SourceWithMarker = {
     moveMarker(movement.backward)
+  }
+
+  def applyMovement(movement: SimpleMovement): Option[SourceWithMarker] = {
+    if (isDepleted) None
+    else movement(this).map(m => copy(marker = m))
   }
 
   def withMarkerAtLastChar: SourceWithMarker = {

--- a/src/main/scala/scala/tools/refactoring/util/SourceWithMarker.scala
+++ b/src/main/scala/scala/tools/refactoring/util/SourceWithMarker.scala
@@ -543,8 +543,14 @@ object SourceWithMarker {
             if (sourceWithMarker.isDepleted) {
               None
             } else {
-              val newSourceWithMarker = sourceWithMarker.applyMovement(actualSkipping).getOrElse {
-                sourceWithMarker.step(forward)
+              val newSourceWithMarker = {
+                val markerAfterSkipping = actualSkipping(sourceWithMarker).flatMap { markerAfterSkipping =>
+                  if (markerAfterSkipping == sourceWithMarker.marker) None
+                  else Some(markerAfterSkipping)
+                }
+
+                val newMarker = markerAfterSkipping.getOrElse(nextMarker(sourceWithMarker.marker, forward))
+                sourceWithMarker.withMarkerAt(newMarker)
               }
 
               go(newSourceWithMarker)

--- a/src/main/scala/scala/tools/refactoring/util/SourceWithMarker.scala
+++ b/src/main/scala/scala/tools/refactoring/util/SourceWithMarker.scala
@@ -335,6 +335,14 @@ object SourceWithMarker {
   }
 
   object Movement {
+    /**
+     * Factory method for constructing movements
+     *
+     * Constructs a movement from a function of the form `(sourceWithMarker, forward) => markers`
+     * where `sourceWithMarker` represents a position in some piece of source code, `forward` tells
+     * us in which direction to move, and the return value `markers` is the possibly empty
+     * sequence of markers this movement might lead to.
+     */
     def apply(impl: (SourceWithMarker, Boolean) => Seq[Int]): Movement = {
       class MovementImpl(forward: Boolean) extends Movement {
         override def compute(sourceWithMarker: SourceWithMarker) = impl(sourceWithMarker, forward)

--- a/src/test/scala/scala/tools/refactoring/tests/RefactoringTestSuite.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/RefactoringTestSuite.scala
@@ -75,5 +75,6 @@ import scala.tools.refactoring.implementations.OrganizeImportsAlgosTest
     classOf[UnionFindInitTest],
     classOf[UnionFindTest],
     classOf[UnusedImportsFinderTest],
+    classOf[SourceWithMarkerTest],
     classOf[OrganizeImportsAlgosTest]))
 class RefactoringTestSuite {}

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
@@ -3362,6 +3362,70 @@ class Blubb
   } prepareAndApplyRefactoring(prepareAndRenameTo("ups"))
 
   @Test
+  def testRenameWithNamedArgs1002501Ex5() = new FileSet {
+    """
+    object Tests {
+      class SomeClass(a: Int = 1, b: Int, /*(*/tryRenameMe/*)*/: Int = 99)
+      new SomeClass(b = 5, tryRenameMe = 33)
+    }
+    """ becomes
+    """
+    object Tests {
+      class SomeClass(a: Int = 1, b: Int, /*(*/ups/*)*/: Int = 99)
+      new SomeClass(b = 5, ups = 33)
+    }
+    """ -> TaggedAsGlobalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("ups"))
+
+  @Test
+  def testRenameWithNamedArgs1002501Ex6() = new FileSet {
+    """
+    object Tests {
+      class ClassWithSecondaryCtor(/*(*/tryRenameMe: Int/*)*/) {
+        def this(tryRenameMe: Long) = this(tryRenameMe.toInt)
+      }
+
+      new ClassWithSecondaryCtor(tryRenameMe = 3L)
+      new ClassWithSecondaryCtor(tryRenameMe = 3)
+    }
+    """ becomes
+    """
+    object Tests {
+      class ClassWithSecondaryCtor(/*(*/ups: Int/*)*/) {
+        def this(tryRenameMe: Long) = this(tryRenameMe.toInt)
+      }
+
+      new ClassWithSecondaryCtor(tryRenameMe = 3L)
+      new ClassWithSecondaryCtor(ups = 3)
+    }
+    """ -> TaggedAsGlobalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("ups"))
+
+  @Test
+  def testRenameWithNamedArgs1002501Ex7() = new FileSet {
+    """
+    object Tests {
+      class ClassWithSecondaryCtor(tryRenameMe: Int) {
+        def this(/*(*/tryRenameMe/*)*/: Long) = this(tryRenameMe.toInt)
+      }
+
+      new ClassWithSecondaryCtor(tryRenameMe = 3L)
+      new ClassWithSecondaryCtor(tryRenameMe = 3)
+    }
+    """ becomes
+    """
+    object Tests {
+      class ClassWithSecondaryCtor(tryRenameMe: Int) {
+        def this(/*(*/ups/*)*/: Long) = this(ups.toInt)
+      }
+
+      new ClassWithSecondaryCtor(ups = 3L)
+      new ClassWithSecondaryCtor(tryRenameMe = 3)
+    }
+    """ -> TaggedAsGlobalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("ups"))
+
+  @Test
   def testRenameWithPrivateClassVal() = new FileSet {
     """
     class SomeClass {

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
@@ -3426,6 +3426,170 @@ class Blubb
   } prepareAndApplyRefactoring(prepareAndRenameTo("ups"))
 
   @Test
+  def testRenameWithNamedArgs1002501Ex8() = new FileSet {
+    """
+    case class CaseClass1(/*(*/tryRenameMe/*)*/: Int) {
+      CaseClass1(tryRenameMe = 22)
+    }
+    """ becomes
+    """
+    case class CaseClass1(/*(*/ups/*)*/: Int) {
+      CaseClass1(ups = 22)
+    }
+    """ -> TaggedAsGlobalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("ups"))
+
+  @Test
+  def testRenameWithNamedArgs1002501Ex9() = new FileSet {
+    """
+    case class CaseClass2(/*(*/tryRenameMe/*)*/: Int, b: Int = 42, c: Int = 43) {
+      CaseClass2(c = 0, tryRenameMe = 22)
+    }
+    """ becomes
+    """
+    case class CaseClass2(/*(*/ups/*)*/: Int, b: Int = 42, c: Int = 43) {
+      CaseClass2(c = 0, ups = 22)
+    }
+    """ -> TaggedAsGlobalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("ups"))
+
+  @Test
+  def testRenameWithNamedArgs1002501Ex10() = new FileSet {
+    """
+    case class CaseClass3(/*(*/tryRenameMe/*)*/: Int) {
+      copy(tryRenameMe = 12)
+    }
+    """ becomes
+    """
+    case class CaseClass3(/*(*/ups/*)*/: Int) {
+      copy(ups = 12)
+    }
+    """ -> TaggedAsGlobalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("ups"))
+
+  @Test
+  def testRenameWithNamedArgs1002501Ex11() = new FileSet {
+    """
+    case class CaseClass4(a: Int = 1, /*(*/tryRenameMe/*)*/: Int = 2, c: Int = 3) {
+      CaseClass4(tryRenameMe = 12)
+      copy(tryRenameMe = 18)
+    }
+    """ becomes
+    """
+    case class CaseClass4(a: Int = 1, /*(*/ups/*)*/: Int = 2, c: Int = 3) {
+      CaseClass4(ups = 12)
+      copy(ups = 18)
+    }
+    """ -> TaggedAsGlobalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("ups"))
+
+  @Test
+  def testRenameWithNamedArgs1002501Ex12() = new FileSet {
+    """
+    case class CaseClass5(a: Int = 1, /*(*/tryRenameMe/*)*/: Int = 2) {
+      def copy(tryRenameMe: Int) = ???
+    }
+
+    object CaseClass5 {
+      def apply(tryRenameMe: Int): CaseClass5 = CaseClass5(a = 10, tryRenameMe = tryRenameMe)
+    }
+    """ becomes
+    """
+    case class CaseClass5(a: Int = 1, /*(*/ups/*)*/: Int = 2) {
+      def copy(tryRenameMe: Int) = ???
+    }
+
+    object CaseClass5 {
+      def apply(tryRenameMe: Int): CaseClass5 = CaseClass5(a = 10, ups = tryRenameMe)
+    }
+    """ -> TaggedAsGlobalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("ups"))
+
+  @Test
+  def testRenameWithNamedArgs1002501Ex13() = new FileSet {
+    """
+    object TestWithChainedCopy {
+      case class Elefant(name: String, /*(*/alter/*)*/: Int)
+      val benjamin = Elefant(name = "Benjamin", alter = 12).copy(alter = 3)
+      val nathalie = benjamin.copy(name = "Nathalie", alter = 1).copy(alter = 2)
+    }
+    """ becomes
+    """
+    object TestWithChainedCopy {
+      case class Elefant(name: String, /*(*/age/*)*/: Int)
+      val benjamin = Elefant(name = "Benjamin", age = 12).copy(age = 3)
+      val nathalie = benjamin.copy(name = "Nathalie", age = 1).copy(age = 2)
+    }
+    """ -> TaggedAsGlobalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("age"))
+
+  @Test
+  def testRenameWithNamedArgs1002501Ex14() = new FileSet {
+    """
+    object TestWithUnChainedCopy {
+      case class Elefant(name: String, /*(*/alter/*)*/: Int)
+      val benjamin = Elefant(name = "Benjamin", alter = 12)
+      val nathalie = benjamin.copy(alter = 2)
+    }
+    """ becomes
+    """
+    object TestWithUnChainedCopy {
+      case class Elefant(name: String, /*(*/age/*)*/: Int)
+      val benjamin = Elefant(name = "Benjamin", age = 12)
+      val nathalie = benjamin.copy(age = 2)
+    }
+    """ -> TaggedAsGlobalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("age"))
+
+  @Test
+  def testRenameWithNamedArgs1002501Ex15() = new FileSet {
+    """
+    object TestWithChainedCopyMinimal {
+      case class Elefant(name: String, /*(*/alter/*)*/: Int)
+      val benjamin = Elefant(name = "Benjamin", alter = 12).copy(alter = 3)
+    }
+    """ becomes
+    """
+    object TestWithChainedCopyMinimal {
+      case class Elefant(name: String, /*(*/age/*)*/: Int)
+      val benjamin = Elefant(name = "Benjamin", age = 12).copy(age = 3)
+    }
+    """ -> TaggedAsGlobalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("age"))
+
+  @Test
+  def testRenameWithNamedArgs1002501Ex16() = new FileSet {
+    """
+    object TestWithChainedFunCalls {
+      def chainMe(a: Int = 1, /*(*/b/*)*/: Int = 2) = this
+      chainMe(b = 2).chainMe(b = 9, a = 2)
+    }
+    """ becomes
+    """
+    object TestWithChainedFunCalls {
+      def chainMe(a: Int = 1, /*(*/xxx/*)*/: Int = 2) = this
+      chainMe(xxx = 2).chainMe(xxx = 9, a = 2)
+    }
+    """ -> TaggedAsGlobalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("xxx"))
+
+  @Test
+  def testRenameWithNamedArgs1002501Ex17() = new FileSet {
+    """
+    object TestWithChainedFunCalls {
+      def chainMe(/*(*/a/*)*/: Int = 1, b: Int = 2) = this
+      chainMe(b = 2).chainMe(b = 9, a = 2)
+    }
+    """ becomes
+    """
+    object TestWithChainedFunCalls {
+      def chainMe(/*(*/xxx/*)*/: Int = 1, b: Int = 2) = this
+      chainMe(b = 2).chainMe(b = 9, xxx = 2)
+    }
+    """ -> TaggedAsGlobalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("xxx"))
+
+  @Test
   def testRenameWithPrivateClassVal() = new FileSet {
     """
     class SomeClass {

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
@@ -3606,7 +3606,7 @@ class Blubb
         new OwnedByMethod(xxx = 222)
       }
     }
-    """ -> TaggedAsGlobalRename
+    """ -> TaggedAsLocalRename
   } prepareAndApplyRefactoring(prepareAndRenameTo("xxx"))
 
   @Test
@@ -3644,7 +3644,7 @@ class Blubb
         OwnedByMethod(b = 33, xxx = 4).copy(b = 10).copy(xxx = 3)
       }
     }
-    """ -> TaggedAsGlobalRename
+    """ -> TaggedAsLocalRename
   } prepareAndApplyRefactoring(prepareAndRenameTo("xxx"))
 
   @Test

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
@@ -3360,4 +3360,38 @@ class Blubb
     }
     """ -> TaggedAsGlobalRename
   } prepareAndApplyRefactoring(prepareAndRenameTo("ups"))
+
+  @Test
+  def testRenameWithPrivateClassVal() = new FileSet {
+    """
+    class SomeClass {
+      private val /*(*/tryRenameMe/*)*/ = 42
+    }
+    """ becomes
+    """
+    class SomeClass {
+      private val /*(*/ups/*)*/ = 42
+    }
+    """ -> TaggedAsLocalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("ups"))
+
+  @Test
+  def testRenameWithPrivateClassCtorParam() = new FileSet {
+    """
+    class SomeClass private (/*(*/tryRenameMe/*)*/: Int)
+    """ becomes
+    """
+    class SomeClass private (/*(*/ups/*)*/: Int)
+    """ -> TaggedAsLocalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("ups"))
+
+  @Test
+  def testRenameWithProtectedClassCtorParam() = new FileSet {
+    """
+    class SomeClass protected (/*(*/tryRenameMe/*)*/: Int)
+    """ becomes
+    """
+    class SomeClass protected (/*(*/ups/*)*/: Int)
+    """ -> TaggedAsGlobalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("ups"))
 }

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
@@ -3328,6 +3328,7 @@ class Blubb
     """ -> TaggedAsGlobalRename
   } prepareAndApplyRefactoring(prepareAndRenameTo("ups"))
 
+  @Ignore
   @Test
   def testRenameWithNamedArgs1002501Ex3() = new FileSet {
     """

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
@@ -1522,7 +1522,6 @@ class Blubb
     """
   } applyRefactoring(renameTo("booh"))
 
-  @Ignore
   @Test
   def namedParameter() = new FileSet {
     """
@@ -1543,7 +1542,6 @@ class Blubb
     """
   } applyRefactoring(renameTo("xys"))
 
-  @Ignore
   @Test
   def namedParameterAndDefault() = new FileSet {
     """
@@ -1564,7 +1562,6 @@ class Blubb
     """
   } applyRefactoring(renameTo("xys"))
 
-  @Ignore
   @Test
   def namedParameterInDeclaredOrder() = new FileSet {
     """
@@ -1585,7 +1582,6 @@ class Blubb
     """
   } applyRefactoring(renameTo("xys"))
 
-  @Ignore
   @Test
   def namedParameterInSecondArgsList() = new FileSet {
     """
@@ -1606,7 +1602,6 @@ class Blubb
     """
   } applyRefactoring(renameTo("xys"))
 
-  @Ignore
   @Test
   def updateMethodAndNamedArgument() = new FileSet {
     """
@@ -3297,6 +3292,54 @@ class Blubb
 
     class Bug extends ImplicitVals {
       val /*(*/ups/*)*/ = Bug().withDefault()
+    }
+    """ -> TaggedAsGlobalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("ups"))
+
+  @Test
+  def testRenameWithNamedArgs1002501Ex1() = new FileSet {
+    """
+    class Bug {
+      def f(/*(*/tryRenameMe/*)*/: Int) = tryRenameMe
+      def g(a: Int, b: Int) = f(tryRenameMe = a) + b
+    }
+    """ becomes
+    """
+    class Bug {
+      def f(/*(*/ups/*)*/: Int) = ups
+      def g(a: Int, b: Int) = f(ups = a) + b
+    }
+    """ -> TaggedAsGlobalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("ups"))
+
+  @Test
+  def testRenameWithNamedArgs1002501Ex2() = new FileSet {
+    """
+    class Bug {
+      def f(tryRenameMe: Int) = /*(*/tryRenameMe/*)*/
+      def g(a: Int, b: Int) = f(tryRenameMe = a) + b
+    }
+    """ becomes
+    """
+    class Bug {
+      def f(ups: Int) = /*(*/ups/*)*/
+      def g(a: Int, b: Int) = f(ups = a) + b
+    }
+    """ -> TaggedAsGlobalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("ups"))
+
+  @Test
+  def testRenameWithNamedArgs1002501Ex3() = new FileSet {
+    """
+    class Bug {
+      def f(tryRenameMe: Int) = tryRenameMe
+      def g(a: Int, b: Int) = f(/*(*/tryRenameMe/*)*/ = a) + b
+    }
+    """ becomes
+    """
+    class Bug {
+      def f(ups: Int) = ups
+      def g(a: Int, b: Int) = f(/*(*/ups/*)*/ = a) + b
     }
     """ -> TaggedAsGlobalRename
   } prepareAndApplyRefactoring(prepareAndRenameTo("ups"))

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
@@ -3590,6 +3590,24 @@ class Blubb
   } prepareAndApplyRefactoring(prepareAndRenameTo("xxx"))
 
   @Test
+  def testRenameWithNamedArgs1002572Ex1() = new FileSet {
+    """
+    case class CCC(/*(*/a/*)*/: Int) {
+      copy(a = 0)
+      CCC(a = 23)
+      val b = this.a
+    }
+    """ becomes
+    """
+    case class CCC(/*(*/abc/*)*/: Int) {
+      copy(abc = 0)
+      CCC(abc = 23)
+      val b = this.abc
+    }
+    """ -> TaggedAsGlobalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("abc"))
+
+  @Test
   def testRenameWithPrivateClassVal() = new FileSet {
     """
     class SomeClass {

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
@@ -3606,8 +3606,28 @@ class Blubb
         new OwnedByMethod(xxx = 222)
       }
     }
-    """ -> TaggedAsLocalRename
+    """ -> TaggedAsGlobalRename
   } prepareAndApplyRefactoring(prepareAndRenameTo("xxx"))
+
+  @Test
+  def testRenameWithNamedArgs1002501Ex19() = new FileSet {
+    """
+    object TestWithDefOwnedByValue {
+      val nest = {
+        def nested(/*(*/x/*)*/: Int) = x
+        nested(x = 33)
+      }
+    }
+    """ becomes
+    """
+    object TestWithDefOwnedByValue {
+      val nest = {
+        def nested(/*(*/zzz/*)*/: Int) = zzz
+        nested(zzz = 33)
+      }
+    }
+    """ -> TaggedAsLocalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("zzz"))
 
   @Test
   def testRenameWithNamedArgs1002572Ex1() = new FileSet {
@@ -3644,7 +3664,59 @@ class Blubb
         OwnedByMethod(b = 33, xxx = 4).copy(b = 10).copy(xxx = 3)
       }
     }
-    """ -> TaggedAsLocalRename
+    """ -> TaggedAsGlobalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("xxx"))
+
+  @Test
+  def testRenameWithNamedArgs1002572Ex3() = new FileSet {
+    """
+    object TestWithCaseClassOwnedByMethod {
+      trait Visible {
+        def elefant: Int
+      }
+
+      def nested = {
+        case class OwnedByMethod(/*(*/elefant/*)*/: Int, mouse: Int) extends Visible
+        OwnedByMethod(elefant = 1, mouse = 0)
+      }
+
+      println(nested.elefant)
+    }
+    """ becomes
+    """
+    object TestWithCaseClassOwnedByMethod {
+      trait Visible {
+        def lion: Int
+      }
+
+      def nested = {
+        case class OwnedByMethod(/*(*/lion/*)*/: Int, mouse: Int) extends Visible
+        OwnedByMethod(lion = 1, mouse = 0)
+      }
+
+      println(nested.lion)
+    }
+    """ -> TaggedAsGlobalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("lion"))
+
+  @Test
+  def testRenameWithNamedArgs1002572Ex4() = new FileSet {
+    """
+    object TestWithCaseClassOwnedByValue {
+      val someValue = {
+        case class OwnedByValue(/*(*/a/*)*/: Int, b: Int)
+        OwnedByValue(b = 33, a = 4).copy(b = 10).copy(a = 3)
+      }
+    }
+    """ becomes
+    """
+    object TestWithCaseClassOwnedByValue {
+      val someValue = {
+        case class OwnedByValue(/*(*/xxx/*)*/: Int, b: Int)
+        OwnedByValue(b = 33, xxx = 4).copy(b = 10).copy(xxx = 3)
+      }
+    }
+    """ -> TaggedAsGlobalRename
   } prepareAndApplyRefactoring(prepareAndRenameTo("xxx"))
 
   @Test

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
@@ -3590,6 +3590,26 @@ class Blubb
   } prepareAndApplyRefactoring(prepareAndRenameTo("xxx"))
 
   @Test
+  def testRenameWithNamedArgs1002501Ex18() = new FileSet {
+    """
+    object TestWithCaseClassOwnedByMethod {
+      def someOtherMethod: Any = {
+        class OwnedByMethod(/*(*/tryRenameMe/*)*/: Int)
+        new OwnedByMethod(tryRenameMe = 222)
+      }
+    }
+    """ becomes
+    """
+    object TestWithCaseClassOwnedByMethod {
+      def someOtherMethod: Any = {
+        class OwnedByMethod(/*(*/xxx/*)*/: Int)
+        new OwnedByMethod(xxx = 222)
+      }
+    }
+    """ -> TaggedAsGlobalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("xxx"))
+
+  @Test
   def testRenameWithNamedArgs1002572Ex1() = new FileSet {
     """
     case class CCC(/*(*/a/*)*/: Int) {
@@ -3606,6 +3626,26 @@ class Blubb
     }
     """ -> TaggedAsGlobalRename
   } prepareAndApplyRefactoring(prepareAndRenameTo("abc"))
+
+  @Test
+  def testRenameWithNamedArgs1002572Ex2() = new FileSet {
+    """
+    object TestWithCaseClassOwnedByMethod {
+      def someMethod = {
+        case class OwnedByMethod(/*(*/a/*)*/: Int, b: Int)
+        OwnedByMethod(b = 33, a = 4).copy(b = 10).copy(a = 3)
+      }
+    }
+    """ becomes
+    """
+    object TestWithCaseClassOwnedByMethod {
+      def someMethod = {
+        case class OwnedByMethod(/*(*/xxx/*)*/: Int, b: Int)
+        OwnedByMethod(b = 33, xxx = 4).copy(b = 10).copy(xxx = 3)
+      }
+    }
+    """ -> TaggedAsGlobalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("xxx"))
 
   @Test
   def testRenameWithPrivateClassVal() = new FileSet {

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
@@ -3344,4 +3344,20 @@ class Blubb
     }
     """ -> TaggedAsGlobalRename
   } prepareAndApplyRefactoring(prepareAndRenameTo("ups"))
+
+  @Test
+  def testRenameWithNamedArgs1002501Ex4() = new FileSet {
+    """
+    object Bug {
+      class SomeClass(/*(*/tryRenameMe/*)*/: Int)
+      new SomeClass(tryRenameMe = 22)
+    }
+    """ becomes
+    """
+    object Bug {
+      class SomeClass(/*(*/ups/*)*/: Int)
+      new SomeClass(ups = 22)
+    }
+    """ -> TaggedAsGlobalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("ups"))
 }

--- a/src/test/scala/scala/tools/refactoring/tests/util/SourceWithMarkerTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/util/SourceWithMarkerTest.scala
@@ -290,6 +290,19 @@ class SourceWithMarkerTest {
   }
 
   @Test
+  def testUntilWithNonConsumingSkippingMovement(): Unit = {
+    val src = SourceWithMarker("^123[^trap$]456$")
+
+    val mvnt =
+      until('$', skipping = bracketsWithContents.zeroOrMore) ~
+      "6$".backward ~
+      until('^', skipping = bracketsWithContents.zeroOrMore).backward ~
+      "^1"
+
+    assertEquals("2", src.moveMarker(mvnt).currentStr)
+  }
+
+  @Test
   def testSeqOpsAtEndOfSource(): Unit = {
     val src = SourceWithMarker("aaa")
 

--- a/src/test/scala/scala/tools/refactoring/tests/util/SourceWithMarkerTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/util/SourceWithMarkerTest.scala
@@ -286,7 +286,7 @@ class SourceWithMarkerTest {
 
     assertEquals("b",
         src5.withMarkerAtLastChar.moveMarker(
-            until(Movements.id ~ commentsAndSpaces ~ ('(' | space), skipping = (curlyBracesWithContents | comment)).backward ~ '(').currentStr)
+            until(Movements.id ~ commentsAndSpaces ~ '(', skipping = (curlyBracesWithContents | comment)).backward ~ '(').currentStr)
   }
 
   @Test
@@ -421,6 +421,66 @@ class SourceWithMarkerTest {
     {
       val src = SourceWithMarker("abc").withMarkerAtLastChar
       assertTrue(src.withMarkerAtLastChar.moveMarkerBack(varid).isDepleted)
+    }
+  }
+
+  @Test
+  def testWithSimpleExamplesWhereBacktrackingIsNeeded(): Unit = {
+    {
+      val src = SourceWithMarker("aaaab")
+      assertTrue(src.moveMarker('a'.zeroOrMore ~ 'a' ~ 'b').isDepleted)
+      assertTrue(src.moveMarker('a'.zeroOrMore ~ 'a'.nTimes(4) ~ 'b').isDepleted)
+    }
+
+    {
+      val src = SourceWithMarker("aaaab").withMarkerAtLastChar
+      val asOrBs = ('a'.zeroOrMore || 'b'.zeroOrMore)
+      assertTrue(src.moveMarkerBack(asOrBs ~ 'a' ~ 'b').isDepleted)
+      assertTrue(src.moveMarkerBack(asOrBs.zeroOrMore ~ asOrBs.nTimes(4) ~ 'b').isDepleted)
+    }
+
+    {
+      val src = SourceWithMarker("aaab")
+      val mvnt = 'a' ~ 'a'.atLeastOnce
+      assertTrue(src.moveMarker(mvnt ~ (mvnt ~ 'b').backward ~ mvnt ~ 'b').isDepleted)
+    }
+  }
+
+  @Test
+  def testZeroOrMore(): Unit = {
+    {
+      val src = SourceWithMarker("aaa")
+      assertEquals(Seq(3, 2, 1, 0), 'a'.zeroOrMore.compute(src))
+    }
+
+    {
+      val src = SourceWithMarker("")
+      assertTrue(src.applyMovement('a'.zeroOrMore).isDefined)
+    }
+
+    {
+      val src = SourceWithMarker("a")
+      assertTrue(src.moveMarker('a'.zeroOrMore).isDepleted)
+    }
+
+    {
+      val src = SourceWithMarker("aaaa")
+      assertTrue(src.moveMarker('a'.zeroOrMore).isDepleted)
+    }
+
+    {
+      val src = SourceWithMarker("aaaa")
+      assertTrue(src.moveMarker(('a' || 'b').zeroOrMore).isDepleted)
+    }
+
+    {
+      val src = SourceWithMarker("aaaa")
+      assertTrue(src.moveMarker('a'.zeroOrMore.zeroOrMore).isDepleted)
+    }
+
+    {
+      val src = SourceWithMarker("abaabbbaaabaaabaa")
+      assertTrue(src.moveMarker(('a' ~ 'b'.zeroOrMore ~ 'a'.zeroOrMore).zeroOrMore).isDepleted)
     }
   }
 

--- a/src/test/scala/scala/tools/refactoring/tests/util/SourceWithMarkerTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/util/SourceWithMarkerTest.scala
@@ -1,4 +1,5 @@
 package scala.tools.refactoring.tests.util
+
 import org.junit.Test
 import org.junit.Assert._
 import scala.tools.refactoring.util.SourceWithMarker
@@ -55,10 +56,10 @@ class SourceWithMarkerTest {
     val srcStr5 = "/**/ //**/"
     val src5 = SourceWithMarker(srcStr5, srcStr5.size - 1)
 
-    assertEquals("x", src4.moveMarker(commentsAndSpaces.backward).current.toString)
-    assertEquals("v", src1.moveMarker(commentsAndSpaces).current.toString)
-    assertEquals("v", src2.moveMarker(commentsAndSpaces).current.toString)
-    assertEquals("v", src3.moveMarker(commentsAndSpaces).current.toString)
+    assertEquals("x", src4.moveMarker(commentsAndSpaces.backward).currentStr)
+    assertEquals("v", src1.moveMarker(commentsAndSpaces).currentStr)
+    assertEquals("v", src2.moveMarker(commentsAndSpaces).currentStr)
+    assertEquals("v", src3.moveMarker(commentsAndSpaces).currentStr)
     assertTrue(src5.moveMarker(commentsAndSpaces.backward).isDepleted)
   }
 
@@ -70,9 +71,9 @@ class SourceWithMarkerTest {
       s    s                s
     """)
 
-    assertEquals("s", src1.moveMarker(spaces).current.toString)
-    assertEquals("s", src2.moveMarker(spaces).current.toString)
-    assertEquals("s", src3.moveMarker(spaces ~ 's' ~ spaces ~ 's' ~ spaces).current.toString)
+    assertEquals("s", src1.moveMarker(spaces).currentStr)
+    assertEquals("s", src2.moveMarker(spaces).currentStr)
+    assertEquals("s", src3.moveMarker(spaces ~ 's' ~ spaces ~ 's' ~ spaces).currentStr)
     assertTrue(src1.moveMarker(spaces ~ (spaces ~ "s").backward).isDepleted)
   }
 
@@ -89,14 +90,14 @@ class SourceWithMarkerTest {
     val moveToBracketOpen = "protected" ~ commentsAndSpaces
     val moveToBracketClose = moveToBracketOpen ~ bracketsWithContents ~ '/'.backward
     val moveToStartOfMultilineComment = moveToBracketClose ~ ']' ~ (comment) ~ spaces
-    val moveToEndOfMultilineComment = moveToStartOfMultilineComment ~ comments ~ (spaces ~ 'o').backward
+    val moveToEndOfMultilineComment = moveToStartOfMultilineComment ~ commentsAndSpaces ~ (spaces ~ 'o').backward
     val moveToVal = moveToBracketClose ~ ']' ~ commentsAndSpaces ~ "override" ~ commentsAndSpaces
 
-    assertEquals("[", src.moveMarker(moveToBracketOpen).current.toString)
-    assertEquals("]", src.moveMarker(moveToBracketClose).current.toString)
-    assertEquals("/", src.moveMarker(moveToStartOfMultilineComment).current.toString)
-    assertEquals("/", src.moveMarker(moveToEndOfMultilineComment).current.toString)
-    assertEquals("v", src.moveMarker(moveToVal).current.toString)
+    assertEquals("[", src.moveMarker(moveToBracketOpen).currentStr)
+    assertEquals("]", src.moveMarker(moveToBracketClose).currentStr)
+    assertEquals("/", src.moveMarker(moveToStartOfMultilineComment).currentStr)
+    assertEquals("/", src.moveMarker(moveToEndOfMultilineComment).currentStr)
+    assertEquals("v", src.moveMarker(moveToVal).currentStr)
 
     assertTrue(src.moveMarker("protected" ~ ("protected" ~ commentsAndSpaces).backward).isDepleted)
     assertTrue(src.moveMarker(moveToVal ~ (moveToVal ~ "v").backward).isDepleted)
@@ -117,12 +118,12 @@ class SourceWithMarkerTest {
     val src = SourceWithMarker(srcStr, srcStr.lastIndexOf("]"))
     val mvmt = (("private" | "protected") ~ commentsAndSpaces ~ bracketsWithContents).backward
 
-    assertEquals("p", src.moveMarker(mvmt ~ commentsAndSpaces).current.toString)
+    assertEquals("p", src.moveMarker(mvmt ~ commentsAndSpaces).currentStr)
   }
 
   @Test
   def testWithScopedAccessModifiers(): Unit = {
-    val src = SourceWithMarker("private[test]").withMarkerOnLastChar
+    val src = SourceWithMarker("private[test]").withMarkerAtLastChar
     assertTrue(src.moveMarker((("private" | "protected") ~ commentsAndSpaces ~ bracketsWithContents).backward).isDepleted)
   }
 
@@ -177,15 +178,15 @@ class SourceWithMarkerTest {
     val src1 = SourceWithMarker("(a='b',b=''',c='\'',e='s)")
     val baseMvnt1 = '(' ~ "a=" ~ characterLiteral ~ ",b=" ~ characterLiteral ~ ",c=" ~ characterLiteral ~ ",e="
 
-    assertEquals("'", src1.moveMarker(baseMvnt1).current.toString)
-    assertEquals("(", src1.moveMarker(baseMvnt1 ~ characterLiteral).current.toString)
+    assertEquals("'", src1.moveMarker(baseMvnt1).currentStr)
+    assertEquals("(", src1.moveMarker(baseMvnt1 ~ characterLiteral).currentStr)
     assertTrue(src1.moveMarker(baseMvnt1 ~ "'s)").isDepleted)
 
     val src2 = SourceWithMarker("""'\222'x''';'\b'°'\\'''\"'::""")
     val baseMvnt2 = (characterLiteral ~ any).zeroOrMore
 
-    assertEquals(":", src2.moveMarker(baseMvnt2).current.toString)
-    assertEquals("'", src2.moveMarker(baseMvnt2 ~ (any ~ characterLiteral ~ any).backward).current.toString)
+    assertEquals(":", src2.moveMarker(baseMvnt2).currentStr)
+    assertEquals("'", src2.moveMarker(baseMvnt2 ~ (any ~ characterLiteral ~ any).backward).currentStr)
   }
 
   @Test
@@ -199,15 +200,16 @@ class SourceWithMarkerTest {
   @Test
   def testOpChar(): Unit = {
     val src = SourceWithMarker("+-/*:><!~^\u03f6.")
-    assertEquals("~", src.moveMarker(opChar.zeroOrMore ~ (opChar.nTimes(2) ~ '.').backward).current.toString)
+    assertEquals("~", src.moveMarker(opChar.zeroOrMore ~ (opChar.nTimes(2) ~ '.').backward).currentStr)
   }
 
   @Test
   def testUntilWithSimpleExamples(): Unit = {
     val src = SourceWithMarker("0123456789")
-    assertEquals("5", src.moveMarker(until("5")).current.toString)
-    assertEquals("5", src.moveMarker(until("5", skipping = digit)).current.toString)
-    assertEquals("0", src.moveMarker(until("5", skipping = digit.zeroOrMore)).current.toString)
+    assertEquals("5", src.moveMarker(until("5")).currentStr)
+    assertEquals("5", src.moveMarker(until("5", skipping = digit)).currentStr)
+    assertEquals("0", src.moveMarker(until("5", skipping = digit.zeroOrMore)).currentStr)
+    assertEquals("1", src.moveMarker("01234" ~ until('1', skipping = '2').backward).currentStr)
   }
 
   @Test
@@ -229,7 +231,7 @@ class SourceWithMarkerTest {
     """)
 
     val mvnt2 = (spaces ~ stringLiteral ~ spaces).atLeastOnce
-    assertEquals(";", src2.moveMarker(mvnt2).current.toString)
+    assertEquals(";", src2.moveMarker(mvnt2).currentStr)
   }
 
   @Test
@@ -247,13 +249,44 @@ class SourceWithMarkerTest {
       $trippleQuote, b = 'd_=, c = 'd', d= 3)
     )""")
 
-    assertEquals("i", src1.moveMarker(untilVal("j") ~ any.nTimes(4)).current.toString)
-    assertEquals("j", src1.moveMarker(untilVal("i") ~ any.nTimes(4)).current.toString)
+    assertEquals("i", src1.moveMarker(untilVal("j") ~ any.nTimes(4)).currentStr)
+    assertEquals("j", src1.moveMarker(untilVal("i") ~ any.nTimes(4)).currentStr)
 
-    assertEquals("v", src2.moveMarker(untilVal("i") ~ any.nTimes(5)).current.toString)
-    assertEquals("l", src2.moveMarker(untilVal("k") ~ any.nTimes(2)).current.toString)
+    assertEquals("v", src2.moveMarker(untilVal("i") ~ any.nTimes(5)).currentStr)
+    assertEquals("l", src2.moveMarker(untilVal("k") ~ any.nTimes(2)).currentStr)
 
-    assertEquals("3", src3.moveMarker(untilVal("d") ~ any.nTimes(3)).current.toString)
+    assertEquals("3", src3.moveMarker(untilVal("d") ~ any.nTimes(3)).currentStr)
+
+    assertEquals(")", src1.moveMarker(until(')')).currentStr)
+    assertEquals("(", src1.moveMarker(until("xxx", any)).currentStr)
+
+    assertEquals("(", src1.moveMarker(until(')')).moveMarkerBack(until('(', skipping = id | '=' | space | comment)).currentStr)
+    assertEquals(")", src1.moveMarker(until(')')).moveMarkerBack(until(')', skipping = '=' | space | comment)).currentStr)
+
+    val src4 = SourceWithMarker("(a = { 1 + * (3 + 4) }, b = 9)")
+    assertEquals("3", src4.moveMarker(
+        until(')') ~ until('(').backward ~ '(').currentStr)
+
+    assertEquals(")", src4.moveMarker(
+        until(')') ~ until('(').backward ~ "(3" ~ until(')')).currentStr)
+
+    assertEquals("=", src4.moveMarker(
+        until(')') ~ until('(').backward ~ "(3" ~ until(')', skipping = "4)") ~ until("(", skipping = curlyBracesWithContents).backward ~ "(a ").currentStr)
+
+    assertTrue(SourceWithMarker("chainMe(").moveMarker(id ~ '(').isDepleted)
+    assertTrue(SourceWithMarker("chainMe").withMarkerAtLastChar.moveMarkerBack(Movements.letter.atLeastOnce).isDepleted)
+
+    val src5 = SourceWithMarker("chainMe(a = 2).chainMe(b = 9, xxx = 2)")
+
+    assertEquals("9", src5.moveMarker(until("9")).currentStr)
+
+    assertEquals("(",
+        src5.moveMarker(
+            until("9") ~ until('(', skipping = (curlyBracesWithContents | comment)).backward).currentStr)
+
+    assertEquals("b",
+        src5.withMarkerAtLastChar.moveMarker(
+            until(Movements.id ~ commentsAndSpaces ~ ('(' | space), skipping = (curlyBracesWithContents | comment)).backward ~ '(').currentStr)
   }
 
   @Test
@@ -306,9 +339,92 @@ class SourceWithMarkerTest {
     runIdTest("privateval", "privateval")
     runIdTest("val x = 3", "")
     runIdTest("->", "->")
+    runIdTest("2", "")
+    runIdTest("x2", "x2")
+  }
+
+  @Test
+  def testCurlyBracesWithContents(): Unit = {
+    val src = SourceWithMarker(""">
+    val x1 = {
+      val x2 = {
+         3
+      }
+      //; }
+      //; {
+      /*{*/
+      x + 2
+      /*}*/
+    };
+    """)
+
+    assertEquals(";", src.moveMarker('>' ~ commentsAndSpaces ~ "val x1 = " ~ curlyBracesWithContents).currentStr)
+
+    val res = src.applyMovement(until(";", skipping = curlyBracesWithContents)).flatMap { src =>
+      println(src)
+      src.applyMovement(until("x", skipping = curlyBracesWithContents).backward).flatMap { src =>
+        println(src)
+        src.applyMovement("x1 = ")
+      }
+    }
+
+    assertTrue(res.isDefined)
+  }
+
+  @Test
+  def testGoingBackward(): Unit = {
+    {
+      val src = SourceWithMarker("abc").withMarkerAtLastChar
+      assertTrue(src.moveMarkerBack("abc").isDepleted)
+    }
+
+    {
+      val src = SourceWithMarker("abc").withMarkerAtLastChar
+      assertTrue(src.withMarkerAtLastChar.moveMarkerBack("x" | "y" | "abc").isDepleted)
+    }
+
+    {
+      val src = SourceWithMarker("abc").withMarkerAtLastChar
+      assertTrue(src.withMarkerAtLastChar.moveMarkerBack("a" ~ "b" ~ "c").isDepleted)
+    }
+
+    {
+      val src = SourceWithMarker("abc").withMarkerAtLastChar
+      assertTrue(src.withMarkerAtLastChar.moveMarkerBack("a".atLeastOnce ~ "b".zeroOrMore ~ "c".atLeastOnce).isDepleted)
+    }
+
+    {
+      val src = SourceWithMarker("abc").withMarkerAtLastChar
+      assertTrue(src.withMarkerAtLastChar.moveMarkerBack("a".zeroOrMore ~ "b".atLeastOnce ~ "c".zeroOrMore).isDepleted)
+    }
+
+    {
+      val src = SourceWithMarker("abc").withMarkerAtLastChar
+      assertTrue(src.withMarkerAtLastChar.moveMarkerBack((character('a') | 'c').butNot('d') ~ 'b' ~ 'c').isDepleted)
+    }
+
+    {
+      val src = SourceWithMarker("abc").withMarkerAtLastChar
+      assertTrue(src.withMarkerAtLastChar.moveMarkerBack('a' ~ 'b' ~ 'c').isDepleted)
+    }
+
+    {
+      val src = SourceWithMarker("abc").withMarkerAtLastChar
+      assertTrue(src.withMarkerAtLastChar.moveMarkerBack("abc".butNot("ab" | "bc")).isDepleted)
+    }
+
+    {
+      val src = SourceWithMarker("abc").withMarkerAtLastChar
+      assertTrue(src.withMarkerAtLastChar.moveMarkerBack(idrest).isDepleted)
+    }
+
+    {
+      val src = SourceWithMarker("abc").withMarkerAtLastChar
+      assertTrue(src.withMarkerAtLastChar.moveMarkerBack(varid).isDepleted)
+    }
   }
 
   private implicit class SourceWithMarkerOps(underlying: SourceWithMarker) {
-    def withMarkerOnLastChar = underlying.copy(marker = underlying.source.length - 1)
+    def currentStr = underlying.current.toString
   }
 }

--- a/src/test/scala/scala/tools/refactoring/tests/util/TestHelper.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/util/TestHelper.scala
@@ -215,7 +215,7 @@ trait TestHelper extends TestRules with Refactoring with CompilerProvider with c
 
         def assertOk() = {
           expectGlobalRename.foreach { expectGlobalRename =>
-            assertEquals(expectGlobalRename, !prepResult.get.right.get.hasLocalScope)
+            assertEquals(s"Wrong value for globalRename - ", expectGlobalRename, !prepResult.get.right.get.hasLocalScope)
           }
           assertEqualSource()
         }


### PR DESCRIPTION
This PR implements support for named parameters when doing rename refactorings (see [Ticket #1002501](https://www.assembla.com/spaces/scala-ide/tickets/1002501-rename-does-not-consider-named-parameters/details#), as well as [Ticket #1002572](https://www.assembla.com/spaces/scala-ide/tickets/1002572-rename-refactoring-for-case-class-parameter-should-also-rename-named-arguments-to-apply-and-copy/details#)). To achieve this, this PR takes care of several things:

1. Named parameters are desugared. Therefore we have to manually parse them in the original source code. Unfortunately, due to the compiler setting incorrect positions on some of the trees in the AST, this is harder than it should be. The parsing is done with the `SourceWithMarker` framework, that now supports backtracking (note that I've strong evidence for the fact that the newly added backtracking support should not cause performance regressions: https://github.com/mlangc/scala-refactoring-experiments/blob/master/src/test/scala/com/github/mlangc/experiments/refactoring/SourceWithMarkerBenchmark.scala).
2. Named parameters are often used in connection with constructors and case classes. In these cases, there is a one-to-one mapping between certain named parameters and class values (think of constructors and generated `copy` and `apply` methods). This is what the updates related to `SymbolExpander` are about.
3. Renaming a method parameter is no longer a local operation in the sense of `Rename.PreparationResult.hasLocalScope` if the method might be called from outside the file that defines it.
4. The performance problems that led to support for named arguments being dropped in the past should be addressed by 168d91fd22b85a65d2930dd2bdd7224d55377f14. I did some benchmarking (see https://github.com/mlangc/scala-refactoring-experiments/blob/master/src/test/scala/com/github/mlangc/experiments/refactoring/RenameBenchmark.scala) and did not see any changes in the results, but there might be corner cases that are not covered by the benchmark.

Note that it is currently not possible to rename named parameters where they are used, but only where they are defined, that is you cannot initiate a rename refactoring at `f(tryRenameMe = 22)`, but only at `def f(tryRenameMe: Int)`. In my opinion, we should take care of this in a separate PR though because

- this is not a regression
- this PR is quite large already
- fixing this issue would also require changes to Scala-IDE and possibly ENSIME