### PR TITLE
`Movements.id` must not match comments

### DIFF
--- a/src/main/scala/scala/tools/refactoring/util/SourceWithMarker.scala
+++ b/src/main/scala/scala/tools/refactoring/util/SourceWithMarker.scala
@@ -640,7 +640,7 @@ object SourceWithMarker {
       "_" | ":" | "=" | "=>" | "<-" | "<:" | "<%" | ">:" | "#" | "@" |
       "\u21D2" | "\u2190"
 
-    val id = (plainid | literalIdentifier).butNot(reservedName)
+    val id = (plainid | literalIdentifier).butNot(reservedName | comment)
 
     val spaces: Movement = space.zeroOrMore
     val comments: Movement = comment.zeroOrMore

--- a/src/test/scala/scala/tools/refactoring/tests/util/SourceWithMarkerTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/util/SourceWithMarkerTest.scala
@@ -354,6 +354,8 @@ class SourceWithMarkerTest {
     runIdTest("->", "->")
     runIdTest("2", "")
     runIdTest("x2", "x2")
+    runIdTest("/*comment*/", "")
+    runIdTest("//comment", "")
   }
 
   @Test


### PR DESCRIPTION
@sschaef `Movements.id` now should behave as expected and not match comments any more.