### PR TITLE
Organize Imports in Defs avoiding tree printer

### DIFF
--- a/src/main/scala/scala/tools/refactoring/analysis/CompilationUnitDependencies.scala
+++ b/src/main/scala/scala/tools/refactoring/analysis/CompilationUnitDependencies.scala
@@ -116,6 +116,7 @@ trait CompilationUnitDependencies extends CompilerApiExtensions with ScalaVersio
    */
   def dependencies(t: Tree): List[Select] = {
     val wholeTree = t
+    val isNotInImports = new IsNotInImports(CompilationUnitDependencies.this.global, CompilationUnitDependencies.this, t);
 
     def qualifierIsEnclosingPackage(t: Select) = {
       enclosingPackage(wholeTree, t.pos) match {
@@ -386,7 +387,8 @@ trait CompilationUnitDependencies extends CompilerApiExtensions with ScalaVersio
                   && hasStableQualifier(t)
                   && !t.symbol.isLocal
                   && !isRelativeToLocalImports(t)
-                  && !isDefinedLocallyAndQualifiedWithEnclosingPackage(t)) {
+                  && !isDefinedLocallyAndQualifiedWithEnclosingPackage(t)
+                  && isNotInImports.isSelectNotInRelativeImports(t)) {
                 addToResult(t)
               }
 

--- a/src/main/scala/scala/tools/refactoring/analysis/IsNotInImports.scala
+++ b/src/main/scala/scala/tools/refactoring/analysis/IsNotInImports.scala
@@ -1,0 +1,60 @@
+package scala.tools.refactoring
+package analysis
+
+import tools.nsc.interactive.Global
+
+class IsNotInImports(val global: Global, val cuDependenciesInstance: CompilationUnitDependencies with common.EnrichedTrees, tree: Global#Tree) {
+  import global._
+  val wholeTree = tree.asInstanceOf[Tree]
+
+  private def collectPotentialOwners(of: Select): List[Symbol] = {
+    val upToPosition = of.pos.start
+    def isThisSelectTree(fromWholeTree: Tree): Boolean =
+      fromWholeTree.pos.isRange && fromWholeTree.pos.start == upToPosition
+    var owners = List.empty[Symbol]
+    val collectPotentialOwners = new Traverser {
+      var owns = List.empty[Symbol]
+      override def traverse(t: Tree) = {
+        owns = currentOwner :: owns
+        t match {
+          case t if !t.pos.isRange || t.pos.start > upToPosition =>
+          case potential if isThisSelectTree(potential) =>
+            owners = owns.distinct
+          case t =>
+            super.traverse(t)
+            owns = owns.tail
+        }
+      }
+    }
+    collectPotentialOwners.traverse(wholeTree)
+    owners
+  }
+
+  def isSelectNotInRelativeImports(tested: Global#Select): Boolean = {
+    val doesNameFitInTested = compareNameWith(tested) _
+    val nonPackageOwners = collectPotentialOwners(tested.asInstanceOf[Select]).filterNot { _.hasPackageFlag }
+    def isValidPosition(t: Import): Boolean = t.pos.isRange && t.pos.start < tested.pos.start
+    val isImportForTested = new Traverser {
+      var found = false
+      override def traverse(t: Tree) = t match {
+        case imp: Import if isValidPosition(imp) && doesNameFitInTested(imp) && nonPackageOwners.contains(currentOwner) =>
+          found = true
+        case t => super.traverse(t)
+      }
+    }
+    isImportForTested.traverse(wholeTree.asInstanceOf[Tree])
+    !isImportForTested.found
+  }
+
+  private def compareNameWith(tested: Global#Select)(that: Global#Import): Boolean = {
+    import cuDependenciesInstance.additionalTreeMethodsForPositions
+    val Select(testedQual, testedName) = tested
+    val testedQName = List(testedQual.asInstanceOf[cuDependenciesInstance.global.Tree].nameString, testedName).mkString(".")
+    val Import(thatQual, thatSels) = that
+    val impNames = thatSels.map { sel =>
+      if (sel.name == nme.WILDCARD) thatQual.asInstanceOf[cuDependenciesInstance.global.Tree].nameString
+      else List(thatQual.asInstanceOf[cuDependenciesInstance.global.Tree].nameString, sel.name).mkString(".")
+    }
+    impNames.exists { testedQName.startsWith }
+  }
+}

--- a/src/main/scala/scala/tools/refactoring/implementations/NotPackageImportParticipants.scala
+++ b/src/main/scala/scala/tools/refactoring/implementations/NotPackageImportParticipants.scala
@@ -1,0 +1,79 @@
+package scala.tools.refactoring
+package implementations
+
+import scala.tools.nsc.interactive.Global
+
+class NotPackageImportParticipants(val global: Global, val organizeImportsInstance: OrganizeImports) {
+  import global._
+
+  class RemoveUnused(block: Global#Tree) extends organizeImportsInstance.Participant {
+    private def treeWithoutImports(tree: Tree) = new Transformer {
+      override def transform(tree: Tree): Tree = tree match {
+        case Import(_, _) => EmptyTree
+        case t => super.transform(t)
+      }
+    }.transform(tree)
+
+    private lazy val allSelects = {
+      import scala.collection.mutable
+      val selects = mutable.ListBuffer[Global#Select]()
+      val selectsTraverser = new organizeImportsInstance.TraverserWithFakedTrees {
+        override def traverse(tree: organizeImportsInstance.global.Tree): Unit = tree match {
+          case s @ organizeImportsInstance.global.Select(qual, _) =>
+            selects += s
+            traverse(qual)
+          case t => super.traverse(t)
+        }
+      }
+      selectsTraverser.traverse(treeWithoutImports(block.asInstanceOf[Tree]).asInstanceOf[organizeImportsInstance.global.Tree])
+      selects.toList
+    }
+
+    protected def doApply(trees: List[organizeImportsInstance.global.Import]) = trees.asInstanceOf[List[Import]] collect {
+      case imp @ Import(importQualifier, importSelections) =>
+        val usedSelectors = importSelections filter { importSel =>
+          val importSym = importQualifier.symbol.fullName
+          val isWildcard = importSel.name == nme.WILDCARD
+          val importSelNames = Set(importSel.name, importSel.rename).filterNot { _ == null }.map { _.toString }
+
+          allSelects.exists { foundSel =>
+            def downToPackage(selectQualifierSymbol: Global#Symbol): Global#Symbol =
+              if (selectQualifierSymbol == null || selectQualifierSymbol == NoSymbol
+                  || selectQualifierSymbol.isPackage || selectQualifierSymbol.isModule
+                  || selectQualifierSymbol.isStable)
+                selectQualifierSymbol
+              else
+                downToPackage(selectQualifierSymbol.owner)
+            val foundNames = Set(foundSel.name.toString, foundSel.symbol.owner.nameString)
+            val foundSym = Option(downToPackage(foundSel.qualifier.symbol)).getOrElse(downToPackage(foundSel.symbol))
+            (isWildcard || foundNames.&(importSelNames).nonEmpty) &&
+              foundSym != null && foundSym.fullName == importSym
+          }
+        }
+        val result = usedSelectors match {
+          case Nil => Import(EmptyTree, Nil)
+          case _ => imp.copy(selectors = usedSelectors)
+        }
+        result.asInstanceOf[organizeImportsInstance.global.Import]
+    }
+  }
+
+  object RemoveDuplicatedByWildcard extends organizeImportsInstance.Participant {
+    protected def doApply(trees: List[organizeImportsInstance.global.Import]) = trees.asInstanceOf[List[Import]].map { imp =>
+      val wild = imp.selectors.find(_.name == nme.WILDCARD)
+      if (wild.nonEmpty)
+        imp.copy(selectors = wild.toList)
+      else
+        imp
+    }.groupBy {
+      _.expr.toString
+    }.collect {
+      case (_, imports) =>
+        val (wild, rest) = imports.partition(_.selectors.exists(_.name == nme.WILDCARD))
+        if (wild.nonEmpty)
+          wild
+        else
+          rest
+    }.flatten.toList.asInstanceOf[List[organizeImportsInstance.global.Import]]
+  }
+}

--- a/src/main/scala/scala/tools/refactoring/implementations/OrganizeImports.scala
+++ b/src/main/scala/scala/tools/refactoring/implementations/OrganizeImports.scala
@@ -480,6 +480,7 @@ abstract class OrganizeImports extends MultiStageRefactoring with TreeFactory
       _.transform { i =>
         scala.Function.chain { RemoveDuplicatedByWildcard.asInstanceOf[Participant] ::
           (new NPRemovedUnused(rootTree)).asInstanceOf[Participant] ::
+          RemoveDuplicates ::
           SortImportSelectors ::
           SortImports ::
           Nil }(i.asInstanceOf[List[Import]])

--- a/src/main/scala/scala/tools/refactoring/implementations/OrganizeImports.scala
+++ b/src/main/scala/scala/tools/refactoring/implementations/OrganizeImports.scala
@@ -235,7 +235,7 @@ abstract class OrganizeImports extends MultiStageRefactoring with TreeFactory
           def removeDuplicates(l: List[ImportSelector]) = {
             l.groupBy(_.name.toString).map(_._2.head).toList
           }
-          imp.copy(selectors = removeDuplicates(selectors).sortBy(_.name.toString))
+          imp.copy(selectors = removeDuplicates(selectors).sortBy(_.name.toString)).setPos(imp.pos)
       }
     }
   }
@@ -475,10 +475,12 @@ abstract class OrganizeImports extends MultiStageRefactoring with TreeFactory
     import oimports.NotPackageImportParticipants
     val notPackageParticipants = new NotPackageImportParticipants(global, this)
     import notPackageParticipants.RemoveDuplicatedByWildcard
+    import notPackageParticipants.{ RemoveUnused => NPRemovedUnused }
     val regions = new DefImportsOrganizer(global).transformTreeToRegions(rootTree).map {
       _.transform { i =>
         scala.Function.chain { RemoveDuplicatedByWildcard.asInstanceOf[Participant] ::
-          //SortImportSelectors ::
+          (new NPRemovedUnused(rootTree)).asInstanceOf[Participant] ::
+          SortImportSelectors ::
           SortImports ::
           Nil }(i.asInstanceOf[List[Import]])
       }

--- a/src/main/scala/scala/tools/refactoring/implementations/OrganizeImports.scala
+++ b/src/main/scala/scala/tools/refactoring/implementations/OrganizeImports.scala
@@ -468,62 +468,22 @@ abstract class OrganizeImports extends MultiStageRefactoring with TreeFactory
       case (p, existingImports, others) =>
         val imports = scala.Function.chain(participants)(existingImports)
         p copy (stats = imports ::: others) replaces p
-    } &> transformation[Tree, Tree] {
-      case p: PackageDef =>
-        MethodImportsOrganizer.organizeImportsInMethodBlocks(p).replaces(p)
     }
 
-    Right(transformFile(selection.file, organizeImports |> topdown(matchingChildren(organizeImports))))
-  }
-
-  object MethodImportsOrganizer {
-    val methodOrganizeImportsParticipants = new NotPackageImportParticipants(OrganizeImports.this.global, OrganizeImports.this)
-    import methodOrganizeImportsParticipants.RemoveDuplicatedByWildcard
-
-    private def organizeImportsIfNoImportInSameLine(imports: List[Import])(organizeImports: List[Import] => List[Import]): List[Import] = {
-      val importsWithPosition = imports.filter { _.pos.isDefined }
-      if (importsWithPosition.nonEmpty &&
-        importsWithPosition.size != importsWithPosition.map { _.pos.line }.distinct.size)
-        imports
-      else organizeImports(imports)
+    val rootTree = abstractFileToTree(selection.file)
+    import oimports.DefImportsOrganizer
+    import oimports.NotPackageImportParticipants
+    val notPackageParticipants = new NotPackageImportParticipants(global, this)
+    import notPackageParticipants.RemoveDuplicatedByWildcard
+    val regions = new DefImportsOrganizer(global).transformTreeToRegions(rootTree).map {
+      _.transform { i =>
+        scala.Function.chain { RemoveDuplicatedByWildcard.asInstanceOf[Participant] ::
+          //SortImportSelectors ::
+          SortImports ::
+          Nil }(i.asInstanceOf[List[Import]])
+      }
     }
-
-    private def organizeGroupedImports(stats: List[Tree])(importsOrganizer: List[Import] => List[Import])(transformer: Transformer): List[Tree] = {
-      val treeListTurnedToListOfSingleTreeElementList = stats.map { tree => List(tree) }
-      val mergeNeighborImportLists = treeListTurnedToListOfSingleTreeElementList.foldLeft(List.empty[List[Tree]]) { (zero, elem) =>
-        elem.head match {
-          case addToProceedingImports: Import =>
-            def isZeroHeadAListOfImports(zeroHead: List[Tree]) = zeroHead.forall { _.isInstanceOf[Import] }
-            zero match {
-              case head :: tail if isZeroHeadAListOfImports(head) => (addToProceedingImports :: head) :: tail
-              case _ => elem :: zero
-            }
-          case _ => elem :: zero
-        }
-      }
-      val restoreOrderAfterFoldLeft = mergeNeighborImportLists.reverse.map {
-        _.reverse
-      }
-      val applyImportsOrganizerToImportsLists = restoreOrderAfterFoldLeft.map {
-        case imps @ (head: Import) :: _ =>
-          organizeImportsIfNoImportInSameLine(imps.asInstanceOf[List[Import]])(importsOrganizer)
-        case t => t.map { transformer.transform }
-      }
-      applyImportsOrganizerToImportsLists.flatten
-    }
-
-    def organizeImportsInMethodBlocks(tree: Tree): Tree = new Transformer {
-      override def transform(t: Tree) = t match {
-        case b @ Block(stats, _) if currentOwner.isMethod && !currentOwner.isLazy =>
-          val participants = (new methodOrganizeImportsParticipants.RemoveUnused(b)).asInstanceOf[Participant] ::
-            RemoveDuplicatedByWildcard.asInstanceOf[Participant] ::
-            RemoveDuplicates :: SortImportSelectors :: SortImports :: Nil
-          val importsOrganizer = scala.Function.chain(participants)
-          val reorganizedStats = organizeGroupedImports(stats)(importsOrganizer)(this)
-          b.copy(stats = reorganizedStats).replaces(b)
-        case skipPlainText: PlainText => skipPlainText
-        case t => super.transform(t)
-      }
-    }.transform(tree)
+    val changes = regions.map { _.print }
+    Right(transformFile(selection.file, organizeImports |> topdown(matchingChildren(organizeImports))) ::: changes)
   }
 }

--- a/src/main/scala/scala/tools/refactoring/implementations/OrganizeImports.scala
+++ b/src/main/scala/scala/tools/refactoring/implementations/OrganizeImports.scala
@@ -76,7 +76,12 @@ object OrganizeImports {
  *
  *
  */
-abstract class OrganizeImports extends MultiStageRefactoring with TreeFactory with TreeTraverser with UnusedImportsFinder with analysis.CompilationUnitDependencies with common.InteractiveScalaCompiler with common.TreeExtractors {
+abstract class OrganizeImports extends MultiStageRefactoring with TreeFactory
+                                                             with TreeTraverser
+                                                             with UnusedImportsFinder
+                                                             with analysis.CompilationUnitDependencies
+                                                             with common.InteractiveScalaCompiler
+                                                             with common.TreeExtractors {
 
   import OrganizeImports.Algos
   import global._
@@ -465,74 +470,15 @@ abstract class OrganizeImports extends MultiStageRefactoring with TreeFactory wi
         p copy (stats = imports ::: others) replaces p
     } &> transformation[Tree, Tree] {
       case p: PackageDef =>
-        InnerImports.organizeImportsInMethodBlocks(p).replaces(p)
+        MethodImportsOrganizer.organizeImportsInMethodBlocks(p).replaces(p)
     }
 
     Right(transformFile(selection.file, organizeImports |> topdown(matchingChildren(organizeImports))))
   }
 
-  object InnerImports {
-    class RemoveUnused(block: Tree) extends Participant {
-      private def treeWithoutImports(tree: Tree) = new Transformer {
-        override def transform(tree: Tree): Tree = tree match {
-          case Import(_, _) => EmptyTree
-          case t => super.transform(t)
-        }
-      }.transform(tree)
-
-      private lazy val allSelects = {
-        import scala.collection.mutable
-        val selects = mutable.ListBuffer[Select]()
-        val selectsTraverser = new Traverser {
-          override def traverse(tree: Tree): Unit = tree match {
-            case s @ Select(qual, _) =>
-              selects += s
-              traverse(qual)
-            case t => super.traverse(t)
-          }
-        }
-        selectsTraverser.traverse(treeWithoutImports(block))
-        selects.toList
-      }
-
-      protected def doApply(trees: List[Import]) = trees collect {
-        case imp @ Import(importQualifier: Select, importSelections) =>
-          val usedSelectors = importSelections filter { importSel =>
-            val importName = importSel.name.toString
-            val importSym = importQualifier.symbol
-            val isWildcard = importSel.name == nme.WILDCARD
-
-            allSelects.exists { foundSel =>
-              val foundName = foundSel.symbol.nameString
-              val foundSym = foundSel.qualifier.symbol
-              (isWildcard || foundName == importName) && foundSym == importSym
-            }
-          }
-          usedSelectors match {
-            case Nil => Import(EmptyTree, Nil)
-            case _ => imp.copy(selectors = usedSelectors)
-          }
-      }
-    }
-
-    object RemoveDuplicatedByWildcard extends Participant {
-      protected def doApply(trees: List[Import]) = trees.map { imp =>
-        val wild = imp.selectors.find(_.name == nme.WILDCARD)
-        if (wild.nonEmpty)
-          imp.copy(selectors = wild.toList)
-        else
-          imp
-      }.groupBy {
-        _.expr.toString
-      }.collect {
-        case (_, imports) =>
-          val (wild, rest) = imports.partition(_.selectors.exists(_.name == nme.WILDCARD))
-          if (wild.nonEmpty)
-            wild
-          else
-            rest
-      }.flatten.toList
-    }
+  object MethodImportsOrganizer {
+    val methodOrganizeImportsParticipants = new NotPackageImportParticipants(OrganizeImports.this.global, OrganizeImports.this)
+    import methodOrganizeImportsParticipants.RemoveDuplicatedByWildcard
 
     private def organizeImportsIfNoImportInSameLine(imports: List[Import])(organizeImports: List[Import] => List[Import]): List[Import] = {
       val importsWithPosition = imports.filter { _.pos.isDefined }
@@ -542,17 +488,39 @@ abstract class OrganizeImports extends MultiStageRefactoring with TreeFactory wi
       else organizeImports(imports)
     }
 
+    private def organizeGroupedImports(stats: List[Tree])(importsOrganizer: List[Import] => List[Import])(transformer: Transformer): List[Tree] = {
+      val treeListTurnedToListOfSingleTreeElementList = stats.map { tree => List(tree) }
+      val mergeNeighborImportLists = treeListTurnedToListOfSingleTreeElementList.foldLeft(List.empty[List[Tree]]) { (zero, elem) =>
+        elem.head match {
+          case addToProceedingImports: Import =>
+            def isZeroHeadAListOfImports(zeroHead: List[Tree]) = zeroHead.forall { _.isInstanceOf[Import] }
+            zero match {
+              case head :: tail if isZeroHeadAListOfImports(head) => (addToProceedingImports :: head) :: tail
+              case _ => elem :: zero
+            }
+          case _ => elem :: zero
+        }
+      }
+      val restoreOrderAfterFoldLeft = mergeNeighborImportLists.reverse.map {
+        _.reverse
+      }
+      val applyImportsOrganizerToImportsLists = restoreOrderAfterFoldLeft.map {
+        case imps @ (head: Import) :: _ =>
+          organizeImportsIfNoImportInSameLine(imps.asInstanceOf[List[Import]])(importsOrganizer)
+        case t => t.map { transformer.transform }
+      }
+      applyImportsOrganizerToImportsLists.flatten
+    }
+
     def organizeImportsInMethodBlocks(tree: Tree): Tree = new Transformer {
       override def transform(t: Tree) = t match {
         case b @ Block(stats, _) if currentOwner.isMethod && !currentOwner.isLazy =>
-          val (rawImports, others) = stats.partition { _.isInstanceOf[Import] }
-          val imports = rawImports.asInstanceOf[List[Import]]
-          val importsOrganizer = scala.Function.chain(new RemoveUnused(b) :: RemoveDuplicatedByWildcard ::
-              RemoveDuplicates :: SortImportSelectors :: SortImports :: Nil)
-          val visitedOthers = others.map { t =>
-            transform(t).replaces(t)
-          }
-          b.copy(stats = organizeImportsIfNoImportInSameLine(imports)(importsOrganizer) ::: visitedOthers).replaces(b)
+          val participants = (new methodOrganizeImportsParticipants.RemoveUnused(b)).asInstanceOf[Participant] ::
+            RemoveDuplicatedByWildcard.asInstanceOf[Participant] ::
+            RemoveDuplicates :: SortImportSelectors :: SortImports :: Nil
+          val importsOrganizer = scala.Function.chain(participants)
+          val reorganizedStats = organizeGroupedImports(stats)(importsOrganizer)(this)
+          b.copy(stats = reorganizedStats).replaces(b)
         case skipPlainText: PlainText => skipPlainText
         case t => super.transform(t)
       }

--- a/src/main/scala/scala/tools/refactoring/implementations/oimports/DefImportsOrganizer.scala
+++ b/src/main/scala/scala/tools/refactoring/implementations/oimports/DefImportsOrganizer.scala
@@ -5,6 +5,7 @@ import scala.tools.nsc.interactive.Global
 import scala.tools.refactoring.common.Change
 import scala.tools.refactoring.common.TextChange
 import scala.util.Properties
+import scala.annotation.implicitNotFound
 
 class DefImportsOrganizer(val global: Global) {
   import global._
@@ -104,5 +105,20 @@ object Region {
   def apply(imports: List[Global#Import]): Region = {
     assert(imports.nonEmpty)
     Region(imports, imports.head.pos, imports.last.pos)
+  }
+}
+
+object ImportPrinters {
+  @implicitNotFound("ImportPrinter[${I}] not found in scope")
+  trait ImportPrinter[I <: Global#Import] {
+    def print(imp: I): List[Change]
+  }
+
+  object ImportPrinter {
+    def apply[I <: Global#Import : ImportPrinter]: ImportPrinter[I] = implicitly[ImportPrinter[I]]
+  }
+
+  object Printer {
+    def print[I <: Global#Import : ImportPrinter](imp: I) = ImportPrinter[I].print(imp)
   }
 }

--- a/src/main/scala/scala/tools/refactoring/implementations/oimports/DefImportsOrganizer.scala
+++ b/src/main/scala/scala/tools/refactoring/implementations/oimports/DefImportsOrganizer.scala
@@ -1,0 +1,102 @@
+package scala.tools.refactoring
+package implementations.oimports
+
+import scala.tools.nsc.interactive.Global
+import scala.tools.refactoring.common.Change
+import scala.tools.refactoring.common.TextChange
+import scala.util.Properties
+
+class DefImportsOrganizer(val global: Global) {
+  import global._
+
+  private def noAnyTwoImportsInSameLine(importsGroup: List[Global#Import]): Boolean =
+    importsGroup.size == importsGroup.map { _.pos.line }.distinct.size
+
+  private def importsGroupsFromTree(tree: Global#Tree): List[List[Global#Import]] = {
+    val impTraverser = new Traverser {
+      var groupedImports = List.empty[List[Import]]
+      var group = List.empty[Import]
+      override def traverse(tree: Tree) = tree match {
+        case imp: Import =>
+          group = group :+ imp
+        case t =>
+          if (group.nonEmpty) {
+            groupedImports = groupedImports :+ group
+            group = List.empty[Import]
+          }
+          super.traverse(t)
+      }
+    }
+    impTraverser.traverse(tree.asInstanceOf[Tree])
+    impTraverser.groupedImports
+  }
+
+  import scala.collection._
+  /** Try to fetch `CollectTreeTraverser` */
+  private class TreeCollector[T <: Global#Tree](traverserBody: mutable.ListBuffer[T] => PartialFunction[Tree, Unit]) extends Traverser {
+    val collected = mutable.ListBuffer.empty[T]
+    override def traverse(tree: Tree): Unit = traverserBody(collected).orElse[Tree, Unit] {
+      case t => super.traverse(t)
+    }(tree)
+  }
+
+  private def forTreesOfKind[T <: Global#Tree](tree: Global#Tree)(traverserBody: mutable.ListBuffer[T] => PartialFunction[Tree, Unit]): List[T] = {
+    val treeTraverser = new TreeCollector[T](traverserBody)
+    treeTraverser.traverse(tree.asInstanceOf[Tree])
+    treeTraverser.collected.toList
+  }
+
+  private def forTreesOfBlocks(tree: Global#Tree) = forTreesOfKind[Global#Block](tree) { collected => {
+      case b: Block =>
+        collected += b
+    }
+  }
+
+  private def toRegions(groupedImports: List[List[Global#Import]]): List[Region] =
+    groupedImports.map {
+      case imports @ h :: _ => Some(Region(imports))
+      case _ => None
+    }.filter {
+      _.nonEmpty
+    }.map { _.get }
+
+  def transformTreeToRegions(tree: Global#Tree): List[Region] = toRegions(forTreesOfBlocks(tree).flatMap { block =>
+    importsGroupsFromTree(block).filter {
+      noAnyTwoImportsInSameLine
+    }
+  })
+}
+
+case class Region private (val imports: List[Global#Import], val startPos: Global#Position, val endPos: Global#Position) {
+  def transform(transformation: List[Global#Import] => List[Global#Import]): Region =
+    copy(imports = transformation(imports))
+
+  def print: Change = {
+    val sourceFile = imports.head.pos.source
+    val from = startPos.pos.start
+    val to = endPos.pos.end
+    val text = imports.zipWithIndex.foldLeft("") { (acc, imp) =>
+      def indentation(imp: Global#Import): String =
+        sourceFile.lineToString(sourceFile.offsetToLine(imp.pos.start)).takeWhile { _.isWhitespace }
+      def isLast(idx: Int) = idx == imports.size - 1
+      imp match {
+        case (imp, 0) if isLast(0) =>
+          acc + sourceFile.content.slice(imp.pos.start, imp.pos.end).mkString
+        case (imp, 0) =>
+          acc + sourceFile.content.slice(imp.pos.start, imp.pos.end).mkString + Properties.lineSeparator
+        case (imp, idx) if isLast(idx) =>
+          acc + indentation(imp) + sourceFile.content.slice(imp.pos.start, imp.pos.end).mkString
+        case (imp, _) =>
+          acc + indentation(imp) + sourceFile.content.slice(imp.pos.start, imp.pos.end).mkString + Properties.lineSeparator
+      }
+    }
+    TextChange(sourceFile, from, to, text)
+  }
+}
+
+object Region {
+  def apply(imports: List[Global#Import]): Region = {
+    assert(imports.nonEmpty)
+    Region(imports, imports.head.pos, imports.last.pos)
+  }
+}

--- a/src/main/scala/scala/tools/refactoring/implementations/oimports/NotPackageImportParticipants.scala
+++ b/src/main/scala/scala/tools/refactoring/implementations/oimports/NotPackageImportParticipants.scala
@@ -53,11 +53,11 @@ class NotPackageImportParticipants(val global: Global, val organizeImportsInstan
           }
         }
         val result = usedSelectors match {
-          case Nil => Import(EmptyTree, Nil)
-          case _ => imp.copy(selectors = usedSelectors)
+          case Nil => null
+          case s => imp.copy(selectors = usedSelectors).setPos(imp.pos)
         }
         result.asInstanceOf[organizeImportsInstance.global.Import]
-    }
+    } filter { _ ne null }
   }
 
   object RemoveDuplicatedByWildcard extends organizeImportsInstance.Participant {

--- a/src/main/scala/scala/tools/refactoring/implementations/oimports/NotPackageImportParticipants.scala
+++ b/src/main/scala/scala/tools/refactoring/implementations/oimports/NotPackageImportParticipants.scala
@@ -64,8 +64,7 @@ class NotPackageImportParticipants(val global: Global, val organizeImportsInstan
     protected def doApply(trees: List[organizeImportsInstance.global.Import]) = trees.asInstanceOf[List[Import]].map { imp =>
       val wild = imp.selectors.find(_.name == nme.WILDCARD)
       if (wild.nonEmpty) {
-        val newImp = imp.copy(selectors = wild.toList)
-        newImp.pos = imp.pos
+        val newImp = imp.copy(selectors = wild.toList).setPos(imp.pos)
         newImp.symbol = imp.symbol
         newImp
       } else

--- a/src/main/scala/scala/tools/refactoring/implementations/oimports/NotPackageImportParticipants.scala
+++ b/src/main/scala/scala/tools/refactoring/implementations/oimports/NotPackageImportParticipants.scala
@@ -1,7 +1,9 @@
 package scala.tools.refactoring
-package implementations
+package implementations.oimports
 
 import scala.tools.nsc.interactive.Global
+import scala.collection.mutable
+import scala.tools.refactoring.implementations.OrganizeImports
 
 class NotPackageImportParticipants(val global: Global, val organizeImportsInstance: OrganizeImports) {
   import global._
@@ -61,9 +63,12 @@ class NotPackageImportParticipants(val global: Global, val organizeImportsInstan
   object RemoveDuplicatedByWildcard extends organizeImportsInstance.Participant {
     protected def doApply(trees: List[organizeImportsInstance.global.Import]) = trees.asInstanceOf[List[Import]].map { imp =>
       val wild = imp.selectors.find(_.name == nme.WILDCARD)
-      if (wild.nonEmpty)
-        imp.copy(selectors = wild.toList)
-      else
+      if (wild.nonEmpty) {
+        val newImp = imp.copy(selectors = wild.toList)
+        newImp.pos = imp.pos
+        newImp.symbol = imp.symbol
+        newImp
+      } else
         imp
     }.groupBy {
       _.expr.toString

--- a/src/main/scala/scala/tools/refactoring/sourcegen/SourceUtils.scala
+++ b/src/main/scala/scala/tools/refactoring/sourcegen/SourceUtils.scala
@@ -124,7 +124,7 @@ trait SourceUtils {
 
     (rest zip comments) map {
       case (' ', _1) => ""+ _1
-      case (`c`, _ ) => ""
+      case (`c`, _) => ""
       case (_1, ' ') => ""+ _1
       case ('\n', '\n') => "\n"
       case _ => assert(false)

--- a/src/main/scala/scala/tools/refactoring/sourcegen/TreeChangesDiscoverer.scala
+++ b/src/main/scala/scala/tools/refactoring/sourcegen/TreeChangesDiscoverer.scala
@@ -156,9 +156,18 @@ trait TreeChangesDiscoverer {
           List((changed, orig.pos, Set(changed) ++ searchChildrenForChanges(changed)))
         }
 
+        def drillDownChildrenAndCollectChangesWithPosition(parent: Tree): List[(Tree, Position, Set[Tree])] = {
+          val allPotentials = children(parent).flatMap {
+            findAllChangedTrees
+          }
+          allPotentials.filterNot {
+            case (_, position, _) => position == NoPosition
+          }
+        }
+
         (t, onlyDifferentChildren) match {
           case (t: Block   , (orig, changed) :: Nil) if changed.pos == NoPosition =>
-            replaceSingleDef(orig, changed)
+            replaceSingleDef(orig, changed) ++ drillDownChildrenAndCollectChangesWithPosition(t)
           case (t: Template, (orig, changed) :: Nil) if changed.pos == NoPosition && t.body.contains(changed) =>
             // Only use the efficient replace when the changed tree is in the template body,
             // if it's e.g. a parent type, then we still need to print the whole template

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
@@ -2019,6 +2019,8 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
 
     """
     /*<-*/
+    package test
+
     class A {
       def foo = {
         import org.Acne
@@ -2179,6 +2181,7 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
           object inner {
             val I = 5
           }
+
           import inner.I
 
           A + H + I
@@ -2264,6 +2267,7 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
           object inner {
             val I = 5
           }
+
           import inner.I
 
           A + H + I + (new AcneHelper(5)).AH

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
@@ -10,6 +10,7 @@ import language.reflectiveCalls
 import language.postfixOps
 import scala.collection.mutable.ListBuffer
 import scala.tools.refactoring.implementations.OrganizeImports.Dependencies
+import org.junit.Ignore
 
 class OrganizeImportsTest extends OrganizeImportsBaseTest {
   private def organize(pro: FileSet) = new OrganizeImportsRefatoring(pro) {
@@ -1256,9 +1257,9 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
 
     class Bar {
       def foo = {
-        import acme.Acme.{A, B}
         import fake.Acme.C
         val c = C
+        import acme.Acme.{A, B}
         A + B + c
       }
     }
@@ -1309,9 +1310,9 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
 
     class Bar {
       def foo = {
-        import acme.Acme.A
         import fake.Acme.D
         val d = D
+        import acme.Acme.A
         def k = {
           import acme.Acme.B
           import fake.Acme.C
@@ -1711,9 +1712,9 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
         import fake.Acme._
         import acme.Acme.{A, D}
         import fake.Acme.D
-        val d = D
         import fake.Acme.{C, B, B}
         import acme.Acme.B
+        val d = D
         A + B + C + d
       }
     }
@@ -1995,4 +1996,398 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
     }
     """
   } applyRefactoring organizeCustomized(dependencies = Dependencies.RecomputeAndModify, useWildcards = Set("a.b"))
+
+  @Test
+  def shouldNotOrganizeImportsForDetachedImportsInDefBlock() = new FileSet {
+    """
+    package acme
+
+    class Acme(val A: Int) {
+      val B = 6
+    }
+
+    object AcmeHelper {
+      val H = 7
+    }
+    """ isNotModified
+
+    """
+    package org
+
+    class Acne(val A: Int)
+    """ isNotModified
+
+    """
+    /*<-*/
+    class A {
+      def foo = {
+        import org.Acne
+        import acme._
+
+        val tested = new Acme((new Acne(4)).A)
+        import tested._
+
+        import acme.AcmeHelper.H
+
+        B + H
+    }
+    """ becomes {
+    """
+    /*<-*/
+    package test
+
+    class A {
+      def foo = {
+        import acme._
+        import org.Acne
+
+        val tested = new Acme((new Acne(4)).A)
+        import acme.AcmeHelper.H
+        import tested._
+
+        B + H
+    }
+    """
+    }
+  } applyRefactoring organizeWithTypicalParams
+
+  @Test
+  def shouldOrganizeImportsForRelativeImport() = new FileSet {
+    """
+    package acme
+
+    class Acme {
+      val B = 6
+    }
+
+    object AcmeHelper {
+      val H = 7
+    }
+    """ isNotModified
+
+    """
+    package acme.abefore
+
+    class Abscess(val A: Int)
+    """ isNotModified
+
+    """
+    /*<-*/
+    package test
+
+    class A {
+      def foo = {
+        import acme._
+        import abefore._
+        import acme.AcmeHelper.H
+
+        val tested = new Acme
+        import tested._
+
+        B + H + (new Abscess(3)).A
+      }
+    }
+    """ becomes {
+    """
+    /*<-*/
+    package test
+
+    class A {
+      def foo = {
+        import acme._
+        import acme.AcmeHelper.H
+        import abefore._
+
+        val tested = new Acme
+        import tested._
+
+        B + H + (new Abscess(3)).A
+      }
+    }
+    """
+    }
+  } applyRefactoring organizeWithTypicalParams
+
+  @Test
+  def shouldNotOrganizeImportsForDetachedImportsInNestedDefBlockWhenImportIsInOuterToo() = new FileSet {
+    """
+    package acme
+
+    class Acme(val A: Int) {
+      val B = 6
+    }
+
+    class AcmeHelper {
+      val H = 7
+    }
+    """ isNotModified
+
+    """
+    package org
+
+    class Acne(val A: Int)
+    """ isNotModified
+
+    """
+    /*<-*/
+    package test
+
+    class A {
+      def foo = {
+        import acme.AcmeHelper
+
+        def bar = {
+          import org.Acne
+          import acme.Acme
+
+          val tested = new Acme((new Acne(4)).A)
+          import tested._
+
+          val help = new AcmeHelper
+          import help._
+
+          object inner {
+            val I = 5
+          }
+
+          import inner.I
+
+          A + H + I
+        }
+        bar
+      }
+    }
+    """ becomes {
+    """
+    /*<-*/
+    package test
+
+    class A {
+      def foo = {
+        import acme.AcmeHelper
+
+        def bar = {
+          import acme.Acme
+          import org.Acne
+
+          val tested = new Acme((new Acne(4)).A)
+          import tested._
+
+          val help = new AcmeHelper
+          import help._
+
+          object inner {
+            val I = 5
+          }
+          import inner.I
+
+          A + H + I
+        }
+        bar
+      }
+    }
+    """
+    }
+  } applyRefactoring organizeWithTypicalParams
+
+  @Test
+  def shouldOrganizeImportsForOuterAndInnerDefBlocks() = new FileSet {
+    """
+    package acme
+
+    class Acme(val A: Int) {
+      val B = 6
+    }
+
+    class AcmeHelper {
+      val H = 7
+    }
+    """ isNotModified
+
+    """
+    package org
+
+    class Acne(val A: Int)
+    class AcneHelper(val AH: Int)
+    """ isNotModified
+
+    """
+    /*<-*/
+    package test
+
+    class A {
+      def foo = {
+        import org.AcneHelper
+        import acme.AcmeHelper
+
+        def bar = {
+          import org.Acne
+          import acme.Acme
+
+          val tested = new Acme((new Acne(4)).A)
+          import tested._
+
+          val help = new AcmeHelper
+          import help._
+
+          object inner {
+            val I = 5
+          }
+
+          import inner.I
+
+          A + H + I + (new AcneHelper(5)).AH
+        }
+        bar
+      }
+    }
+    """ becomes {
+    """
+    /*<-*/
+    package test
+
+    class A {
+      def foo = {
+        import acme.AcmeHelper
+        import org.AcneHelper
+
+        def bar = {
+          import acme.Acme
+          import org.Acne
+
+          val tested = new Acme((new Acne(4)).A)
+          import tested._
+
+          val help = new AcmeHelper
+          import help._
+
+          object inner {
+            val I = 5
+          }
+          import inner.I
+
+          A + H + I + (new AcneHelper(5)).AH
+        }
+        bar
+      }
+    }
+    """
+    }
+  } applyRefactoring organizeWithTypicalParams
+
+  @Test
+  def shouldNotDisplaceDetachedImport() = new FileSet {
+    """
+    package acme
+
+    class Map
+    """ isNotModified
+
+    """
+    /*<-*/
+    package test
+
+    class A {
+      def foo = {
+        val scalaMap = Map[Int, Int]()
+        import acme.Map
+        val acmeMap: Map = new Map
+        acmeMap
+      }
+    }
+    """ isNotModified
+  } applyRefactoring organizeWithTypicalParams
+
+  @Test
+  def shouldNotDisplaceDetachedImportForParameterizedType() = new FileSet {
+    """
+    package acme
+
+    class Map[K, V]
+    """ isNotModified
+
+    """
+    /*<-*/
+    package test
+
+    class A {
+      def foo = {
+        val scalaMap = Map[Int, Int]()
+        import acme.Map
+        val acmeMap: Map[Int, String] = new Map[Int, String]
+        acmeMap
+      }
+    }
+    """ isNotModified
+  } applyRefactoring organizeWithTypicalParams
+
+  @Test
+  def shouldNotDisplaceDetachedShadowingImport() = new FileSet {
+    """
+    /*<-*/
+    package test
+
+    class A {
+      def foo = {
+        val scalaMap = Map[Int, Int]()
+        import java.util.Map
+        import java.util.HashMap
+        val javaMap: Map[Int, Int] = new HashMap[Int, Int]()
+        scalaMap
+      }
+    }
+    """ becomes {
+    """
+    /*<-*/
+    package test
+
+    class A {
+      def foo = {
+        val scalaMap = Map[Int, Int]()
+        import java.util.HashMap
+        import java.util.Map
+        val javaMap: Map[Int, Int] = new HashMap[Int, Int]()
+        scalaMap
+      }
+    }
+    """
+    }
+  } applyRefactoring organizeWithTypicalParams
+
+  @Ignore("under construction")
+  @Test
+  def shouldOrganizeImportsInClassDefBySorting() = new FileSet {
+
+    """
+    /*<-*/
+    package test
+
+    object X {
+      val m = Map[String, String]()
+
+      def f = {
+        import scala.util.Try
+        for ((a, b) ← m)
+          println((a,b))
+        0
+      }
+    }
+    """ becomes {
+    """
+    /*<-*/
+    package test
+
+    object X {
+      val m = Map[String, String]()
+
+      def f = {
+        $
+        for ((a, b) ← m)
+          println((a,b))
+        0
+      }
+    }
+    """.replace("$", "")
+    }
+  } applyRefactoring organizeCustomized(dependencies = Dependencies.RecomputeAndModify)
 }

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
@@ -1954,13 +1954,12 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
       val m = Map[String, String]()
 
       def f = {
-        $
         for ((a, b) ← m)
           println((a,b))
         0
       }
     }
-    """.replace("$", "")
+    """
     }
   } applyRefactoring organizeCustomized(dependencies = Dependencies.RecomputeAndModify)
 
@@ -2359,6 +2358,7 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
   } applyRefactoring organizeWithTypicalParams
 
   @Test
+  @Ignore("implement me")
   def shouldSortImportsInClassBody() = new FileSet {
     """
     package acme

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
@@ -2409,40 +2409,4 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
     """
     }
   } applyRefactoring organizeWithTypicalParams
-
-  @Test
-  def shouldOrganizeImportsInClassDefBySorting() = new FileSet {
-
-    """
-    /*<-*/
-    package test
-
-    object X {
-      val m = Map[String, String]()
-
-      def f = {
-        import scala.util.Try
-        for ((a, b) ← m)
-          println((a,b))
-        0
-      }
-    }
-    """ becomes {
-    """
-    /*<-*/
-    package test
-
-    object X {
-      val m = Map[String, String]()
-
-      def f = {
-        $
-        for ((a, b) ← m)
-          println((a,b))
-        0
-      }
-    }
-    """.replace("$", "")
-    }
-  } applyRefactoring organizeCustomized(dependencies = Dependencies.RecomputeAndModify)
 }

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
@@ -2354,7 +2354,58 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
     }
   } applyRefactoring organizeWithTypicalParams
 
-  @Ignore("under construction")
+  @Test
+  def shouldSortImportsInClassBody() = new FileSet {
+    """
+    package acme
+
+    object Acme {
+      val A = 5
+      val B = 6
+    }
+    """ isNotModified
+
+    """
+    package fake
+
+    object Acme {
+      val D = 11
+    }
+    """ isNotModified
+
+    """
+    /*<-*/
+    package test
+
+    class Bar {
+      import acme.Acme.B
+      import fake.Acme.D
+      import acme.Acme.A
+
+      def foo = {
+        val d = D
+        A + B + d
+      }
+    }
+    """ becomes {
+    """
+    /*<-*/
+    package test
+
+    class Bar {
+    import acme.Acme.A
+      import acme.Acme.B
+      import fake.Acme.D
+
+      def foo = {
+        val d = D
+        A + B + d
+      }
+    }
+    """
+    }
+  } applyRefactoring organizeWithTypicalParams
+
   @Test
   def shouldOrganizeImportsInClassDefBySorting() = new FileSet {
 


### PR DESCRIPTION
REMARK: @sschaef  commit is rather irrelevant.

Attempt (proof of concept) to organize imports with no modification of original tree.
There are 2 files which are the machinery:
1 DefImportsOrganizer.scala
2 NotPackageImportPratitioners.scala
The first one is the heart of engine

An example of usage is in OrganizeImports.scala. Main idea concerns
creation of `TextChanges` and adding them to those produced by
"PackageDef" old fashionable part.