### PR TITLE
Update Scala version to 2.11.8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,13 +2,13 @@ name := "org.scala-refactoring.library"
 
 version := "0.10.0-SNAPSHOT"
 
-scalaVersion := "2.11.7"
+scalaVersion := "2.11.8"
 
 moduleName := name.value
 
 organization := "org.scala-refactoring"
 
-crossScalaVersions := Seq("2.10.6", "2.11.7")
+crossScalaVersions := Seq("2.10.6", "2.11.7", "2.11.8")
 
 crossVersion <<= isSnapshot { isSnapshot =>
   if (isSnapshot)

--- a/src/main/scala/scala/tools/refactoring/Refactoring.scala
+++ b/src/main/scala/scala/tools/refactoring/Refactoring.scala
@@ -7,7 +7,6 @@ package scala.tools.refactoring
 import scala.tools.nsc.io.AbstractFile
 import scala.tools.refactoring.common.Selections
 import scala.tools.refactoring.common.EnrichedTrees
-import scala.tools.refactoring.common.Change
 import scala.tools.refactoring.sourcegen.SourceGenerator
 import scala.tools.refactoring.transformation.TreeTransformations
 import scala.tools.refactoring.common.TextChange

--- a/src/main/scala/scala/tools/refactoring/common/EnrichedTrees.scala
+++ b/src/main/scala/scala/tools/refactoring/common/EnrichedTrees.scala
@@ -8,7 +8,6 @@ package common
 import tools.nsc.symtab.Flags
 import tools.nsc.ast.parser.Tokens
 import tools.nsc.symtab.Flags
-import scala.tools.nsc.Global
 import util.Memoized
 import scala.collection.mutable.ListBuffer
 import scala.tools.refactoring.sourcegen.Fragment

--- a/src/main/scala/scala/tools/refactoring/common/Selections.scala
+++ b/src/main/scala/scala/tools/refactoring/common/Selections.scala
@@ -6,9 +6,7 @@ package scala.tools.refactoring
 package common
 
 import collection.mutable.ListBuffer
-import tools.nsc.Global
 import scala.reflect.internal.util.RangePosition
-import scala.reflect.internal.Flags
 
 trait Selections extends TreeTraverser with common.EnrichedTrees {
 

--- a/src/main/scala/scala/tools/refactoring/common/TreeTraverser.scala
+++ b/src/main/scala/scala/tools/refactoring/common/TreeTraverser.scala
@@ -5,9 +5,6 @@
 package scala.tools.refactoring
 package common
 
-import tools.nsc.io.AbstractFile
-import collection.mutable.ListBuffer
-import tools.nsc.Global
 
 trait TreeTraverser {
 

--- a/src/main/scala/scala/tools/refactoring/common/tracing.scala
+++ b/src/main/scala/scala/tools/refactoring/common/tracing.scala
@@ -5,7 +5,6 @@
 package scala.tools.refactoring
 package common
 
-import java.io.IOException
 import java.io.File
 import java.io.FileOutputStream
 import java.io.PrintStream

--- a/src/main/scala/scala/tools/refactoring/implementations/ChangeParamOrder.scala
+++ b/src/main/scala/scala/tools/refactoring/implementations/ChangeParamOrder.scala
@@ -1,7 +1,6 @@
 package scala.tools.refactoring
 package implementations
 
-import scala.tools.refactoring.common.Change
 
 /**
  * Refactoring that changes the order of the parameters of a method.

--- a/src/main/scala/scala/tools/refactoring/implementations/EliminateMatch.scala
+++ b/src/main/scala/scala/tools/refactoring/implementations/EliminateMatch.scala
@@ -6,7 +6,6 @@ package scala.tools.refactoring
 package implementations
 
 import common.Change
-import tools.nsc.symtab.Flags
 import transformation.TreeFactory
 
 abstract class EliminateMatch extends MultiStageRefactoring with ParameterlessRefactoring with common.TreeExtractors with TreeFactory {

--- a/src/main/scala/scala/tools/refactoring/implementations/ExpandCaseClassBinding.scala
+++ b/src/main/scala/scala/tools/refactoring/implementations/ExpandCaseClassBinding.scala
@@ -6,7 +6,6 @@ package scala.tools.refactoring
 package implementations
 
 import common.Change
-import tools.nsc.symtab.Flags
 import scala.tools.refactoring.analysis.GlobalIndexes
 
 abstract class ExpandCaseClassBinding extends MultiStageRefactoring with ParameterlessRefactoring with GlobalIndexes {

--- a/src/main/scala/scala/tools/refactoring/implementations/IntroduceProductNTrait.scala
+++ b/src/main/scala/scala/tools/refactoring/implementations/IntroduceProductNTrait.scala
@@ -1,7 +1,6 @@
 package scala.tools.refactoring
 package implementations
 
-import common.Change
 
 /**
  * Refactoring that implements the ProductN trait for a class.

--- a/src/main/scala/scala/tools/refactoring/implementations/OrganizeImports.scala
+++ b/src/main/scala/scala/tools/refactoring/implementations/OrganizeImports.scala
@@ -8,10 +8,7 @@ package implementations
 import common.TreeTraverser
 import common.Change
 import transformation.TreeFactory
-import scala.collection.mutable.ListBuffer
-import scala.collection.mutable.LinkedHashMap
 import scala.util.control.NonFatal
-import scala.collection.immutable.Queue
 
 object OrganizeImports {
   /**

--- a/src/main/scala/scala/tools/refactoring/implementations/Rename.scala
+++ b/src/main/scala/scala/tools/refactoring/implementations/Rename.scala
@@ -7,14 +7,11 @@ package implementations
 
 import transformation.TreeFactory
 import analysis.TreeAnalysis
-import tools.nsc.symtab.Flags
 import scala.tools.refactoring.common.RenameSourceFileChange
 import scala.tools.refactoring.common.PositionDebugging
 import scala.reflect.internal.util.RangePosition
 import scala.tools.refactoring.util.SourceWithMarker
 import scala.tools.refactoring.util.SourceWithMarker.Movements
-import scala.tools.refactoring.util.SourceWithMarker.MovementHelpers
-import scala.tools.refactoring.util.SourceWithMarker.Movement
 import scala.tools.refactoring.common.TextChange
 import scala.tools.refactoring.common.RenameSourceFileChange
 import scala.tools.refactoring.common.Change

--- a/src/main/scala/scala/tools/refactoring/sourcegen/ReusingPrinter.scala
+++ b/src/main/scala/scala/tools/refactoring/sourcegen/ReusingPrinter.scala
@@ -13,7 +13,6 @@ import scala.tools.refactoring.util.SourceWithMarker.Movement
 import scala.tools.refactoring.util.SourceWithMarker.Movements
 import scala.tools.refactoring.util.SourceWithMarker.Movements.charToMovement
 import scala.tools.refactoring.util.SourceWithMarker.Movements.commentsAndSpaces
-import scala.tools.refactoring.util.SourceWithMarker.Movements.space
 
 trait ReusingPrinter extends TreePrintingTraversals with AbstractPrinter with ScalaVersionAdapters.CompilerApiAdapters {
 

--- a/src/main/scala/scala/tools/refactoring/sourcegen/SourceGenerator.scala
+++ b/src/main/scala/scala/tools/refactoring/sourcegen/SourceGenerator.scala
@@ -6,7 +6,6 @@ package scala.tools.refactoring
 package sourcegen
 
 import common.Tracing
-import common.Change
 import common.EnrichedTrees
 import scala.tools.refactoring.common.TextChange
 import scala.reflect.internal.util.SourceFile

--- a/src/main/scala/scala/tools/refactoring/transformation/TransformableSelections.scala
+++ b/src/main/scala/scala/tools/refactoring/transformation/TransformableSelections.scala
@@ -1,6 +1,5 @@
 package scala.tools.refactoring.transformation
 
-import scala.reflect.internal.util.RangePosition
 import scala.tools.refactoring.common.Selections
 import scala.tools.refactoring.common.CompilerAccess
 

--- a/src/main/scala/scala/tools/refactoring/util/CompilerProvider.scala
+++ b/src/main/scala/scala/tools/refactoring/util/CompilerProvider.scala
@@ -15,7 +15,6 @@ import scala.reflect.internal.util.BatchSourceFile
 import scala.reflect.internal.util.SourceFile
 import scala.reflect.internal.util.Position
 import scala.reflect.internal.MissingRequirementError
-import scala.tools.nsc.interactive.Problem
 
 class CompilerInstance {
 

--- a/src/main/scala/scala/tools/refactoring/util/SourceWithMarker.scala
+++ b/src/main/scala/scala/tools/refactoring/util/SourceWithMarker.scala
@@ -1,11 +1,8 @@
 package scala.tools.refactoring.util
 
 import scala.annotation.tailrec
-import java.util.Arrays
-import scala.collection.immutable.SortedMap
 import scala.language.implicitConversions
 import scala.reflect.internal.util.RangePosition
-import scala.collection.SeqView
 
 /**
  * Represents source code with a movable marker.

--- a/src/test/scala/scala/tools/refactoring/tests/analysis/MultipleFilesIndexTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/analysis/MultipleFilesIndexTest.scala
@@ -8,7 +8,7 @@ package tests.analysis
 import analysis.GlobalIndexes
 import tests.util._
 
-import language.{ postfixOps, reflectiveCalls }
+import language.postfixOps
 
 class MultipleFilesIndexTest extends TestHelper with GlobalIndexes with FreshCompilerForeachTest {
 

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/ChangeParamOrderTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/ChangeParamOrderTest.scala
@@ -5,7 +5,6 @@ import implementations.ChangeParamOrder
 import tests.util.TestHelper
 import tests.util.TestRefactoring
 
-import language.reflectiveCalls
 
 class ChangeParamOrderTest extends TestHelper with TestRefactoring {
 

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/EliminateMatchTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/EliminateMatchTest.scala
@@ -10,7 +10,6 @@ import tests.util.TestHelper
 import tests.util.TestRefactoring
 import scala.tools.refactoring.implementations.EliminateMatch
 
-import language.reflectiveCalls
 
 class EliminateMatchTest extends TestHelper with TestRefactoring {
   outer =>

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/ExpandCaseClassBindingTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/ExpandCaseClassBindingTest.scala
@@ -9,7 +9,6 @@ import tests.util.TestRefactoring
 import tests.util.TestHelper
 import scala.tools.refactoring.implementations.ExpandCaseClassBinding
 
-import language.reflectiveCalls
 
 class ExpandCaseClassBindingTest extends TestHelper with TestRefactoring {
 

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/ExplicitGettersSettersTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/ExplicitGettersSettersTest.scala
@@ -9,7 +9,6 @@ import implementations.ExplicitGettersSetters
 import tests.util.TestHelper
 import tests.util.TestRefactoring
 
-import language.reflectiveCalls
 
 class ExplicitGettersSettersTest extends TestHelper with TestRefactoring {
   outer =>

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/ExtractLocalTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/ExtractLocalTest.scala
@@ -9,7 +9,6 @@ import implementations.ExtractLocal
 import tests.util.TestRefactoring
 import tests.util.TestHelper
 
-import language.reflectiveCalls
 
 class ExtractLocalTest extends TestHelper with TestRefactoring {
   outer =>

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/ExtractMethodTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/ExtractMethodTest.scala
@@ -9,7 +9,6 @@ import tests.util.TestRefactoring
 import implementations.ExtractMethod
 import tests.util.TestHelper
 
-import language.reflectiveCalls
 
 class ExtractMethodTest extends TestHelper with TestRefactoring {
 

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/ExtractTraitTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/ExtractTraitTest.scala
@@ -1,12 +1,8 @@
 package scala.tools.refactoring.tests
 package implementations
 
-import util.TestHelper
 import util.TestRefactoring
 import scala.tools.refactoring.implementations.ExtractTrait
-import org.junit.Assert
-import org.junit.Ignore
-import language.reflectiveCalls
 import scala.tools.refactoring.util.CompilerInstance
 import org.junit.After
 

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/GenerateHashcodeAndEqualsTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/GenerateHashcodeAndEqualsTest.scala
@@ -4,11 +4,9 @@ package tests.implementations
 import implementations.GenerateHashcodeAndEquals
 import tests.util.TestHelper
 import tests.util.TestRefactoring
-import org.junit.Ignore
 import org.junit.After
 import scala.tools.refactoring.util.CompilerInstance
 
-import language.reflectiveCalls
 
 class GenerateHashcodeAndEqualsTest extends TestHelper with TestRefactoring {
 

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/InlineLocalTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/InlineLocalTest.scala
@@ -9,7 +9,6 @@ import implementations.InlineLocal
 import tests.util.TestRefactoring
 import tests.util.TestHelper
 
-import language.reflectiveCalls
 
 class InlineLocalTest extends TestHelper with TestRefactoring {
   outer =>

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/IntroduceProductNTraitTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/IntroduceProductNTraitTest.scala
@@ -5,7 +5,6 @@ import implementations.IntroduceProductNTrait
 import tests.util.TestHelper
 import tests.util.TestRefactoring
 import scala.tools.refactoring.implementations.IntroduceProductNTrait
-import language.reflectiveCalls
 import org.junit.After
 import scala.tools.refactoring.util.CompilerInstance
 

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/MarkOccurrencesTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/MarkOccurrencesTest.scala
@@ -8,7 +8,6 @@ package tests.implementations
 import implementations.MarkOccurrences
 import tests.util.TestHelper
 import org.junit.Assert._
-import org.junit.Ignore
 
 class MarkOccurrencesTest extends TestHelper {
   outer =>

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/MergeParameterListsTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/MergeParameterListsTest.scala
@@ -4,9 +4,7 @@ package tests.implementations
 import implementations.MergeParameterLists
 import tests.util.TestHelper
 import tests.util.TestRefactoring
-import org.junit.Assert
 
-import language.reflectiveCalls
 
 class MergeParameterListsTest extends TestHelper with TestRefactoring {
 

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/MoveClassTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/MoveClassTest.scala
@@ -1,13 +1,11 @@
 package scala.tools.refactoring
 package tests.implementations
 
-import org.junit.Test
 
 import implementations.MoveClass
 import tests.util.TestRefactoring
 import tests.util.TestHelper
 
-import language.reflectiveCalls
 
 class MoveClassTest extends TestHelper with TestRefactoring {
 

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/MoveConstructorToCompanionObjectTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/MoveConstructorToCompanionObjectTest.scala
@@ -5,7 +5,6 @@ import implementations.MoveConstructorToCompanionObject
 import tests.util.TestHelper
 import tests.util.TestRefactoring
 
-import language.reflectiveCalls
 
 class MoveConstructorToCompanionObjectTest extends TestHelper with TestRefactoring {
 

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
@@ -5,8 +5,6 @@
 package scala.tools.refactoring
 package tests.implementations
 
-import scala.language.existentials
-import scala.language.reflectiveCalls
 import scala.tools.refactoring.common.Change
 import scala.tools.refactoring.common.TracingImpl
 

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/SplitParameterListsTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/SplitParameterListsTest.scala
@@ -4,10 +4,7 @@ package tests.implementations
 import implementations.SplitParameterLists
 import tests.util.TestHelper
 import tests.util.TestRefactoring
-import org.junit.Ignore
-import org.junit.Assert
 
-import language.reflectiveCalls
 
 class SplitParameterListsTest extends TestHelper with TestRefactoring {
 

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/AddImportStatementTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/AddImportStatementTest.scala
@@ -9,7 +9,6 @@ import implementations.AddImportStatement
 import tests.util.TestHelper
 import common.Change
 import org.junit.Assert._
-import scala.tools.refactoring.common.TextChange
 import language.reflectiveCalls
 import scala.tools.refactoring.util.UniqueNames
 

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsCollapseSelectorsToWildcardTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsCollapseSelectorsToWildcardTest.scala
@@ -1,6 +1,5 @@
 package scala.tools.refactoring.tests.implementations.imports
 
-import language.reflectiveCalls
 
 class OrganizeImportsCollapseSelectorsToWildcardTest extends OrganizeImportsBaseTest {
 

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsFullyRecomputeTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsFullyRecomputeTest.scala
@@ -5,9 +5,7 @@
 package scala.tools.refactoring
 package tests.implementations.imports
 
-import tests.util.TestHelper
 
-import language.reflectiveCalls
 
 class OrganizeImportsFullyRecomputeTest extends OrganizeImportsBaseTest {
 

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsGroupsTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsGroupsTest.scala
@@ -5,9 +5,7 @@
 package scala.tools.refactoring
 package tests.implementations.imports
 
-import org.junit.Test
 
-import language.reflectiveCalls
 
 class OrganizeImportsGroupsTest extends OrganizeImportsBaseTest {
 

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsRecomputeAndModifyTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsRecomputeAndModifyTest.scala
@@ -5,9 +5,7 @@
 package scala.tools.refactoring
 package tests.implementations.imports
 
-import tests.util.TestHelper
 
-import language.reflectiveCalls
 
 class OrganizeImportsRecomputeAndModifyTest extends OrganizeImportsBaseTest {
 

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
@@ -5,10 +5,7 @@
 package scala.tools.refactoring
 package tests.implementations.imports
 
-import tests.util.TestHelper
-import language.reflectiveCalls
 import language.postfixOps
-import scala.collection.mutable.ListBuffer
 import scala.tools.refactoring.implementations.OrganizeImports.Dependencies
 
 class OrganizeImportsTest extends OrganizeImportsBaseTest {

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsWildcardsTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsWildcardsTest.scala
@@ -5,9 +5,7 @@
 package scala.tools.refactoring
 package tests.implementations.imports
 
-import org.junit.Test
 
-import language.reflectiveCalls
 
 class OrganizeImportsWildcardsTest extends OrganizeImportsBaseTest {
 

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeMissingImportsTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeMissingImportsTest.scala
@@ -9,7 +9,6 @@ import implementations.OrganizeImports
 import tests.util.TestRefactoring
 import tests.util.TestHelper
 
-import language.reflectiveCalls
 
 class OrganizeMissingImportsTest extends TestHelper with TestRefactoring {
   outer =>

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/PrependOrDropScalaPackageFromRecomputedTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/PrependOrDropScalaPackageFromRecomputedTest.scala
@@ -5,9 +5,7 @@
 package scala.tools.refactoring
 package tests.implementations.imports
 
-import tests.util.TestHelper
 
-import language.reflectiveCalls
 
 class PrependOrDropScalaPackageFromRecomputedTest extends OrganizeImportsBaseTest {
 

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/PrependOrDropScalaPackageKeepTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/PrependOrDropScalaPackageKeepTest.scala
@@ -5,9 +5,7 @@
 package scala.tools.refactoring
 package tests.implementations.imports
 
-import tests.util.TestHelper
 
-import language.reflectiveCalls
 
 class PrependOrDropScalaPackageKeepTest extends OrganizeImportsBaseTest {
 

--- a/src/test/scala/scala/tools/refactoring/tests/sourcegen/CustomFormattingTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/sourcegen/CustomFormattingTest.scala
@@ -6,13 +6,11 @@ package scala.tools.refactoring
 package tests.sourcegen
 
 import tests.util.TestHelper
-import org.junit.Assert
 import org.junit.Assert._
 import sourcegen.SourceGenerator
 import scala.tools.refactoring.implementations.OrganizeImports
 import scala.tools.refactoring.tests.util.TestRefactoring
 
-import language.reflectiveCalls
 
 class CustomFormattingTest extends TestHelper with TestRefactoring with SourceGenerator {
 

--- a/src/test/scala/scala/tools/refactoring/tests/sourcegen/IndividualSourceGenTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/sourcegen/IndividualSourceGenTest.scala
@@ -10,9 +10,8 @@ import org.junit.Assert
 import org.junit.Assert._
 import common.Change
 import tools.nsc.symtab.Flags
-import tools.nsc.ast.parser.Tokens
 
-import language.{postfixOps, implicitConversions}
+import language.implicitConversions
 
 class IndividualSourceGenTest extends TestHelper {
 

--- a/src/test/scala/scala/tools/refactoring/tests/sourcegen/PrettyPrinterTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/sourcegen/PrettyPrinterTest.scala
@@ -6,7 +6,6 @@ package scala.tools.refactoring
 package tests.sourcegen
 
 import tests.util.TestHelper
-import org.junit.Assert
 import org.junit.Assert._
 import tools.nsc.symtab.Flags
 import tools.nsc.ast.parser.Tokens

--- a/src/test/scala/scala/tools/refactoring/tests/sourcegen/SourceGenTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/sourcegen/SourceGenTest.scala
@@ -6,12 +6,11 @@ package scala.tools.refactoring
 package tests.sourcegen
 
 import tests.util.TestHelper
-import org.junit.Assert
 import org.junit.Assert._
 import tools.nsc.symtab.Flags
 import tools.nsc.ast.parser.Tokens
 
-import language.{ postfixOps, implicitConversions }
+import language.postfixOps
 
 class SourceGenTest extends TestHelper {
 

--- a/src/test/scala/scala/tools/refactoring/tests/transformation/TreeTransformationsTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/transformation/TreeTransformationsTest.scala
@@ -7,7 +7,7 @@ package tests.transformation
 
 import tests.util.TestHelper
 import org.junit.Assert._
-import language.{ postfixOps, reflectiveCalls }
+import language.postfixOps
 import scala.tools.nsc.util.FailedInterrupt
 import scala.tools.refactoring.common.TracingImpl
 

--- a/src/test/scala/scala/tools/refactoring/tests/util/SourceWithMarkerTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/util/SourceWithMarkerTest.scala
@@ -2,8 +2,6 @@ package scala.tools.refactoring.tests.util
 import org.junit.Test
 import org.junit.Assert._
 import scala.tools.refactoring.util.SourceWithMarker
-import scala.language.implicitConversions
-import scala.util.control.NonFatal
 import scala.tools.refactoring.util.SourceWithMarker.SimpleMovement
 import scala.tools.refactoring.util.SourceWithMarker.Movements
 import scala.tools.refactoring.util.SourceWithMarker.Movement

--- a/src/test/scala/scala/tools/refactoring/tests/util/TestHelper.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/util/TestHelper.scala
@@ -19,7 +19,7 @@ import org.junit.Assert.assertFalse
 import org.junit.Before
 import scala.tools.refactoring.common.InteractiveScalaCompiler
 import scala.tools.refactoring.common.Selections
-import language.{ postfixOps, implicitConversions, reflectiveCalls }
+import language.{ postfixOps, reflectiveCalls }
 import scala.tools.refactoring.common.NewFileChange
 import scala.tools.refactoring.common.RenameSourceFileChange
 import scala.tools.refactoring.implementations.Rename

--- a/src/test/scala/scala/tools/refactoring/tests/util/TestRefactoring.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/util/TestRefactoring.scala
@@ -8,7 +8,6 @@ package tests.util
 import common.Change
 import common.InteractiveScalaCompiler
 import scala.tools.refactoring.common.InteractiveScalaCompiler
-import org.junit.Before
 
 trait TestRefactoring extends TestHelper {
 

--- a/src/test/scala/scala/tools/refactoring/tests/util/UnionFindInitTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/util/UnionFindInitTest.scala
@@ -5,7 +5,6 @@ import scala.util.Random
 import scala.tools.refactoring.util.UnionFind
 import org.junit.Test
 import org.junit.Assert._
-import org.junit.Before
 
 class UnionFindInitTest {
 


### PR DESCRIPTION
The removal of the imports was done automatically by the following script:

    tac warnings.txt | awk '{split($0,a,":"); print "'"'"'sed -i " "\""a[2] "d\" " a[1] "'"'"'"}' | xargs -i -t sh -c "eval {}"

`warnings.txt` is a file whose contents look like this:

    /path-to-refactoring/scala-refactoring/src/main/scala/scala/tools/refactoring/Refactoring.scala:10: Unused import
    /path-to-refactoring/scala-refactoring/src/main/scala/scala/tools/refactoring/common/EnrichedTrees.scala:11: Unused import
    /path-to-refactoring/scala-refactoring/src/main/scala/scala/tools/refactoring/common/Selections.scala:9: Unused import
    /path-to-refactoring/scala-refactoring/src/main/scala/scala/tools/refactoring/common/Selections.scala:11: Unused import
    /path-to-refactoring/scala-refactoring/src/main/scala/scala/tools/refactoring/common/TreeTraverser.scala:8: Unused import

These are the actual error messages of the compiler or better the first
line of each error message, since this line contains all the important
information. The script generates a command that calls `sed` to remove
the import.