### PR TITLE
Properly Rename Scala Annotation Arguments

### DIFF
--- a/src/main/scala/scala/tools/refactoring/common/TreeTraverser.scala
+++ b/src/main/scala/scala/tools/refactoring/common/TreeTraverser.scala
@@ -254,7 +254,6 @@ trait TreeTraverser extends TracingImpl {
   }
 
   class TreeWithSymbolTraverser(f: (Symbol, Tree) => Unit) extends Traverser with TraversalInstrumentation {
-
     override def traverse(t: Tree) = {
 
       t match {
@@ -335,8 +334,10 @@ trait TreeTraverser extends TracingImpl {
 
         case t: DefTree if t.symbol != NoSymbol =>
           f(t.symbol, t)
+
         case t: RefTree =>
           f(t.symbol, t)
+
         case t: TypeTree if t.original == null =>
 
           def handleType(typ: Type): Unit = typ match {
@@ -377,7 +378,22 @@ trait TreeTraverser extends TracingImpl {
       t match {
         case _: NamedArgument | _: NameTree | _: MultipleAssignment =>
           ()
+
         case t =>
+          val annotations = {
+            if (t.isInstanceOf[DefTree] && t.symbol != null && t.symbol != NoSymbol) {
+              t.symbol.annotations
+            } else {
+              Nil
+            }
+          }
+
+          annotations.foreach { annotation =>
+            context("annotaton tree") {
+              traverse(annotation.original)
+            }
+          }
+
           super.traverse(t)
       }
     }

--- a/src/main/scala/scala/tools/refactoring/common/TreeTraverser.scala
+++ b/src/main/scala/scala/tools/refactoring/common/TreeTraverser.scala
@@ -5,7 +5,6 @@
 package scala.tools.refactoring
 package common
 
-
 trait TreeTraverser extends TracingImpl {
 
   this: CompilerAccess with common.EnrichedTrees =>
@@ -46,7 +45,18 @@ trait TreeTraverser extends TracingImpl {
         }
       }
 
-      def treeAsString = t.summaryString
+      def treeAsString = {
+        val symString = {
+          val sym = t.symbol
+          if (sym == NoSymbol) {
+            "NoSymbol"
+          } else {
+            "" + sym
+          }
+        }
+
+        t.summaryString + "@" + symString
+      }
 
       def sourceFileAsString = t.pos match {
         case null | NoPosition => "<no-source-file>"

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
@@ -3928,4 +3928,59 @@ class Blubb
     }
     """ -> TaggedAsLocalRename
   } prepareAndApplyRefactoring(prepareAndRenameTo("ups"))
+
+  /*
+   * See Assembla Ticket 1002680
+   */
+  @Test
+  def testRenameAnnotationArgs1002680Ex1() = new FileSet {
+    """
+    public @interface AnAnnotation {
+      Class<?> value1() default Integer.class;
+      Class<?> value2() default Integer.class;
+      int value3() default 42;
+    }
+    """ -> PreloadAsJava("AnAnnotation")
+
+    """
+    object RenameBug1 {
+      class /*(*/TryRenameMe/*)*/
+
+      @AnAnnotation(value1 = classOf[TryRenameMe])
+      class SomeClass
+    }""" becomes
+    """
+    object RenameBug1 {
+      class /*(*/HumptyDumpty/*)*/
+
+      @AnAnnotation(value1 = classOf[HumptyDumpty])
+      class SomeClass
+    """ -> TaggedAsGlobalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("HumptyDumpty"))
+
+  @Test
+  def testRenameAnnotationArgs1002680Ex2() = new FileSet {
+    """
+    public @interface AnAnnotation {
+      Class<?> value1() default Integer.class;
+      Class<?> value2() default Integer.class;
+      int value3() default 42;
+    }
+    """ -> PreloadAsJava("AnAnnotation")
+
+    """
+    object RenameBug2 {
+      final val /*(*/TryRenameMe/*)*/ = 42
+
+      @AnAnnotation(value3 = TryRenameMe)
+      class SomeClass
+    }""" becomes
+    """
+    object RenameBug2 {
+      final val /*(*/CheshireCat/*)*/ = 42
+
+      @AnAnnotation(value3 = CheshireCat)
+      class SomeClass
+    """ -> TaggedAsGlobalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("CheshireCat"))
 }

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
@@ -3933,7 +3933,7 @@ class Blubb
    * See Assembla Ticket 1002680
    */
   @Test
-  def testRenameAnnotationArgs1002680Ex1() = new FileSet {
+  def testRenameJavaAnnotationArgs1002680Ex1() = new FileSet {
     """
     public @interface AnAnnotation {
       Class<?> value1() default Integer.class;
@@ -3959,7 +3959,7 @@ class Blubb
   } prepareAndApplyRefactoring(prepareAndRenameTo("HumptyDumpty"))
 
   @Test
-  def testRenameAnnotationArgs1002680Ex2() = new FileSet {
+  def testRenameJavaAnnotationArgs1002680Ex2() = new FileSet {
     """
     public @interface AnAnnotation {
       Class<?> value1() default Integer.class;
@@ -3983,4 +3983,50 @@ class Blubb
       class SomeClass
     """ -> TaggedAsGlobalRename
   } prepareAndApplyRefactoring(prepareAndRenameTo("CheshireCat"))
+
+  @Test
+  def testRenameScalaAnnotationArgs1002680Ex1() = new FileSet {
+    """
+    final class SomeScalaAnnotation(value1: Int = 23, value2: Class[_] = classOf[String])
+      extends annotation.StaticAnnotation
+    """ isNotModified()
+
+    """
+    object RenameBug3 {
+      final val /*(*/TryRenameMe/*)*/ = 42
+
+      @SomeScalaAnnotation(value1 = TryRenameMe)
+      class SomeClass
+    }""" becomes
+    """
+    object RenameBug3 {
+      final val /*(*/Caterpillar/*)*/ = 42
+
+      @SomeScalaAnnotation(value1 = Caterpillar)
+      class SomeClass
+    }""" -> TaggedAsGlobalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("Caterpillar"))
+
+  @Test
+  def testRenameScalaAnnotationArgs1002680Ex2() = new FileSet {
+    """
+    final class SomeScalaAnnotation(value1: Int = 23, value2: Class[_] = classOf[String])
+      extends annotation.StaticAnnotation
+    """ isNotModified()
+
+    """
+    object RenameBug4 {
+      class /*(*/TryRenameMe/*)*/
+
+      @SomeScalaAnnotation(value2 = classOf[TryRenameMe])
+      class ImInnocent
+    }""" becomes
+    """
+    object RenameBug4 {
+      class /*(*/Hatter/*)*/
+
+      @SomeScalaAnnotation(value2 = classOf[Hatter])
+      class ImInnocent
+    }""" -> TaggedAsGlobalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("Hatter"))
 }

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
@@ -3932,6 +3932,7 @@ class Blubb
   /*
    * See Assembla Ticket 1002680
    */
+  @Ignore("Needs compiler support")
   @Test
   def testRenameJavaAnnotationArgs1002680Ex1() = new FileSet {
     """
@@ -3958,6 +3959,7 @@ class Blubb
     """ -> TaggedAsGlobalRename
   } prepareAndApplyRefactoring(prepareAndRenameTo("HumptyDumpty"))
 
+  @Ignore("Needs compiler support")
   @Test
   def testRenameJavaAnnotationArgs1002680Ex2() = new FileSet {
     """

--- a/src/test/scala/scala/tools/refactoring/tests/util/TestHelper.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/util/TestHelper.scala
@@ -270,7 +270,7 @@ trait TestHelper extends TestRules with Refactoring with CompilerProvider with c
             true
           } else {
             sym.annotations.exists { annotation =>
-              containsError(annotation.tree)
+              containsError(annotation.original)
             }
           }
         }

--- a/src/test/scala/scala/tools/refactoring/tests/util/TestRefactoring.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/util/TestRefactoring.scala
@@ -22,7 +22,8 @@ trait TestRefactoring extends TestHelper {
       val global = TestRefactoring.this.global
 
       lazy val trees = {
-        project.sources map { case(code, filename) => addToCompiler(filename, code) } map (global.unitOfFile(_).body)
+        project.javaSources.foreach { case (code, filename) => addToCompiler(filename, code) }
+        project.sources.map { case(code, filename) => addToCompiler(filename, code) }.map(global.unitOfFile(_).body)
       }
 
       override val index = global.ask { () =>


### PR DESCRIPTION
This PR takes care of [ticket 1002680](https://www.assembla.com/spaces/scala-ide/tickets/1002680-rename-ignores-arguments-of-annotations) for Scala Annotations. Handling Java annotations properly requires changes to the compiler, as discussed in [ticket 1001793](https://www.assembla.com/spaces/scala-ide/tickets/1001793-rename-and-organize-imports-ignore-arguments-of-annotations).