### PR TITLE
Prework for 1002704 assembla ticket

### DIFF
--- a/src/main/scala/scala/tools/refactoring/implementations/oimports/NotPackageImportParticipants.scala
+++ b/src/main/scala/scala/tools/refactoring/implementations/oimports/NotPackageImportParticipants.scala
@@ -190,7 +190,7 @@ class NotPackageImportParticipants[O <: OrganizeImports](val organizeImportsInst
         }
         (imp, usedSelectors)
     }.collect {
-      case (imp, selectors @ h :: _) => imp.copy(selectors = selectors).setPos(imp.pos)
+      case (imp, selectors @ h :: _) => imp.copy(selectors = selectors).setPos(imp.pos).setSymbol(imp.symbol).setType(imp.tpe)
     }.toList
   }
 
@@ -201,9 +201,7 @@ class NotPackageImportParticipants[O <: OrganizeImports](val organizeImportsInst
     protected def doApply(trees: List[Import]) = trees.map { imp =>
       val wild = imp.selectors.find(_.name == nme.WILDCARD)
       if (wild.nonEmpty) {
-        val newImp = imp.copy(selectors = imp.selectors.filter { renamed }.sortBy { _.name } ::: wild.toList).setPos(imp.pos)
-        newImp.symbol = imp.symbol
-        newImp
+        imp.copy(selectors = imp.selectors.filter { renamed }.sortBy { _.name } ::: wild.toList).setPos(imp.pos).setSymbol(imp.symbol).setType(imp.tpe)
       } else
         imp
     }.groupBy {

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
@@ -5309,4 +5309,37 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
     }
     """ isNotModified
   } applyRefactoring organizeCustomized(dependencies = Dependencies.RecomputeAndModify)
+
+  @Test
+  def shouldNotRemoveImportWhenPathIsPartiallyGiven_v1() = new FileSet {
+    """
+    /*<-*/
+    package acme
+
+    object Main extends App {
+      import scala.concurrent.duration
+      import scala.concurrent.duration.FiniteDuration
+
+      val d1: FiniteDuration = ???
+      val d2: duration.FiniteDuration = ???
+    }
+    """ isNotModified
+  } applyRefactoring organizeCustomized(dependencies = Dependencies.RecomputeAndModify)
+
+  @Ignore("FIXME")
+  @Test
+  def shouldNotRemoveImportWhenPathIsPartiallyGiven_v2() = new FileSet {
+    """
+    /*<-*/
+    package acme
+
+    import scala.concurrent.duration
+    import scala.concurrent.duration.FiniteDuration
+
+    object Main extends App {
+      val d1: FiniteDuration = ???
+      val d2: duration.FiniteDuration = ???
+    }
+    """ isNotModified
+  } applyRefactoring organizeCustomized(dependencies = Dependencies.RecomputeAndModify)
 }


### PR DESCRIPTION
Adds tests for problem described in #1002704 originally related to
package scope. Tests cover import pattern in other scope.

The package scope is not fixed. Reason(s):
- `addToResult()` of `CompilationUnitDependencies` groups `Selects` with
  key made of string so loses info about original positions of transformed
  `TypeTrees` and there is no way to check how type has been declared in
  source file