### PR TITLE
Fix renaming identifiers starting with '_'

### DIFF
--- a/src/main/scala/scala/tools/refactoring/util/SourceWithMarker.scala
+++ b/src/main/scala/scala/tools/refactoring/util/SourceWithMarker.scala
@@ -184,9 +184,11 @@ object SourceWithMarker {
 
     def or[MovementT <: SimpleMovement](mvnt1: MovementT, mvnt2: MovementT)(sourceWithMarker: SourceWithMarker): Seq[Int] = {
       val res1 = mvnt1.compute(sourceWithMarker)
+      val res2 = mvnt2.compute(sourceWithMarker)
 
-      if (res1.isEmpty) mvnt2.compute(sourceWithMarker)
-      else res1
+      (res1 ++ res2).sortBy { newMarker =>
+        -math.abs((sourceWithMarker.marker - newMarker))
+      }
     }
 
     def repeat[MovementT <: SimpleMovement](mvnt: MovementT)(sourceWithMarker: SourceWithMarker): Seq[Int] = {

--- a/src/main/scala/scala/tools/refactoring/util/SourceWithMarker.scala
+++ b/src/main/scala/scala/tools/refactoring/util/SourceWithMarker.scala
@@ -672,11 +672,13 @@ object SourceWithMarker {
       }
     }
 
+    private val upper = charOfClass(c => c.isUpper || c == '_')
+
     val idrest = (letter | digit).zeroOrMore ~ ('_' ~ op).zeroOrMore
 
     val varid = charOfClass(_.isLower) ~ idrest
 
-    val plainid = (charOfClass(_.isUpper) ~ idrest) | varid | op
+    val plainid = (upper ~ idrest) | varid | op
 
     val symbolLiteral = ''' ~ plainid
 

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
@@ -4031,4 +4031,56 @@ class Blubb
       class ImInnocent
     }""" -> TaggedAsGlobalRename
   } prepareAndApplyRefactoring(prepareAndRenameTo("Hatter"))
+
+
+  /*
+   * See Assembla Ticket 1002674
+   */
+  @Test
+  def testRenamePrivateVarWithUnderscore1002674() = new FileSet {
+    """
+    object Bug {
+      private var /*(*/_tryRenameMe/*)*/ = 0
+      _tryRenameMe = _tryRenameMe + 1
+    }
+    """ becomes
+    """
+    object Bug {
+      private var /*(*/ups/*)*/ = 0
+      ups = ups + 1
+    }
+    """ -> TaggedAsLocalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("ups"))
+
+  @Test
+  def testRenameVarWithUnderscore1002674() = new FileSet {
+    """
+    object Bug1 {
+      var /*(*/_tryRenameMe/*)*/ = 0
+      _tryRenameMe = _tryRenameMe + 1
+    }
+    """ becomes
+    """
+    object Bug1 {
+      var /*(*/ups/*)*/ = 0
+      ups = ups + 1
+    }
+    """ -> TaggedAsGlobalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("ups"))
+
+  @Test
+  def testRenameValWithUnderscore1002674() = new FileSet {
+    """
+    object Bug2 {
+      val /*(*/_tryRenameMe/*)*/ = 0
+      val x = _tryRenameMe
+    }
+    """ becomes
+    """
+    object Bug2 {
+      val /*(*/ups/*)*/ = 0
+      val x = ups
+    }
+    """ -> TaggedAsGlobalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("ups"))
 }

--- a/src/test/scala/scala/tools/refactoring/tests/util/SourceWithMarkerTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/util/SourceWithMarkerTest.scala
@@ -562,6 +562,16 @@ class SourceWithMarkerTest {
     }
   }
 
+  @Test
+  def testMakeSureThatSourceWithMarkerOrIsGreedy(): Unit = {
+    def performTest(toConsume: String, mvnt: Movement): Unit = {
+      runCoveredStringTest(toConsume, 0, mvnt, toConsume, false)
+    }
+
+    performTest("aa", 'a' || "aa")
+    performTest("abababc", 'a' || "ab".zeroOrMore || ("ab".atLeastOnce ~ 'c'))
+  }
+
   private implicit class SourceWithMarkerOps(underlying: SourceWithMarker) {
     def currentStr = underlying.current.toString
   }

--- a/src/test/scala/scala/tools/refactoring/tests/util/SourceWithMarkerTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/util/SourceWithMarkerTest.scala
@@ -371,6 +371,11 @@ class SourceWithMarkerTest {
     runSimpleIdTest("+//<-trap", "+")
     runSimpleIdTest("+/*trap*/", "+")
     runSimpleIdTest("+/*<-trap*/", "+")
+    runSimpleIdTest("_id", "_id")
+    runSimpleIdTest("id_id", "id_id")
+    runSimpleIdTest("_id_id_id", "_id_id_id")
+    runSimpleIdTest("dot_product_*", "dot_product_*")
+    runSimpleIdTest("__system", "__system")
 
     val srcIdInMlComment = SourceWithMarker("/*::*/", 3)
     val srcIdInSlComment = SourceWithMarker("//::", 3)


### PR DESCRIPTION
See [ticket 1002674](https://app.assembla.com/spaces/scala-ide/tickets/1002674-cannot-rename-private-var-starting-with---39-_--39-/details#) to understand the problem. Consult the commit messages to comprehend the solution ;-).