### PR TITLE
Swallow exception after nameString call

### DIFF
--- a/src/main/scala/scala/tools/refactoring/analysis/CompilationUnitDependencies.scala
+++ b/src/main/scala/scala/tools/refactoring/analysis/CompilationUnitDependencies.scala
@@ -122,7 +122,11 @@ trait CompilationUnitDependencies extends CompilerApiExtensions with ScalaVersio
     def qualifierIsEnclosingPackage(t: Select) = {
       enclosingPackage(wholeTree, t.pos) match {
         case pkgDef: PackageDef =>
-          t.qualifier.nameString == pkgDef.nameString
+          try t.qualifier.nameString == pkgDef.nameString
+          catch {
+            // nameString throws an exception if no name is available
+            case _: UnsupportedOperationException => false
+          }
         case _ => false
       }
     }
@@ -486,4 +490,3 @@ trait CompilationUnitDependencies extends CompilerApiExtensions with ScalaVersio
     deps.filterNot(_.symbol.hasPackageFlag).toList
   }
 }
-

--- a/src/main/scala/scala/tools/refactoring/common/EnrichedTrees.scala
+++ b/src/main/scala/scala/tools/refactoring/common/EnrichedTrees.scala
@@ -364,7 +364,7 @@ trait EnrichedTrees extends TracingImpl {
         case t: NameTree => t.nameString
         case t: TypeTree => t.symbol.nameString // FIXME: use something better
         case ImportSelectorTree(NameTree(name), _) => name.toString
-        case _ => sys.error("Tree " + getSimpleClassName(t) + " does not have a name.")
+        case _ => throw new UnsupportedOperationException("Tree " + getSimpleClassName(t) + " does not have a name.")
       }
     }
   }


### PR DESCRIPTION
As the ticket shows, `nameString` can throw an exception. The method
should return an Option but I'm to lazy to refactor the code. Also,
using Option everywhere would lead to quite some overhead, I assume the
few cases that throw an exception are the lesser evil.

Fix #1002711