### PR TITLE
Imports space class

### DIFF
--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsFullyRecomputeTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsFullyRecomputeTest.scala
@@ -436,6 +436,7 @@ class OrganizeImportsFullyRecomputeTest extends OrganizeImportsBaseTest {
     """ becomes
     """
     import scala.beans.BeanProperty
+
     case class JavaPerson(@BeanProperty var name: String, @BeanProperty var addresses: java.lang.Object)
     """
   } applyRefactoring organize
@@ -450,6 +451,7 @@ class OrganizeImportsFullyRecomputeTest extends OrganizeImportsBaseTest {
     """ becomes
     """
     import java.util.Observer
+
     trait X {
       self: Observer =>
     }
@@ -469,6 +471,7 @@ class OrganizeImportsFullyRecomputeTest extends OrganizeImportsBaseTest {
     """
     import java.{util => ju}
     import java.util.{ArrayList => AL}
+
     trait Y {
       def build(ignored : ju.Map[_, _]): Unit
         def build2(ignored : AL[Int]): Unit
@@ -628,6 +631,7 @@ class OrganizeImportsFullyRecomputeTest extends OrganizeImportsBaseTest {
     class MyClass[T]""" becomes
     """
     ▒
+
     class MyClass[T]"""
   } applyRefactoring organize
 
@@ -638,6 +642,7 @@ class OrganizeImportsFullyRecomputeTest extends OrganizeImportsBaseTest {
     class MyClass(i: Int)""" becomes
     """
     ▒
+
     class MyClass(i: Int)"""
   } applyRefactoring organize
 

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsRecomputeAndModifyTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsRecomputeAndModifyTest.scala
@@ -172,6 +172,7 @@ class OrganizeImportsRecomputeAndModifyTest extends OrganizeImportsBaseTest {
     """ becomes
     """
     import java.util.Observer
+
     trait X {
       self: Observer =>
     }
@@ -191,6 +192,7 @@ class OrganizeImportsRecomputeAndModifyTest extends OrganizeImportsBaseTest {
     """
     import java.{util => ju}
     import java.util.{ArrayList => AL}
+
     trait Y {
       def build(ignored : ju.Map[_, _]): Unit
         def build2(ignored : AL[Int]): Unit

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
@@ -515,14 +515,10 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
   def finalBraceShouldNotBeRemoved() = new FileSet {
     """
       import java.io.Serializable
+
       object A extends Serializable {
 
-      }""" becomes
-      """
-      import java.io.Serializable
-      object A extends Serializable {
-
-      }"""
+      }""" isNotModified
   } applyRefactoring organize
 
   /*
@@ -1995,4 +1991,182 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
     }
     """
   } applyRefactoring organizeCustomized(dependencies = Dependencies.RecomputeAndModify, useWildcards = Set("a.b"))
+
+  @Test
+  def shouldInsertEmptyLineBetweenImportsAndTopClassDef() = new FileSet {
+    """
+    /*<-*/
+    package x
+
+    import scala.collection.mutable.Buffer
+    import scala.collection.mutable.ListBuffer
+    class X {
+      val b = Buffer()
+      val lb = ListBuffer()
+    }
+    """ becomes {
+    """
+    /*<-*/
+    package x
+
+    import scala.collection.mutable.Buffer
+    import scala.collection.mutable.ListBuffer
+
+    class X {
+      val b = Buffer()
+      val lb = ListBuffer()
+    }
+    """
+    }
+  } applyRefactoring organizeWithTypicalParams
+
+  @Test
+  def shouldInsertEmptyLineBetweenImportsAndTopModuleDef() = new FileSet {
+    """
+    /*<-*/
+    package x
+
+    import scala.collection.mutable.Buffer
+    import scala.collection.mutable.ListBuffer
+    object X extends App {
+      Buffer
+      ListBuffer
+    }
+    """ becomes {
+    """
+    /*<-*/
+    package x
+
+    import scala.collection.mutable.Buffer
+    import scala.collection.mutable.ListBuffer
+
+    object X extends App {
+      Buffer
+      ListBuffer
+    }
+    """
+    }
+  } applyRefactoring organizeWithTypicalParams
+
+  @Test
+  def shouldKeepExistingEmptyLineBetweenImportsAndTopClassDef() = new FileSet {
+    """
+    /*<-*/
+    package x
+
+    import scala.collection.mutable.Buffer
+    import scala.collection.mutable.ListBuffer
+
+    class X {
+      val b = Buffer()
+      val lb = ListBuffer()
+    }
+    """ isNotModified
+  } applyRefactoring organizeWithTypicalParams
+
+  @Test
+  def shouldKeepExistingEmptyLineBetweenImportsAndTopModuleDef() = new FileSet {
+    """
+    /*<-*/
+    package x
+
+    import scala.collection.mutable.Buffer
+    import scala.collection.mutable.ListBuffer
+
+    object X extends App {
+      Buffer
+      ListBuffer
+    }
+    """ isNotModified
+  } applyRefactoring organizeWithTypicalParams
+
+  @Test
+  def shouldReduceExistingEmptyLinesBetweenImportsAndTopClassDefToOne() = new FileSet {
+    """
+    /*<-*/
+    package x
+
+    import scala.collection.mutable.Buffer
+    import scala.collection.mutable.ListBuffer
+
+
+    class X {
+      val b = Buffer()
+      val lb = ListBuffer()
+    }
+    """ becomes {
+    """
+    /*<-*/
+    package x
+
+    import scala.collection.mutable.Buffer
+    import scala.collection.mutable.ListBuffer
+
+    class X {
+      val b = Buffer()
+      val lb = ListBuffer()
+    }
+    """
+    }
+  } applyRefactoring organizeWithTypicalParams
+
+  @Test
+  def shouldReduceExistingEmptyLinesBetweenImportsAndTopModuleDefToOne() = new FileSet {
+    """
+    /*<-*/
+    package x
+
+    import scala.collection.mutable.Buffer
+    import scala.collection.mutable.ListBuffer
+
+
+    object X extends App {
+      Buffer
+      ListBuffer
+    }
+    """ becomes {
+    """
+    /*<-*/
+    package x
+
+    import scala.collection.mutable.Buffer
+    import scala.collection.mutable.ListBuffer
+
+    object X extends App {
+      Buffer
+      ListBuffer
+    }
+    """
+    }
+  } applyRefactoring organizeWithTypicalParams
+
+  @Test
+  def shouldReduceExistingEmptyLinesWithWhitespacesBetweenImportsAndTopModuleDefToOne() = new FileSet {
+    """
+    /*<-*/
+    package x
+
+    import scala.collection.mutable.Buffer
+    import scala.collection.mutable.ListBuffer
+  
+  
+    object X extends App {
+      Buffer
+      ListBuffer
+    }
+    """ becomes {
+    """
+    /*<-*/
+    package x
+
+    import scala.collection.mutable.Buffer
+    import scala.collection.mutable.ListBuffer
+  
+    object X extends App {
+      Buffer
+      ListBuffer
+    }
+    """
+    }
+  } applyRefactoring organizeWithTypicalParams
 }

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
@@ -82,7 +82,7 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
       import scala.io.Source
       import scala.math._
       import scala.math.BigInt
-      """ + restOfFile
+""" + restOfFile
     } applyRefactoring organizeWithoutCollapsing
 
     new FileSet(expectCompilingCode = false) {
@@ -95,7 +95,7 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
       import scala.io.Source
       import scala.math._
       import scala.math.BigInt
-      """ + restOfFile
+""" + restOfFile
     } applyRefactoring organizeExpand
 
     new FileSet(expectCompilingCode = false) {
@@ -106,7 +106,7 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
       import scala.collection.mutable.{HashMap, ListBuffer}
       import scala.io.Source
       import scala.math._
-      """ + restOfFile
+""" + restOfFile
     } applyRefactoring organize
   }
 
@@ -2148,8 +2148,7 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
 
     import scala.collection.mutable.Buffer
     import scala.collection.mutable.ListBuffer
-  $
-  $
+  
     object X extends App {
       Buffer
       ListBuffer
@@ -2161,7 +2160,7 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
 
     import scala.collection.mutable.Buffer
     import scala.collection.mutable.ListBuffer
-  $
+
     object X extends App {
       Buffer
       ListBuffer
@@ -2169,4 +2168,63 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
     """
     }
   } applyRefactoring organizeWithTypicalParams
+
+  @Test
+  def shouldKeepCommentBetweenImportsAndTopModuleDefAndAddsSingleSpacer() = new FileSet {
+    """
+    /*<-*/
+    package x
+
+    import scala.collection.mutable.Buffer
+    import scala.collection.mutable.ListBuffer
+
+
+    /** Comment */
+    // Line 2
+
+    /**
+     *
+     */
+    object X extends App {
+      Buffer
+      ListBuffer
+    }
+    """ becomes {
+    """
+    /*<-*/
+    package x
+
+    import scala.collection.mutable.Buffer
+    import scala.collection.mutable.ListBuffer
+
+    /** Comment */
+    // Line 2
+    /**
+     *
+     */
+    object X extends App {
+      Buffer
+      ListBuffer
+    }
+    """
+    }
+    } applyRefactoring organizeWithTypicalParams
+
+  @Test
+  def shouldKeepCommentBetweenImportsAndTopClassDef() = new FileSet {
+    """
+    /*<-*/
+    package x
+
+    import scala.collection.mutable.Buffer
+    import scala.collection.mutable.ListBuffer
+
+    // Comment
+    /** Line 2 */
+    class X extends App {
+      Buffer
+      ListBuffer
+    }
+    """ isNotModified
+    } applyRefactoring organizeWithTypicalParams
 }

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
@@ -2148,8 +2148,8 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
 
     import scala.collection.mutable.Buffer
     import scala.collection.mutable.ListBuffer
-  
-  
+  $
+  $
     object X extends App {
       Buffer
       ListBuffer
@@ -2161,7 +2161,7 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
 
     import scala.collection.mutable.Buffer
     import scala.collection.mutable.ListBuffer
-  
+  $
     object X extends App {
       Buffer
       ListBuffer


### PR DESCRIPTION
In case of
```scala
package x
import scala.collection.mutable.Buffer
import scala.collection.mutable.ListBuffer
object X extends App {
  Buffer
  ListBuffer
}
```
formats to
```scala
package x
import scala.collection.mutable.Buffer
import scala.collection.mutable.ListBuffer

object X extends App {
  Buffer
  ListBuffer
}
```
for classes same.
Also for
```scala
package x
import scala.collection.mutable.Buffer
import scala.collection.mutable.ListBuffer


object X extends App {
  Buffer
  ListBuffer
}
```
formats to
```scala
package x
import scala.collection.mutable.Buffer
import scala.collection.mutable.ListBuffer

object X extends App {
  Buffer
  ListBuffer
}
```
Does not work for annotated classes/objects! (problem with finding the beginning of class/object definition)

Fix #1002657