### PR TITLE
Fix rename for interpolated strings like f"$x"

### DIFF
--- a/src/main/scala/scala/tools/refactoring/common/PositionDebugging.scala
+++ b/src/main/scala/scala/tools/refactoring/common/PositionDebugging.scala
@@ -33,14 +33,14 @@ object PositionDebugging {
     if (pos != NoPosition && pos.source != NoSourceFile) {
       val posType = getSimpleClassName(pos)
 
-      val (start, end) = {
-        if (!pos.isRange) (pos.point, pos.point)
-        else (pos.start, pos.end)
+      val (start, point, end) = {
+        if (!pos.isRange) (pos.point, pos.point, pos.point)
+        else (pos.start, pos.point, pos.end)
       }
 
       val markerString = {
-        if (start == end) s"(${start})"
-        else s"(${start}, ${end})"
+        if (start == end) s"($start)"
+        else s"($start, $point, $end)"
       }
 
       val relevantSource = {

--- a/src/main/scala/scala/tools/refactoring/implementations/MarkOccurrences.scala
+++ b/src/main/scala/scala/tools/refactoring/implementations/MarkOccurrences.scala
@@ -22,7 +22,7 @@ abstract class MarkOccurrences extends common.Selections with analysis.Indexes w
 
     def occurrencesForSymbol(s: Symbol) = {
       val occurrences = index.occurences(s)
-      occurrences map (_.namePosition) filter  (_ != global.NoPosition)
+      occurrences map (_.namePosition) filter  (_.isRange)
     }
 
     val selectedTree = (new FileSelection(file, global.unitOfFile(file).body, from, to)).findSelectedWithPredicate {

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
@@ -3757,7 +3757,7 @@ class Blubb
    * See Assembla Ticket 1002651
    */
   @Test
-  def testRenameWithInterpolatedString1002651() = new FileSet {
+  def testRenameWithInterpolatedString1002651Ex1() = new FileSet {
     """
     class Bug {
       val /*(*/renameMe/*)*/ = 13
@@ -3771,4 +3771,32 @@ class Blubb
     }
     """ -> TaggedAsGlobalRename
   } prepareAndApplyRefactoring(prepareAndRenameTo("ups"))
+
+  @Test
+  def testRenameWithInterpolatedString1002651Ex2() = new FileSet {
+    """
+    class Bug {
+      val /*(*/renameMe/*)*/ = 13
+      val renameMeNot = 14
+
+      val bug = f"$renameMe"
+      val moreBugs = f"$renameMe but $renameMeNot and make sure that $renameMe is renamed again"
+      val bugsAllOverThePlace = f"Plase, also ${renameMe} here, but do ${renameMeNot} here"
+
+      val thisWorkedBefore = s"Please $renameMe like you did before"
+    }
+    """ becomes
+    """
+    class Bug {
+      val /*(*/franzi/*)*/ = 13
+      val renameMeNot = 14
+
+      val bug = f"$franzi"
+      val moreBugs = f"$franzi but $renameMeNot and make sure that $franzi is renamed again"
+      val bugsAllOverThePlace = f"Plase, also ${franzi} here, but do ${renameMeNot} here"
+
+      val thisWorkedBefore = s"Please $franzi like you did before"
+    }
+    """ -> TaggedAsGlobalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("franzi"))
 }

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
@@ -3761,15 +3761,15 @@ class Blubb
     """
     class Bug {
       val /*(*/renameMe/*)*/ = 13
-      val bug = f"$renameMe"
+      val bug = f"?renameMe"
     }
-    """ becomes
+    """.replace("?", "$") becomes
     """
     class Bug {
       val /*(*/ups/*)*/ = 13
-      val bug = f"$ups"
+      val bug = f"?ups"
     }
-    """ -> TaggedAsGlobalRename
+    """.replace("?", "$") -> TaggedAsGlobalRename
   } prepareAndApplyRefactoring(prepareAndRenameTo("ups"))
 
   @Test
@@ -3779,24 +3779,24 @@ class Blubb
       val /*(*/renameMe/*)*/ = 13
       val renameMeNot = 14
 
-      val bug = f"$renameMe"
-      val moreBugs = f"$renameMe but $renameMeNot and make sure that $renameMe is renamed again"
-      val bugsAllOverThePlace = f"Plase, also ${renameMe} here, but do ${renameMeNot} here"
+      val bug = f"?renameMe"
+      val moreBugs = f"?renameMe but ?renameMeNot and make sure that ?renameMe is renamed again"
+      val bugsAllOverThePlace = f"Plase, also ?{renameMe} here, but do ?{renameMeNot} here"
 
-      val thisWorkedBefore = s"Please $renameMe like you did before"
+      val thisWorkedBefore = s"Please ?renameMe like you did before"
     }
-    """ becomes
+    """.replace("?", "$") becomes
     """
     class Bug {
       val /*(*/franzi/*)*/ = 13
       val renameMeNot = 14
 
-      val bug = f"$franzi"
-      val moreBugs = f"$franzi but $renameMeNot and make sure that $franzi is renamed again"
-      val bugsAllOverThePlace = f"Plase, also ${franzi} here, but do ${renameMeNot} here"
+      val bug = f"?franzi"
+      val moreBugs = f"?franzi but ?renameMeNot and make sure that ?franzi is renamed again"
+      val bugsAllOverThePlace = f"Plase, also ?{franzi} here, but do ?{renameMeNot} here"
 
-      val thisWorkedBefore = s"Please $franzi like you did before"
+      val thisWorkedBefore = s"Please ?franzi like you did before"
     }
-    """ -> TaggedAsGlobalRename
+    """.replace("?", "$") -> TaggedAsGlobalRename
   } prepareAndApplyRefactoring(prepareAndRenameTo("franzi"))
 }

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
@@ -3752,4 +3752,23 @@ class Blubb
     class SomeClass protected (/*(*/ups/*)*/: Int)
     """ -> TaggedAsGlobalRename
   } prepareAndApplyRefactoring(prepareAndRenameTo("ups"))
+
+  /*
+   * See Assembla Ticket 1002651
+   */
+  @Test
+  def testRenameWithInterpolatedString1002651() = new FileSet {
+    """
+    class Bug {
+      val /*(*/renameMe/*)*/ = 13
+      val bug = f"$renameMe"
+    }
+    """ becomes
+    """
+    class Bug {
+      val /*(*/ups/*)*/ = 13
+      val bug = f"$ups"
+    }
+    """ -> TaggedAsGlobalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("ups"))
 }


### PR DESCRIPTION
And yet another workaround for a position bug of the compiler. Fixes [Ticket #1002651](https://www.assembla.com/spaces/scala-ide/tickets/1002651-rename-breaks-with-interpolated-strings/details#).