### PR TITLE
Implement `Rename` on top of `MarkOccurences`

### DIFF
--- a/src/main/scala/scala/tools/refactoring/implementations/MarkOccurrences.scala
+++ b/src/main/scala/scala/tools/refactoring/implementations/MarkOccurrences.scala
@@ -5,67 +5,188 @@
 package scala.tools.refactoring
 package implementations
 
+import scala.reflect.internal.util.OffsetPosition
 import scala.reflect.internal.util.RangePosition
+import scala.tools.refactoring.common.PositionDebugging
+import scala.tools.refactoring.util.SourceWithMarker
+import scala.tools.refactoring.util.SourceWithMarker.Movements
 import scala.util.control.NonFatal
+import scala.tools.refactoring.util.SourceWithMarker.Movement
 
-abstract class MarkOccurrences extends common.Selections with analysis.Indexes with common.CompilerAccess with common.EnrichedTrees {
-
-  val global: tools.nsc.interactive.Global
+trait MarkOccurrences extends common.Selections with analysis.Indexes with common.CompilerAccess with common.EnrichedTrees with common.InteractiveScalaCompiler {
   import global._
 
-  def occurrencesOf(file: tools.nsc.io.AbstractFile, from: Int, to: Int): (Tree, List[Position]) = {
-
-    def positionOverlapsSelection(p: Position) = (
-          ((new RangePosition(null, from, from, to)) overlaps p) ||
-          (from == to && ( to == p.end || to == p.start))
-      )
-
-    def occurrencesForSymbol(s: Symbol) = {
-      val occurrences = index.occurences(s)
-      occurrences map (_.namePosition) filter  (_.isRange)
+  protected class SingleTreeSelection(val selected: Tree, val root: Tree) {
+    val symbol = selected match {
+      case Import(expr, List(selector)) =>
+        findSymbolForImportSelector(expr, selector.name).getOrElse(NoSymbol)
+      case tree => tree.symbol
     }
 
-    val selectedTree = (new FileSelection(file, global.unitOfFile(file).body, from, to)).findSelectedWithPredicate {
+    val name = {
+      // We try to read the old name from the name position of the original symbol, since this seems to be the most
+      // reliable strategy that also works well in the presence of `backtick-identifiers`.
+      index.declaration(symbol).flatMap { tree =>
+        tree.namePosition() match {
+          case rp: RangePosition => Some(rp.source.content.slice(rp.start, rp.end).mkString(""))
+          case _ => None
+        }
+      }.getOrElse {
+        trace("Cannot find old name of symbol reliably; attempting fallback")
+        try {
+          selected match {
+            case Import(_, List(selector)) => selector.rename.toString
+            case _ => selected match {
+              case s: Select => s.name.toString()
+              case other => other.nameString
+            }
+          }
+        } catch {
+          case NonFatal(e) =>
+            trace("Cannot find old name of symbol; giving up")
+            "<no-name>"
+        }
+      }
+    } \\ { name =>
+      trace(s"SingleTreeSelection.name: $name")
+    }
+  }
+
+  protected def findOccurrences(selection: SingleTreeSelection): List[(RangePosition, Tree)] = {
+    /*
+     * A lazy val is represented by a ValDef and an associated DefDef that contains the initialization code.
+     * Unfortunately, the Scala compiler does not set modifier positions for the DefDef, which is a problem for us,
+     * because we are relying on the DefDef when printing out source code. The following function patches the affected
+     * DefDefs accordingly.
+     *
+     * See #1002392 and #1002502
+     */
+    def eventuallyFixModifierPositionsForLazyVals(t: Tree): Unit = t match {
+      case dd: DefDef if dd.mods.isLazy && dd.mods.positions.isEmpty =>
+        val vd = selection.root.find {
+          case vd: ValDef if vd.mods.isLazy && !vd.mods.positions.isEmpty && dd.pos.point == vd.pos.point => true
+          case _ => false
+        }
+
+        vd.foreach { vd =>
+          // Note that we patch the DefDef in place because we need the correctly set positions in the tree
+          // later in the refactoring process. A precursor of this code pretended to be pure, by copying
+          // dd and then calling 'mods.setPositions' on the copy. This had exactly the same (needed) side effects
+          // however, as the Modifier object affected by setPositions was the same anyway. If you are interested
+          // in the related discussion, take a look at https://github.com/scala-ide/scala-refactoring/pull/78.
+          dd.mods.setPositions(vd.asInstanceOf[ValDef].mods.positions)
+        }
+
+      case _ => ()
+    }
+
+    /*
+     * ImportSelectorTrees need special treatment, since it is not a priory clear which side (the name or rename side) of
+     * the tree is relevant for us.
+     */
+    def positionsWithPotentiallyReferencingTrees(trees: Seq[Tree]): Seq[(Position, Tree)] = {
+      trees.flatMap {
+        case ImportSelectorTree(name, rename) => Seq(name.namePosition() -> name, rename.namePosition() -> rename)
+        case other => Seq(other.namePosition() -> other)
+      }
+    }
+
+    val referencingTrees = index.occurences(selection.symbol)
+
+    referencingTrees.foreach { s =>
+      trace("Symbol is referenced at %s", PositionDebugging.formatCompact(s.pos))
+      eventuallyFixModifierPositionsForLazyVals(s)
+    }
+
+    import Movements._
+    val mvToSymStartForRangePos = Movements.until(selection.name, skipping = (comment | space | reservedName))
+    val occurences = positionsWithPotentiallyReferencingTrees(referencingTrees).flatMap { case (pos, occ) =>
+      pos match {
+        case np: RangePosition =>
+          // Unfortunately, there are cases when the name position cannot be used directly.
+          // Therefore we have to use appropriate movements to make sure we capture the correct range.
+          val srcAtStart = SourceWithMarker.atStartOf(np)
+          mvToSymStartForRangePos(srcAtStart).flatMap { markerAtSymStart =>
+            val consumedId = Movement.coveredString(markerAtSymStart, srcAtStart.source, Movements.id)
+
+            if (consumedId == selection.name) {
+              Some((new RangePosition(np.source, markerAtSymStart, markerAtSymStart, markerAtSymStart + selection.name.length), occ))
+            } else {
+              None
+            }
+          }
+
+        case op: OffsetPosition =>
+          // Normally, we would not like to deal with offset positions here at all.
+          // Unfortunately the compiler emits them instead of range positions in
+          // interpolated strings like f"$x" (see #1002651).
+          val pointIsAtStartOfNameToBeChanged = {
+            val srcBeforePoint = SourceWithMarker.atPoint(op).step(forward = false)
+            val pointIsInMiddleOfId = Movements.id(srcBeforePoint).exists(_ > op.point)
+
+            if (pointIsInMiddleOfId) {
+              false
+            } else {
+              val srcAtPoint = srcBeforePoint.step(forward = true)
+              val consumedId = Movement.coveredString(srcAtPoint, Movements.id)
+              consumedId == selection.name
+            }
+          }
+
+          if (pointIsAtStartOfNameToBeChanged) {
+            Some((new RangePosition(op.source, op.point, op.point, op.point + selection.name.length), occ))
+          } else {
+            None
+          }
+
+        case _ =>
+          None
+      }
+    }
+
+    // Since the ASTs do not directly represent the user source code, it might be easily possible that
+    // some ranges are duplicated. The code below removes them.
+    val uniqOccurences = occurences.groupBy(_._1).map { case (pos, occWithTrees) =>
+      (pos, occWithTrees.head._2)
+    }.toList
+
+    uniqOccurences
+  }
+
+  def occurrencesOf(file: tools.nsc.io.AbstractFile, from: Int, to: Int): (Tree, List[Position]) = {
+    val selection = new FileSelection(file, global.unitOfFile(file).body, from, to)
+
+    val selectedTree = selection.findSelectedWithPredicate {
       case (_: global.TypeTree) | (_: global.SymTree) | (_: global.Ident) => true
       case _ => false
     }
 
-    val occurrences = selectedTree.toList flatMap {
+    val cursorOnScalaId = {
+      val positionsToCheck = selectedTree.toSeq.flatMap {
+        case imp: Import =>
+          // Imports need special handling, since it is not clear on which part of the import statement the cursor might be positioned on
+          Seq(imp.expr.namePosition()) ++ imp.selectors.map(s => new OffsetPosition(imp.pos.source, s.namePos))
 
-      // for example, in List[String], String is an Ident and needs special treatment
-      case t: Ident if t.symbol == null || t.symbol == NoSymbol =>
-        val symbols = index positionToSymbol t.pos
+        case other => Seq(other.namePosition())
+      }
 
-        symbols flatMap occurrencesForSymbol
-
-      case imp: Import =>
-
-        imp.Selectors().find { selector =>
-          positionOverlapsSelection(selector.pos)
-        }.toList.flatMap { selector =>
-          findSymbolForImportSelector(imp.expr, selector.name.name)
-        }.map { sym =>
-          occurrencesForSymbol(sym)
-        }.flatten
-
-      case selectedLocal =>
-        // source files that contain errors can lead to
-        // position exceptions in various places, so we
-        // just catch everything here
-        val namePos = try {
-          selectedLocal.namePosition
-        } catch {
-          case NonFatal(_) => NoPosition
-        }
-        val symbol = selectedLocal.symbol
-
-        if(symbol == null || namePos == NoPosition || !positionOverlapsSelection(namePos)) {
-          Nil
-        } else {
-          occurrencesForSymbol(symbol)
-        }
+      positionsToCheck.exists {
+        case rp: RangePosition => rp.start >= from && rp.end <= to
+        case op: OffsetPosition => op.point >= from && op.point <= to
+        case _ => false
+      }
     }
 
-    (selectedTree getOrElse EmptyTree, occurrences)
+    if (!cursorOnScalaId) {
+      (EmptyTree, Nil)
+    } else {
+      val occurrences = selectedTree.toList.flatMap { selectedTree =>
+        val singleTreeSelection = new SingleTreeSelection(selectedTree, selection.root)
+        val occurences = findOccurrences(singleTreeSelection)
+        occurences.map(_._1)
+      }
+
+      (selectedTree.getOrElse(EmptyTree), occurrences)
+    }
   }
 }

--- a/src/main/scala/scala/tools/refactoring/implementations/MarkOccurrences.scala
+++ b/src/main/scala/scala/tools/refactoring/implementations/MarkOccurrences.scala
@@ -37,7 +37,7 @@ trait MarkOccurrences extends common.Selections with analysis.Indexes with commo
           selected match {
             case Import(_, List(selector)) => selector.rename.toString
             case _ => selected match {
-              case s: Select => s.name.toString()
+              case s: Select => s.name.decoded
               case other => other.nameString
             }
           }
@@ -112,6 +112,7 @@ trait MarkOccurrences extends common.Selections with analysis.Indexes with commo
             if (consumedId == selection.name) {
               Some((new RangePosition(np.source, markerAtSymStart, markerAtSymStart, markerAtSymStart + selection.name.length), occ))
             } else {
+              trace(s"consumedId `$consumedId` does not match selecton name `${selection.name}`")
               None
             }
           }
@@ -216,7 +217,17 @@ trait MarkOccurrences extends common.Selections with analysis.Indexes with commo
       }
     }
 
-    trace(s"Returning occurrences for ${treeWithOccurences._1}: ${treeWithOccurences._2}")
+    trace {
+      val formattedPositions = {
+        val occurences = treeWithOccurences._2
+
+        if (occurences.nonEmpty) occurences.map(PositionDebugging.format).mkString(", ")
+        else "<none>"
+      }
+
+      s"Returning occurrences for ${treeWithOccurences._1}: $formattedPositions"
+    }
+
     treeWithOccurences
   }
 }

