### PR TITLE
Be more careful before rewriting imports in `MoveClass` 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ bin
 **/*.tmpBin
 *.swp
 .ensime*
+.idea
+*.iml

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/MoveClassTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/MoveClassTest.scala
@@ -1446,4 +1446,54 @@ object /*(*/Arith/*)*/ {
     }
     """
   } applyRefactoring(moveTo("com.github.mlangc.experiments.v1.dst.pkg"))
+
+  /*
+   * See Assembla Ticket 1002786
+   */
+  @Test
+  def moveClassThatHasDoppelgangerInDifferentPackage1002786() = new FileSet {
+    """
+    package com.github.mlangc.experiments.src.pkg
+
+    class /*(*/MoveMe/*)*/
+    """ becomes
+    """
+    package com.github.mlangc.experiments.dst.pkg
+
+    class /*(*/MoveMe/*)*/
+    """
+
+    """
+    package com.github.mlangc.experiments.trap
+
+    class MoveMe {
+      def trapped: Int = 42
+    }
+    """ isNotModified()
+
+    """
+    package com.github.mlangc.experiments
+
+    import com.github.mlangc.experiments.src.pkg.MoveMe
+
+    class Bug {
+      val noTrap = new MoveMe
+
+      import com.github.mlangc.experiments.trap.MoveMe
+      val trap = new MoveMe().trapped
+    }
+    """ becomes
+    """
+    package com.github.mlangc.experiments
+
+    import com.github.mlangc.experiments.dst.pkg.MoveMe
+
+    class Bug {
+      val noTrap = new MoveMe
+
+      import com.github.mlangc.experiments.trap.MoveMe
+      val trap = new MoveMe().trapped
+    }
+    """
+  } applyRefactoring(moveTo("com.github.mlangc.experiments.dst.pkg"))
 }


### PR DESCRIPTION
See [#1002786](https://scala-ide-portfolio.assembla.com/spaces/scala-ide/tickets/1002786-move-class-is-mislead-by-types-with-same-name-from-different-packages/details#).