### PR TITLE
Fix rename in for comprehensions

### DIFF
--- a/src/main/scala/scala/tools/refactoring/analysis/GlobalIndexes.scala
+++ b/src/main/scala/scala/tools/refactoring/analysis/GlobalIndexes.scala
@@ -33,7 +33,8 @@ trait GlobalIndexes extends Indexes with DependentSymbolExpanders with Compilati
           LazyValAccessor with
           OverridesInSuperClasses with
           ClassVals with
-          CaseClassVals {
+          CaseClassVals with
+          TermsWithMissingRanges {
 
             val cus = compilationUnits
           }

--- a/src/main/scala/scala/tools/refactoring/analysis/SymbolExpanders.scala
+++ b/src/main/scala/scala/tools/refactoring/analysis/SymbolExpanders.scala
@@ -208,6 +208,15 @@ trait DependentSymbolExpanders extends TracingImpl {
     })
   }
 
+  /**
+   * Associates term symbols with missing ranges to related symbols that have ranges.
+   *
+   * The reason that we need this is that in some cases, the PC generates multiple
+   * symbols for one and the same symbol in user source code, one of them with a
+   * proper range position, and others just with offset positions. One place where
+   * this happens is in desugared for comprehensions with filter clauses.
+   * See Assembler Ticket #1002650.
+   */
   trait TermsWithMissingRanges extends SymbolExpander { this: IndexLookup =>
     protected abstract override def doExpand(s: Symbol): List[Symbol] = {
       termsWithSamePointButRange(s) ::: super.doExpand(s)

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
@@ -3799,4 +3799,133 @@ class Blubb
     }
     """.replace("?", "$") -> TaggedAsGlobalRename
   } prepareAndApplyRefactoring(prepareAndRenameTo("franzi"))
+
+  /*
+   * See Assembla Ticket 1002650
+   */
+  @Test
+  def testRenameWithForComprehensions1002650Ex1() = new FileSet {
+    """
+    class Bug1 {
+      for {
+        (/*(*/renameMe/*)*/, b) <- Seq((1, 2)) if renameMe % 2 == 0
+      } {
+        println(renameMe)
+      }
+    }
+    """ becomes
+    """
+    class Bug1 {
+      for {
+        (/*(*/ups/*)*/, b) <- Seq((1, 2)) if ups % 2 == 0
+      } {
+        println(ups)
+      }
+    }
+    """ -> TaggedAsLocalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("ups"))
+
+  @Test
+  def testRenameWithForComprehensions1002650Ex2() = new FileSet {
+    """
+    class Bug1 {
+      for {
+        (renameMe, b) <- Seq((1, 2)) if /*(*/renameMe/*)*/ % 2 == 0
+      } {
+        println(renameMe)
+      }
+    }
+    """ becomes
+    """
+    class Bug1 {
+      for {
+        (ups, b) <- Seq((1, 2)) if /*(*/ups/*)*/ % 2 == 0
+      } {
+        println(ups)
+      }
+    }
+    """ -> TaggedAsLocalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("ups"))
+
+  @Test
+  def testRenameWithForComprehensions1002650Ex3() = new FileSet {
+    """
+    class Bug1 {
+      for {
+        (renameMe, b) <- Seq((1, 2)) if renameMe % 2 == 0
+      } {
+        println(/*(*/renameMe/*)*/)
+      }
+    }
+    """ becomes
+    """
+    class Bug1 {
+      for {
+        (ups, b) <- Seq((1, 2)) if ups % 2 == 0
+      } {
+        println(/*(*/ups/*)*/)
+      }
+    }
+    """ -> TaggedAsLocalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("ups"))
+
+  @Test
+  def testRenameWithForComprehensions1002650Ex4() = new FileSet {
+    """
+    class Bug2 {
+      for {
+        /*(*/tryRenameMe/*)*/ <- Option(Option(1))
+      } {
+        for {
+          tryRenameMe <- tryRenameMe
+        } yield {
+          tryRenameMe + 1
+        }
+      }
+    }
+    """ becomes
+    """
+    class Bug2 {
+      for {
+        /*(*/ups/*)*/ <- Option(Option(1))
+      } {
+        for {
+          tryRenameMe <- ups
+        } yield {
+          tryRenameMe + 1
+        }
+      }
+    }
+    """ -> TaggedAsLocalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("ups"))
+
+  @Test
+  def testRenameWithForComprehensions1002650Ex5() = new FileSet {
+    """
+    class Bug2 {
+      for {
+        tryRenameMe <- Option(Option(1))
+      } {
+        for {
+          tryRenameMe <- tryRenameMe
+        } yield {
+          /*(*/tryRenameMe/*)*/ + 1
+        }
+      }
+    }
+    """ becomes
+    """
+    class Bug2 {
+      for {
+        tryRenameMe <- Option(Option(1))
+      } {
+        for {
+          ups <- tryRenameMe
+        } yield {
+          /*(*/ups/*)*/ + 1
+        }
+      }
+    }
+    """ -> TaggedAsLocalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("ups"))
 }


### PR DESCRIPTION
Note that this PR actually makes the implementation simpler, and removes more code than it adds.

Fix [#1002650](https://www.assembla.com/spaces/scala-ide/tickets/1002650-rename-fails-in-for-comprehensions/details#)