--- a/src/main/scala/scala/tools/refactoring/implementations/Rename.scala
+++ b/src/main/scala/scala/tools/refactoring/implementations/Rename.scala
@@ -5,19 +5,17 @@
 package scala.tools.refactoring
 package implementations
 
-import transformation.TreeFactory
-import analysis.TreeAnalysis
-import scala.tools.refactoring.common.RenameSourceFileChange
-import scala.tools.refactoring.common.PositionDebugging
-import scala.reflect.internal.util.RangePosition
-import scala.tools.refactoring.util.SourceWithMarker
-import scala.tools.refactoring.util.SourceWithMarker.Movements
-import scala.tools.refactoring.common.TextChange
-import scala.tools.refactoring.common.RenameSourceFileChange
+import scala.Left
+import scala.Right
+import scala.tools.refactoring.MultiStageRefactoring
 import scala.tools.refactoring.common.Change
-import scala.reflect.internal.util.OffsetPosition
+import scala.tools.refactoring.common.RenameSourceFileChange
+import scala.tools.refactoring.common.TextChange
 
-abstract class Rename extends MultiStageRefactoring with TreeAnalysis with analysis.Indexes with TreeFactory with common.InteractiveScalaCompiler {
+import analysis.TreeAnalysis
+import transformation.TreeFactory
+
+abstract class Rename extends MultiStageRefactoring with MarkOccurrences with TreeAnalysis with analysis.Indexes with TreeFactory with common.InteractiveScalaCompiler {
 
   import global._
 
@@ -109,119 +107,31 @@ abstract class Rename extends MultiStageRefactoring with TreeAnalysis with analy
   }
 
   def perform(selection: Selection, prepared: PreparationResult, newName: RefactoringParameters): Either[RefactoringError, List[Change]] = {
-    /*
-     * A lazy val is represented by a ValDef and an associated DefDef that contains the initialization code.
-     * Unfortunately, the Scala compiler does not set modifier positions for the DefDef, which is a problem for us,
-     * because we are relying on the DefDef when printing out source code. The following function patches the affected
-     * DefDefs accordingly.
-     *
-     * See #1002392 and #1002502
-     */
-    def eventuallyFixModifierPositionsForLazyVals(t: Tree): Unit = t match {
-      case dd: DefDef if dd.mods.isLazy && dd.mods.positions.isEmpty =>
-        val vd = selection.root.find {
-          case vd: ValDef if vd.mods.isLazy && !vd.mods.positions.isEmpty && dd.pos.point == vd.pos.point => true
-          case _ => false
-        }
-
-        vd.foreach { vd =>
-          // Note that we patch the DefDef in place because we need the correctly set positions in the tree
-          // later in the refactoring process. A precursor of this code pretended to be pure, by copying
-          // dd and then calling 'mods.setPositions' on the copy. This had exactly the same (needed) side effects
-          // however, as the Modifier object affected by setPositions was the same anyway. If you are interested
-          // in the related discussion, take a look at https://github.com/scala-ide/scala-refactoring/pull/78.
-          dd.mods.setPositions(vd.asInstanceOf[ValDef].mods.positions)
-        }
-
-      case _ => ()
-    }
-
     trace("Selected tree is %s", prepared.selectedTree)
-    val sym = prepared.selectedTree.symbol
-    val oldName = {
-      // We try to read the old name from the name position of the original symbol, since this seems to be the most
-      // reliable strategy that also works well in the presence of `backtick-identifiers`.
-      index.declaration(sym).flatMap { tree =>
-        tree.namePosition() match {
-          case rp: RangePosition => Some(rp.source.content.slice(rp.start, rp.end).mkString(""))
-          case _ => None
-        }
-      }.getOrElse {
-        trace("Cannot find old name of symbol reliably; attempting fallback")
-        prepared.selectedTree.nameString
-      }
-    }
+    val singleTreeSelection = new SingleTreeSelection(prepared.selectedTree, selection.root)
 
     def generateChanges: List[Change] = {
-      val occurences = index.occurences(sym)
+      val occurences = findOccurrences(singleTreeSelection)
 
-      occurences.foreach { s =>
-        trace("Symbol is referenced at %s", PositionDebugging.formatCompact(s.pos))
-        eventuallyFixModifierPositionsForLazyVals(s)
+      val textChangesWithTrees = occurences.map { case (occurence, tree)  =>
+        (TextChange(occurence.source, occurence.start, occurence.end, newName), tree)
       }
 
-      import Movements._
-      val mvToSymStartForRangePos = Movements.until(oldName, skipping = (comment | space | reservedName))
-      val textChangesWithTrees = occurences.flatMap { occ =>
-        occ.namePosition() match {
-          case np: RangePosition =>
-            // Unfortunately, there are cases when the name position cannot be used directly.
-            // Therefore we have to use an appropriate movement to make sure we capture the correct range.
-            val srcAtStart = SourceWithMarker.atStartOf(np)
-            mvToSymStartForRangePos(srcAtStart).map { markerAtSymStart =>
-              (TextChange(np.source, markerAtSymStart, markerAtSymStart + oldName.length, newName), occ)
-            }
-
-          case op: OffsetPosition =>
-            // Normally, we would not like to deal with offset positions here at all.
-            // Unfortunately the compiler emits them instead of range positions in
-            // interpolated strings like f"$x" (see #1002651).
-            val pointIsAtStartOfNameToBeChanged = {
-              val srcBeforePoint = SourceWithMarker.atPoint(op).step(forward = false)
-              val pointIsInMiddleOfId = Movements.id(srcBeforePoint).exists(_ > op.point)
-
-              if (pointIsInMiddleOfId) {
-                false
-              } else {
-                val srcAtPoint = srcBeforePoint.step(forward = true)
-                val srcAfterId = srcAtPoint.moveMarker(Movements.id)
-                val consumedId = srcAtPoint.source.slice(srcAtPoint.marker, srcAfterId.marker).mkString("")
-                consumedId == oldName
-              }
-            }
-
-            if (pointIsAtStartOfNameToBeChanged) {
-              Some((TextChange(op.source, op.point, op.point + oldName.length, newName), occ))
-            } else {
-              None
-            }
-
-          case _ =>
-            None
-        }
-      }
-
-      // Since the ASTs do not directly represent the user source code, it might be easily possible that
-      // some text changes are duplicated. The code below removes them.
-      val uniqTextChangesWithTrees = textChangesWithTrees.groupBy(_._1).map { case (change, changesWithTrees) =>
-        (change, changesWithTrees.head._2)
-      }.toList
-
-      val textChanges = uniqTextChangesWithTrees.map(_._1)
-
-      val newSourceChanges = uniqTextChangesWithTrees.flatMap { case (textChange, tree) =>
-        if (tree.pos.source.file.name == oldName + ".scala") {
+      val newSourceChanges = textChangesWithTrees.flatMap { case (textChange, tree) =>
+        if (tree.pos.source.file.name == singleTreeSelection.name + ".scala") {
           Some(RenameSourceFileChange(tree.pos.source.file, newName + ".scala"))
         } else {
           None
         }
       }.distinct
 
+      val textChanges = textChangesWithTrees.map(_._1)
+
       textChanges ::: newSourceChanges
     }
 
-    trace(s"Old name is $oldName")
-    if (oldName == newName) Right(Nil)
+    trace(s"Old name is ${singleTreeSelection.name}")
+    if (singleTreeSelection.name == newName) Right(Nil)
     else Right(generateChanges)
   }
 }

--- a/src/test/scala/scala/tools/refactoring/tests/analysis/DeclarationIndexTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/analysis/DeclarationIndexTest.scala
@@ -25,9 +25,8 @@ class DeclarationIndexTest extends TestHelper with GlobalIndexes with TreeAnalys
     index = GlobalIndex(List(CompilationUnitIndex(tree)))
 
     val firstSelected = {
-      val start = commentSelectionStart(src)
-      val end   = commentSelectionEnd(src)
-      FileSelection(tree.pos.source.file, tree, start, end)
+      val textSelection = TextSelections.extractOne(src)
+      FileSelection(tree.pos.source.file, tree, textSelection.from, textSelection.to)
     }.selectedTopLevelTrees.head
 
     if(m.isDefinedAt(firstSelected)) {

--- a/src/test/scala/scala/tools/refactoring/tests/analysis/ImportAnalysisTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/analysis/ImportAnalysisTest.scala
@@ -9,7 +9,7 @@ class ImportAnalysisTest extends TestHelper with ImportAnalysis {
 
   @Test
   def importTrees() = global.ask { () =>
-    val s = toSelection("""
+    val tree = treeFrom("""
     import scala.collection.immutable.{LinearSeq, _}
 
     object O{
@@ -23,13 +23,13 @@ class ImportAnalysisTest extends TestHelper with ImportAnalysis {
     }
     """)
 
-    val it = buildImportTree(s.root)
+    val it = buildImportTree(tree)
     assertEquals("{scala.collection.immutable.List{scala.`package`._{scala.Predef._{scala.collection.immutable.LinearSeq{scala.collection.immutable._{scala.math._{}, scala.collection.mutable._{O.a{}}}}}}}}", it.toString())
   }
 
   @Test
   def isImported() = global.ask { () =>
-    val s = toSelection("""
+    val tree = treeFrom("""
     import scala.math.E
 
     object O{
@@ -40,10 +40,10 @@ class ImportAnalysisTest extends TestHelper with ImportAnalysis {
     }
     """)
 
-    val it = buildImportTree(s.root)
-    val piRef = findSymTree(s.root, "value Pi")
-    val eRef = findSymTree(s.root, "value E")
-    val fnDef = findSymTree(s.root, "method fn")
+    val it = buildImportTree(tree)
+    val piRef = findSymTree(tree, "value Pi")
+    val eRef = findSymTree(tree, "value E")
+    val fnDef = findSymTree(tree, "method fn")
 
     assertTrue(it.isImportedAt(piRef.symbol, piRef.pos))
     assertTrue(it.isImportedAt(eRef.symbol, eRef.pos))
@@ -54,7 +54,7 @@ class ImportAnalysisTest extends TestHelper with ImportAnalysis {
 
   @Test
   def isImportedWithWildcard() = global.ask { () =>
-    val s = toSelection("""
+    val tree = treeFrom("""
     object O{
       def fn = {
         import scala.math._
@@ -63,10 +63,10 @@ class ImportAnalysisTest extends TestHelper with ImportAnalysis {
     }
     """)
 
-    val it = buildImportTree(s.root)
-    val piRef = findSymTree(s.root, "value Pi")
-    val eRef = findSymTree(s.root, "value E")
-    val fnDef = findSymTree(s.root, "method fn")
+    val it = buildImportTree(tree)
+    val piRef = findSymTree(tree, "value Pi")
+    val eRef = findSymTree(tree, "value E")
+    val fnDef = findSymTree(tree, "method fn")
 
     assertTrue(it.isImportedAt(piRef.symbol, piRef.pos))
     assertTrue(it.isImportedAt(eRef.symbol, eRef.pos))
@@ -76,18 +76,18 @@ class ImportAnalysisTest extends TestHelper with ImportAnalysis {
 
   @Test
   def predefsAreAlwaysImported() = global.ask { () =>
-    val s = toSelection("""
+    val tree = treeFrom("""
     object O{
       println(123)
       List(1, 2, 3)
     }
     """)
 
-    val it = buildImportTree(s.root)
-    val printlnRef = findSymTree(s.root, "method println")
-    val listRef = findSymTree(s.root, "object List")
+    val it = buildImportTree(tree)
+    val printlnRef = findSymTree(tree, "method println")
+    val listRef = findSymTree(tree, "object List")
 
-    val oDef = findSymTree(s.root, "object O")
+    val oDef = findSymTree(tree, "object O")
 
     assertTrue(it.isImportedAt(printlnRef.symbol, oDef.pos))
     assertTrue(it.isImportedAt(listRef.symbol, oDef.pos))
@@ -96,7 +96,7 @@ class ImportAnalysisTest extends TestHelper with ImportAnalysis {
   @Test
   @Ignore
   def importsOfValueMembers() = global.ask { () =>
-    val s = toSelection("""
+    val tree = treeFrom("""
     package pkg
     object O{
       val a = new{ val b = 1 }
@@ -107,11 +107,11 @@ class ImportAnalysisTest extends TestHelper with ImportAnalysis {
     }
     """)
 
-    val it = buildImportTree(s.root)
-    val bRef = findSymTree(findSymTree(s.root, "method fn"), "value b")
+    val it = buildImportTree(tree)
+    val bRef = findSymTree(findSymTree(tree, "method fn"), "value b")
 
-    val oDef = findSymTree(s.root, "object O")
-    val aDef = findSymTree(s.root, "value a")
+    val oDef = findSymTree(tree, "object O")
+    val aDef = findSymTree(tree, "value a")
 
     assertFalse(it.isImportedAt(bRef.symbol, oDef.pos))
     assertFalse(it.isImportedAt(bRef.symbol, aDef.pos))

--- a/src/test/scala/scala/tools/refactoring/tests/common/InsertionPositionsTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/common/InsertionPositionsTest.scala
@@ -7,6 +7,7 @@ import scala.tools.refactoring.tests.util.TestHelper
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import scala.tools.refactoring.tests.util.TextSelections
 
 class InsertionPositionsTest extends TestHelper with InsertionPositions with Selections {
   import global._
@@ -18,9 +19,8 @@ class InsertionPositionsTest extends TestHelper with InsertionPositions with Sel
   implicit class StringToSelection(src: String) {
     val root = treeFrom(src)
     val selection = {
-      val start = commentSelectionStart(src)
-      val end = commentSelectionEnd(src)
-      FileSelection(root.pos.source.file, root, start, end)
+      val textSelection = TextSelections.extractOne(src)
+      FileSelection(root.pos.source.file, root, textSelection.from, textSelection.to)
     }
 
     def inScope(mkScope: Selection => Tree) = {

--- a/src/test/scala/scala/tools/refactoring/tests/common/SelectionDependenciesTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/common/SelectionDependenciesTest.scala
@@ -3,6 +3,7 @@ package scala.tools.refactoring.tests.common
 import scala.tools.refactoring.tests.util.TestHelper
 import org.junit.Assert._
 import scala.tools.refactoring.common.Selections
+import scala.tools.refactoring.tests.util.TextSelections
 
 class SelectionDependenciesTest extends TestHelper with Selections {
   import global._
@@ -10,9 +11,8 @@ class SelectionDependenciesTest extends TestHelper with Selections {
   implicit class StringToSel(src: String) {
     val root = treeFrom(src)
     val selection = {
-      val start = commentSelectionStart(src)
-      val end = commentSelectionEnd(src)
-      FileSelection(root.pos.source.file, root, start, end)
+      val textSelection = TextSelections.extractOne(src)
+      FileSelection(root.pos.source.file, root, textSelection.from, textSelection.to)
     }
   }
 

--- a/src/test/scala/scala/tools/refactoring/tests/common/SelectionPropertiesTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/common/SelectionPropertiesTest.scala
@@ -4,15 +4,15 @@ import scala.tools.refactoring.common.Selections
 import scala.tools.refactoring.tests.util.TestHelper
 
 import org.junit.Assert._
+import scala.tools.refactoring.tests.util.TextSelections
 
 class SelectionPropertiesTest extends TestHelper with Selections {
 
   implicit class StringToSel(src: String) {
     val root = treeFrom(src)
     val selection = {
-      val start = commentSelectionStart(src)
-      val end = commentSelectionEnd(src)
-      FileSelection(root.pos.source.file, root, start, end)
+      val textSelection = TextSelections.extractOne(src)
+      FileSelection(root.pos.source.file, root, textSelection.from, textSelection.to)
     }
   }
 

--- a/src/test/scala/scala/tools/refactoring/tests/common/SelectionsTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/common/SelectionsTest.scala
@@ -7,14 +7,14 @@ package tests.common
 
 import tests.util.TestHelper
 import org.junit.Assert._
+import scala.tools.refactoring.tests.util.TextSelections
 
 class SelectionsTest extends TestHelper {
 
   private def getIndexedSelection(src: String) = {
     val tree = treeFrom(src)
-    val start = commentSelectionStart(src)
-    val end   = commentSelectionEnd(src)
-    FileSelection(tree.pos.source.file, tree, start, end)
+    val textSelection = TextSelections.extractOne(src)
+    FileSelection(tree.pos.source.file, tree, textSelection.from, textSelection.to)
   }
 
   def selectedLocalVariable(expected: String, src: String) = {

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/MarkOccurrencesTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/MarkOccurrencesTest.scala
@@ -438,4 +438,46 @@ class MarkOccurrencesTest extends TestHelper {
       def doit = for (#(x) <- Seq(#(1), #(2))) yield x
     }
     """)
+
+  @Test
+  def trivialObject() = markOccurrences("""
+    object DasDing/*<-cursor-3*/
+    """, """
+    object #######/*<-cursor-3*/
+    """)
+
+  @Test
+  def nextToTrivialObject() = markOccurrences("""
+    object /*<-*/KnappDaneben
+    """, """
+    object /*<-*/KnappDaneben
+    """)
+
+  @Test
+  def onObjectKeyword() = markOccurrences("""
+    object/*<-cursor*/ WiederVorbei
+    """, """
+    object/*<-cursor*/ WiederVorbei
+    """)
+
+  @Test
+  def onEndOfBacktickAbomination() = markOccurrences("""
+    object `/*<!!-<.>-!!>*/`/*<-cursor*/
+    """, """
+    object #################/*<-cursor*/
+    """)
+
+  @Test
+  def onStartOfBacktickAbomination() = markOccurrences("""
+    object /*cursor->*/`/*<!!-<.>-!!>*/`
+    """, """
+    object /*cursor->*/#################
+    """)
+
+  @Test
+  def inTheCenterOfBacktickAbomination() = markOccurrences("""
+    object /*8-cursor->*/`/*<!!-<.>-!!>*/`
+    """, """
+    object /*8-cursor->*/#################
+    """)
 }

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/MarkOccurrencesTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/MarkOccurrencesTest.scala
@@ -8,6 +8,7 @@ package tests.implementations
 import implementations.MarkOccurrences
 import tests.util.TestHelper
 import org.junit.Assert._
+import scala.tools.refactoring.tests.util.TextSelections
 
 class MarkOccurrencesTest extends TestHelper {
   outer =>
@@ -28,11 +29,10 @@ class MarkOccurrencesTest extends TestHelper {
       }
     }
 
-    val start = original.indexOf(startPattern) + startPattern.length
-    val end   = original.indexOf(endPattern)
 
     val (_, positions) = global.ask { () =>
-      markOccurrences.occurrencesOf(tree.pos.source.file, start, end)
+      val textSelection = TextSelections.extractOne(original)
+      markOccurrences.occurrencesOf(tree.pos.source.file, textSelection.from, textSelection.to)
     }
 
     val res = positions.foldLeft(original) {

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/MarkOccurrencesTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/MarkOccurrencesTest.scala
@@ -174,10 +174,10 @@ class MarkOccurrencesTest extends TestHelper {
     """,
     """
     import java.io./*(*/####/*)*/
-    import java.io.{#########}
+    import java.io.{#### => F}
     object Whatever {
       val sep1 = ####.pathSeparator
-      val sep2 = #.pathSeparator
+      val sep2 = F.pathSeparator
     }
     """)
 
@@ -191,10 +191,10 @@ class MarkOccurrencesTest extends TestHelper {
     }
     """,
     """
-    import java.io.####
-    import java.io.{#########}
+    import java.io.File
+    import java.io.{File => #}
     object Whatever {
-      val sep1 = ####.pathSeparator
+      val sep1 = File.pathSeparator
       val sep2 = /*(*/#/*)*/.pathSeparator
     }
     """)

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/MarkOccurrencesTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/MarkOccurrencesTest.scala
@@ -480,4 +480,32 @@ class MarkOccurrencesTest extends TestHelper {
     """, """
     object /*8-cursor->*/#################
     """)
+
+   @Test
+   def onPlusOperator() = markOccurrences("""
+     object Abacus {
+       val a = 4 +/*<-cursor*/ 3
+       val b = a * 5 + 10
+     }
+   """, """
+     object Abacus {
+       val a = 4 #/*<-cursor*/ 3
+       val b = a * 5 # 10
+     }
+   """)
+
+   @Test
+   def onConsOperator() = markOccurrences("""
+     object Constanzia {
+       val a = 1 :: 2 :: 3 :: Nil
+       val b = '1' :: '2' :: Nil
+       val c = 1.1 :: 2.2 ::/*<-cursor*/ Nil
+     }
+   """, """
+     object Constanzia {
+       val a = 1 ## 2 ## 3 ## Nil
+       val b = '1' ## '2' ## Nil
+       val c = 1.1 ## 2.2 ##/*<-cursor*/ Nil
+     }
+   """)
 }

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/MarkOccurrencesTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/MarkOccurrencesTest.scala
@@ -403,7 +403,6 @@ class MarkOccurrencesTest extends TestHelper {
     }
     """)
 
-  @Ignore
   @Test
   def namedArg() = markOccurrences("""
     class Updateable { def update(/*(*/what/*)*/: Int, rest: Int) = 0 }
@@ -418,7 +417,7 @@ class MarkOccurrencesTest extends TestHelper {
 
     class NamedParameter {
       val up = new Updateable
-      up(########) = 2
+      up(#### = 1) = 2
     }
     """)
 

--- a/src/test/scala/scala/tools/refactoring/tests/transformation/TransformableSelectionTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/transformation/TransformableSelectionTest.scala
@@ -3,6 +3,7 @@ package scala.tools.refactoring.tests.transformation
 import scala.tools.refactoring.tests.util.TestHelper
 import org.junit.Assert._
 import scala.tools.refactoring.transformation.TransformableSelections
+import scala.tools.refactoring.tests.util.TextSelections
 
 class TransformableSelectionTest extends TestHelper with TransformableSelections {
   import global._
@@ -12,11 +13,10 @@ class TransformableSelectionTest extends TestHelper with TransformableSelections
     "object O { /*(*/println(123)/*)*/ }".selection.selectedTopLevelTrees.head
 
   implicit class StringToSel(src: String) {
-    val root = treeFrom(src)
-    val selection = {
-      val start = commentSelectionStart(src)
-      val end = commentSelectionEnd(src)
-      FileSelection(root.pos.source.file, root, start, end)
+    lazy val root = treeFrom(src)
+    lazy val selection = {
+      val textSelection = TextSelections.extractOne(src)
+      FileSelection(root.pos.source.file, root, textSelection.from, textSelection.to)
     }
 
     def assertReplacement(mkTrans: Selection => Transformation[Tree, Tree]) = {

--- a/src/test/scala/scala/tools/refactoring/tests/util/SourceWithMarkerTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/util/SourceWithMarkerTest.scala
@@ -376,9 +376,7 @@ class SourceWithMarkerTest {
     assertEquals(";", src.moveMarker('>' ~ commentsAndSpaces ~ "val x1 = " ~ curlyBracesWithContents).currentStr)
 
     val res = src.applyMovement(until(";", skipping = curlyBracesWithContents)).flatMap { src =>
-      println(src)
       src.applyMovement(until("x", skipping = curlyBracesWithContents).backward).flatMap { src =>
-        println(src)
         src.applyMovement("x1 = ")
       }
     }

--- a/src/test/scala/scala/tools/refactoring/tests/util/TextSelections.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/util/TextSelections.scala
@@ -1,0 +1,81 @@
+package scala.tools.refactoring.tests.util
+
+import scala.collection.immutable.Queue
+import scala.annotation.tailrec
+
+/**
+ * Helper class to extract selections from unit test input.
+ *
+ * The following markers are supported:
+ *
+ * <ul>
+ *   <li> `/*(*/` - start of the selection
+ *   <li> `/*)*/` - end of the selection
+ *   <li> `/*<-*/` - an empty selection
+ * </ul>
+ */
+object TextSelections {
+  final val StartMarker = "/*(*/"
+  final val EndMarker = "/*)*/"
+  final val EmptyMarker = "/*<-*/"
+
+  final case class Range(from: Int, to: Int) {
+    require(from <= to)
+    require(from >= 0)
+  }
+
+  /**
+   * Extracts a single selection from the given text
+   *
+   * @throws IllegalArgumentException unless exactly one selection is found
+   */
+  def extractOne(text: String): Range = {
+    extract(text) match {
+      case Seq(range) => range
+
+      case other =>
+        throw new IllegalArgumentException(
+            s"Expected exactly one selection, but got $other\n" +
+            s"  text:\n" +
+            text.lines.map("    " + _).mkString("\n"))
+    }
+  }
+
+  private def extractStartToEndSelections(text: String): Seq[Range] = {
+    @tailrec
+    def go(acc: Queue[Range] = Queue()): Queue[Range] = {
+      val offset = acc.lastOption.map(_.to + EndMarker.length).getOrElse(0)
+
+      text.indexOf(StartMarker, offset) match {
+        case -1 => acc
+        case startMarkerPos =>
+          val from = startMarkerPos + StartMarker.length
+
+          text.indexOf(EndMarker, offset) match {
+            case -1 => acc
+            case to =>
+              go(acc :+ Range(from, to))
+          }
+      }
+    }
+
+    go()
+  }
+
+  private def extractEmptyMarkerSelections(text: String): Seq[Range] = {
+    @tailrec
+    def go(acc: Queue[Range] = Queue()): Queue[Range] = {
+      val offset = acc.lastOption.map(_.to + 1).getOrElse(0)
+      val pos = text.indexOf(EmptyMarker, offset)
+
+      if (pos < 0) acc
+      else go(acc :+ Range(pos, pos))
+    }
+
+    go()
+  }
+
+  private def extract(text: String): Seq[Range] = {
+    extractStartToEndSelections(text) ++ extractEmptyMarkerSelections(text)
+  }
+}

--- a/src/test/scala/scala/tools/refactoring/tests/util/TextSelectionsTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/util/TextSelectionsTest.scala
@@ -1,0 +1,29 @@
+package scala.tools.refactoring.tests.util
+
+import org.junit.Test
+import org.junit.Assert.assertEquals
+import TextSelections.Range
+
+
+class TextSelectionsTest {
+  @Test(expected = classOf[IllegalArgumentException])
+  def testWithEmptyString(): Unit = {
+    TextSelections.extractOne("")
+  }
+
+  @Test(expected = classOf[IllegalArgumentException])
+  def testWithMoreThanOneSelection(): Unit = {
+    TextSelections.extractOne("/*(*/ /*)*/ /*<-*/")
+  }
+
+  @Test
+  def testWithOneEmptySelection(): Unit = {
+    assertEquals(Range(0, 0), TextSelections.extractOne("/*<-*/"))
+    assertEquals(Range(5, 5), TextSelections.extractOne("/*(*//*)*/"))
+  }
+
+  @Test
+  def testWithOneNormalSelection(): Unit = {
+    assertEquals(Range(5, 6), TextSelections.extractOne("/*(*/ /*)*/)"))
+  }
+}

--- a/src/test/scala/scala/tools/refactoring/tests/util/TextSelectionsTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/util/TextSelectionsTest.scala
@@ -26,4 +26,30 @@ class TextSelectionsTest {
   def testWithOneNormalSelection(): Unit = {
     assertEquals(Range(5, 6), TextSelections.extractOne("/*(*/ /*)*/)"))
   }
+
+  @Test
+  def testWithOneSetCursorFromRightSelection(): Unit = {
+    assertEquals(Range(5, 6), TextSelections.extractOne("012345/*<-cursor*/"))
+    assertEquals(Range(5, 6), TextSelections.extractOne("012345/*<-cursor-0*/"))
+    assertEquals(Range(4, 5), TextSelections.extractOne("012345/*<-cursor-1*/"))
+    assertEquals(Range(3, 4), TextSelections.extractOne("012345/*<-cursor-2*/"))
+  }
+
+  @Test(expected = classOf[IllegalArgumentException])
+  def testWithCursorInvalidCursorFromRightSelection(): Unit = {
+    TextSelections.extractOne("0123/*<-cursor-18*/")
+  }
+
+  @Test
+  def testWithOneSetCursorFromLeftSelection(): Unit = {
+    assertEquals(Range(14, 15), TextSelections.extractOne("  /*cursor->*/45678"))
+    assertEquals(Range(14, 15), TextSelections.extractOne("/*0-cursor->*/45678"))
+    assertEquals(Range(15, 16), TextSelections.extractOne("/*1-cursor->*/45678"))
+    assertEquals(Range(16, 17), TextSelections.extractOne("/*2-cursor->*/45678"))
+  }
+
+  @Test(expected = classOf[IllegalArgumentException])
+  def testWithCursorInvalidCursorFromLeftSelection(): Unit = {
+    TextSelections.extractOne("/*cursor->*/")
+  }
 }


### PR DESCRIPTION
Consult [#1002698](https://app.assembla.com/spaces/scala-ide/tickets/1002698-markoccurences-and-rename-refactoring-should-share-common-implementation-for--quot-find-all-occurences-quot-/details#) as well as the commit messages for further background.