### PR TITLE
Special treatment for self references

### DIFF
--- a/src/main/scala/scala/tools/refactoring/common/Selections.scala
+++ b/src/main/scala/scala/tools/refactoring/common/Selections.scala
@@ -5,15 +5,16 @@
 package scala.tools.refactoring
 package common
 
-import collection.mutable.ListBuffer
+import scala.collection.mutable.ListBuffer
 import scala.reflect.internal.util.RangePosition
+import scala.tools.refactoring.util.SourceHelpers
 
 trait Selections extends TreeTraverser with common.EnrichedTrees {
 
   this: CompilerAccess =>
 
   import global._
-  import PartialFunction._
+  import scala.PartialFunction._
 
   trait Selection {
 
@@ -111,7 +112,7 @@ trait Selections extends TreeTraverser with common.EnrichedTrees {
      */
     private def eventuallyAdaptSelectionForSelfReferences(selected: SymTree, root: Tree): SymTree = {
       def isSelfReference(tis: This) = {
-        tis.pos.isRange && stringCoveredBy(tis.pos) != "this"
+        SourceHelpers.stringCoveredBy(tis.pos).exists(_ != "this")
       }
 
       selected match {
@@ -127,10 +128,6 @@ trait Selections extends TreeTraverser with common.EnrichedTrees {
 
         case _ => selected
       }
-    }
-
-    private def stringCoveredBy(pos: Position): String = {
-      new String(pos.source.content.slice(pos.start, pos.end))
     }
 
     /**

--- a/src/main/scala/scala/tools/refactoring/common/Selections.scala
+++ b/src/main/scala/scala/tools/refactoring/common/Selections.scala
@@ -103,6 +103,12 @@ trait Selections extends TreeTraverser with common.EnrichedTrees {
       candidate.map(eventuallyAdaptSelectionForSelfReferences(_, root))
     }
 
+    /*
+     * Usages of self references aka `class Foo { self =>` are represented exaclty like `this`
+     * in ASTs and can only be distinguished by looking into the source code. To work around
+     * this limitation, we actually select the definition of the `self` reference in
+     * this case.
+     */
     private def eventuallyAdaptSelectionForSelfReferences(selected: SymTree, root: Tree): SymTree = {
       def isSelfReference(tis: This) = {
         tis.pos.isRange && stringCoveredBy(tis.pos) != "this"

--- a/src/main/scala/scala/tools/refactoring/common/Selections.scala
+++ b/src/main/scala/scala/tools/refactoring/common/Selections.scala
@@ -104,7 +104,7 @@ trait Selections extends TreeTraverser with common.EnrichedTrees {
     }
 
     /*
-     * Usages of self references aka `class Foo { self =>` are represented exaclty like `this`
+     * Usages of self references aka `class Foo { self =>` are represented exactly like `this`
      * in ASTs and can only be distinguished by looking into the source code. To work around
      * this limitation, we actually select the definition of the `self` reference in
      * this case.

--- a/src/main/scala/scala/tools/refactoring/implementations/MarkOccurrences.scala
+++ b/src/main/scala/scala/tools/refactoring/implementations/MarkOccurrences.scala
@@ -80,7 +80,7 @@ trait MarkOccurrences extends common.Selections with analysis.Indexes with commo
       }
 
       def isSelfReference(tis: This): Boolean = {
-        tis.symbol == owningClassSymbol && tis.pos.isRange && stringCoveredBy(tis.pos) != "this"
+        tis.symbol == owningClassSymbol && SourceHelpers.stringCoveredBy(tis.pos).exists(_ != "this")
       }
 
       val referencesViaThis = parent.collect {
@@ -104,10 +104,6 @@ trait MarkOccurrences extends common.Selections with analysis.Indexes with commo
 
     case _ =>
       None
-  }
-
-  private def stringCoveredBy(pos: Position): String = {
-    new String(pos.source.content.slice(pos.start, pos.end))
   }
 
   protected def findOccurrences(selection: SingleTreeSelection): List[(RangePosition, Tree)] = {

--- a/src/main/scala/scala/tools/refactoring/implementations/MarkOccurrences.scala
+++ b/src/main/scala/scala/tools/refactoring/implementations/MarkOccurrences.scala
@@ -13,6 +13,8 @@ import scala.tools.refactoring.util.SourceWithMarker.Movements
 import scala.util.control.NonFatal
 import scala.tools.refactoring.util.SourceWithMarker.Movement
 import scala.tools.refactoring.common.TracingHelpers
+import scala.tools.refactoring.util.SourceHelpers
+import scala.tools.refactoring.util.SourceWithSelection
 
 trait MarkOccurrences extends common.Selections with analysis.Indexes with common.CompilerAccess with common.EnrichedTrees with common.InteractiveScalaCompiler {
   import global._
@@ -33,9 +35,9 @@ trait MarkOccurrences extends common.Selections with analysis.Indexes with commo
         // We try to read the old name from the name position of the declaration, since this seems to be the most
         // reliable strategy that also works well in the presence of `backtick-identifiers`.
         declaration.namePosition() match {
-          case rp: RangePosition => 
+          case rp: RangePosition =>
             Some(rp.source.content.slice(rp.start, rp.end).mkString(""))
-          case op => 
+          case op =>
             trace(s"Expected range position, but found $op")
             None
         }
@@ -59,7 +61,61 @@ trait MarkOccurrences extends common.Selections with analysis.Indexes with commo
     }
   }
 
+  /*
+   * Self references aka `class Foo { self =>` need special treatment, because their representation in typed
+   * ASTs is incomplete. While `self =>` is represented as a synthetic `ValDef`, usages of the named reference
+   * can not be distinguished from the `this` keyword, without looking into the source code. This method
+   * takes care of this special case.
+   */
+  private def findOccurrencesForSelfReference(selection: SingleTreeSelection): Option[List[(RangePosition, Tree)]] = {
+    def root = selection.root
+    def selected = selection.selected
+    val parent = findParentOfPotentialSelfReference(selected, root)
+
+    parent.map { parent =>
+      val owningClassSymbol = {
+        parent.symbol.ownersIterator.find(_.isClass).getOrElse {
+          throw new IllegalStateException(s"Could not find enclosing class symbol for $parent")
+        }
+      }
+
+      def isSelfReference(tis: This): Boolean = {
+        tis.symbol == owningClassSymbol && tis.pos.isRange && stringCoveredBy(tis.pos) != "this"
+      }
+
+      val referencesViaThis = parent.collect {
+        case tis: This if isSelfReference(tis) => (tis.pos.asInstanceOf[RangePosition], tis)
+      }
+
+      (selected.pos.asInstanceOf[RangePosition], selected) :: referencesViaThis
+    }
+  }
+
+  protected final def findParentOfPotentialSelfReference(potentialRef: Tree, root: Tree): Option[Template] = potentialRef match {
+    case vd: ValDef if vd.rhs.isEmpty =>
+      val parentTemplate = {
+        root.find {
+          case tmpl: Template if tmpl.self == vd => true
+          case _ => false
+        }
+      }
+
+      parentTemplate.map(_.asInstanceOf[Template])
+
+    case _ =>
+      None
+  }
+
+  private def stringCoveredBy(pos: Position): String = {
+    new String(pos.source.content.slice(pos.start, pos.end))
+  }
+
   protected def findOccurrences(selection: SingleTreeSelection): List[(RangePosition, Tree)] = {
+    findOccurrencesForSelfReference(selection)
+      .getOrElse(findOccurrencesUsingIndex(selection))
+  }
+
+  private def findOccurrencesUsingIndex(selection: SingleTreeSelection): List[(RangePosition, Tree)] = {
     /*
      * A lazy val is represented by a ValDef and an associated DefDef that contains the initialization code.
      * Unfortunately, the Scala compiler does not set modifier positions for the DefDef, which is a problem for us,
@@ -162,11 +218,11 @@ trait MarkOccurrences extends common.Selections with analysis.Indexes with commo
   }
 
   private def traceSelection(selection: FileSelection, selectedTree: Option[Tree], from: Int, to: Int): Unit = {
-    val rawSrc = selection.root.pos.source.content
-    val srcFrom = SourceWithMarker(rawSrc, from)
-    val srcTo = SourceWithMarker(rawSrc, to)
+    def rawSrc = selection.root.pos.source.content
+    def srcFrom = SourceWithMarker(rawSrc, from)
+    def srcTo = SourceWithMarker(rawSrc, to)
 
-    val selectedTreeName = {
+    def selectedTreeName = {
       selectedTree.map { selectedTree =>
         try {
           selectedTree.nameString
@@ -198,15 +254,12 @@ trait MarkOccurrences extends common.Selections with analysis.Indexes with commo
   }
 
   def occurrencesOf(file: tools.nsc.io.AbstractFile, from: Int, to: Int): (Tree, List[Position]) = context("occurrencesOf") {
+
+
     val treeWithOccurences = {
       val selection = new FileSelection(file, global.unitOfFile(file).body, from, to)
-
-      val selectedTree = selection.findSelectedWithPredicate {
-        case (_: global.TypeTree) | (_: global.SymTree) | (_: global.Ident) => true
-        case _ => false
-      } \\ { selectedTree =>
-        traceSelection(selection, selectedTree, from, to)
-      }
+      val selectedTree = selection.selectedSymbolTree
+      traceSelection(selection, selectedTree, from, to)
 
       val selectionOnScalaId = {
         val positionsToCheck = selectedTree.toSeq.flatMap {
@@ -217,11 +270,28 @@ trait MarkOccurrences extends common.Selections with analysis.Indexes with commo
           case other => Seq(other.namePosition())
         }
 
-        positionsToCheck.exists {
-          case rp: RangePosition => rp.start <= from && Movements.id(SourceWithMarker.atStartOf(rp)).exists(_ >= to)
-          case op: OffsetPosition => op.point <= from && Movements.id(SourceWithMarker.atPoint(op)).exists(_ >= to)
-          case _ => false
+        def isPlausible(pos: Position): Boolean = {
+          val src = pos match {
+            case rp: RangePosition => Some(SourceWithMarker.atStartOf(rp))
+            case op: OffsetPosition => Some(SourceWithMarker.atPoint(op))
+            case _ => None
+          }
+
+          src.exists { src =>
+            val selectedId = Movement.coveredString(src, Movements.id)
+            if (selectedId == "") {
+              false
+            } else {
+              if (src.marker <= from && src.marker + selectedId.length >= to) {
+                true
+              } else {
+                SourceHelpers.isRangeWithin(selectedId, SourceWithSelection(src.source, from, to))
+              }
+            }
+          }
         }
+
+        positionsToCheck.exists(isPlausible)
       } \\ { selectionOnScalaId =>
         trace(s"selectionOnScalaId: $selectionOnScalaId")
       }

--- a/src/main/scala/scala/tools/refactoring/implementations/Rename.scala
+++ b/src/main/scala/scala/tools/refactoring/implementations/Rename.scala
@@ -32,6 +32,10 @@ abstract class Rename extends MultiStageRefactoring with MarkOccurrences with Tr
      * we always get a fully initialized index.
      */
     def isLocalRename(t: Tree) = {
+      def isSelfReference = {
+        findParentOfPotentialSelfReference(t, s.root).nonEmpty
+      }
+
       def isLocalSymbol(symbol: Symbol) = {
         def isHiddenOrNoAccessor(symbol: Symbol) = symbol == NoSymbol || symbol.isPrivate
 
@@ -46,6 +50,7 @@ abstract class Rename extends MultiStageRefactoring with MarkOccurrences with Tr
             true
           }
         }
+
 
         val relatedCtor = s.root.find {
           case dd: DefDef if dd.symbol.isConstructor && !dd.mods.isPrivate && !dd.mods.isPrivateLocal =>
@@ -88,10 +93,10 @@ abstract class Rename extends MultiStageRefactoring with MarkOccurrences with Tr
         }
       }
 
-      t.symbol match {
+      isSelfReference || (t.symbol match {
         case null | NoSymbol => true
         case properSymbol => isLocalSymbol(properSymbol)
-      }
+      })
     }
 
     s.selectedSymbolTree match {

--- a/src/main/scala/scala/tools/refactoring/util/SourceHelpers.scala
+++ b/src/main/scala/scala/tools/refactoring/util/SourceHelpers.scala
@@ -1,0 +1,44 @@
+package scala.tools.refactoring.util
+
+import scala.annotation.tailrec
+import scala.math.min
+
+object SourceHelpers {
+  def isRangeWithin(text: String, selection: SourceWithSelection): Boolean = {
+    if (selection.length > text.length || selection.source.length < text.length) {
+      false
+    } else {
+      val maxStepsBack = min(text.length - selection.length, selection.start)
+
+      @tailrec
+      def tryMatchText(stepsBack: Int = 0): Boolean = {
+        if (stepsBack > maxStepsBack) {
+          false
+        } else {
+          val start = selection.start - stepsBack
+
+          @tailrec
+          def matchSlice(i: Int = 0): Boolean = {
+            if (i >= text.length) {
+              true
+            } else {
+              if (text.charAt(i) != selection.source.charAt(start + i)) {
+                false
+              } else {
+                matchSlice(i + 1)
+              }
+            }
+          }
+
+          if (start + text.length <= selection.source.length && matchSlice()) {
+            true
+          } else {
+            tryMatchText(stepsBack + 1)
+          }
+        }
+      }
+
+      tryMatchText()
+    }
+  }
+}

--- a/src/main/scala/scala/tools/refactoring/util/SourceHelpers.scala
+++ b/src/main/scala/scala/tools/refactoring/util/SourceHelpers.scala
@@ -2,6 +2,7 @@ package scala.tools.refactoring.util
 
 import scala.annotation.tailrec
 import scala.math.min
+import scala.reflect.api.Position
 
 object SourceHelpers {
 
@@ -53,5 +54,10 @@ object SourceHelpers {
 
       tryMatchText()
     }
+  }
+
+  def stringCoveredBy(pos: Position): Option[String] = {
+    if (pos.isRange) Some(new String(pos.source.content.slice(pos.start, pos.end)))
+    else None
   }
 }

--- a/src/main/scala/scala/tools/refactoring/util/SourceHelpers.scala
+++ b/src/main/scala/scala/tools/refactoring/util/SourceHelpers.scala
@@ -4,6 +4,19 @@ import scala.annotation.tailrec
 import scala.math.min
 
 object SourceHelpers {
+
+  /**
+   * Decides whether a selection lies within a given text
+   *
+   * This is best explained by a few examples (selections are indicated by `[]`):
+   * <ul>
+   *  <li> `isRangeWithin("a", "[a]") == true`</li>
+   *  <li> `isRangeWithin("ab", "[a]ce") == false` </li>
+   *  <li> `isRangeWithin("ab", "[a]bc") == true` </li>
+   *  <li> `isRangeWithin("ab", "a[b]c") == true` </li>
+   *  <li> `isRangeWithin("ab", "ab[c]") == false` </li>
+   * </ul>
+   */
   def isRangeWithin(text: String, selection: SourceWithSelection): Boolean = {
     if (selection.length > text.length || selection.source.length < text.length) {
       false

--- a/src/main/scala/scala/tools/refactoring/util/SourceWithSelection.scala
+++ b/src/main/scala/scala/tools/refactoring/util/SourceWithSelection.scala
@@ -1,0 +1,8 @@
+package scala.tools.refactoring.util
+
+case class SourceWithSelection(source: IndexedSeq[Char], start: Int, end: Int) {
+  require(start > -1 && end >= start)
+  require(end <= source.length)
+
+  def length = end - start
+}

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/MarkOccurrencesTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/MarkOccurrencesTest.scala
@@ -508,4 +508,26 @@ class MarkOccurrencesTest extends TestHelper {
        val c = 1.1 ## 2.2 ##/*<-cursor*/ Nil
      }
    """)
+
+  @Test
+  def onSelfReference1() = markOccurrences("""
+    class Bug1 { /*2-cursor->*/renameMe =>
+      def alias = renameMe
+    }
+  """, """
+    class Bug1 { /*2-cursor->*/######## =>
+      def alias = ########
+    }
+  """)
+
+  @Test
+  def onSelfReference2() = markOccurrences("""
+    class Bug1 { renameMe =>
+      def alias = /*2-cursor->*/renameMe
+    }
+  """, """
+    class Bug1 { ######## =>
+      def alias = /*2-cursor->*/########
+    }
+  """)
 }

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
@@ -4083,4 +4083,89 @@ class Blubb
     }
     """ -> TaggedAsGlobalRename
   } prepareAndApplyRefactoring(prepareAndRenameTo("ups"))
+
+  /*
+   * See Assembla Ticket 1002803
+   */
+  @Test
+  def testRenameWithSelfReference1002803v1() = new FileSet {
+    """
+    class Bug { /*(*/renameMe/*)*/ =>
+      def alias = renameMe
+    }
+    """ becomes
+    """
+    class Bug { /*(*/ups/*)*/ =>
+      def alias = ups
+    }
+    """ -> TaggedAsLocalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("ups"))
+
+  @Test
+  def testRenameWithSelfReference1002803v2() = new FileSet {
+    """
+    class Bug { renameMe =>
+      def alias = /*(*/renameMe/*)*/
+    }
+    """ becomes
+    """
+    class Bug { ups =>
+      def alias = /*(*/ups/*)*/
+    }
+    """ -> TaggedAsLocalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("ups"))
+
+  @Test
+  def testRenameWithSelfReferenceAndOrdinaryThis1002803() = new FileSet {
+    """
+    class Bug2 { /*(*/renameMe/*)*/ =>
+      def karl = renameMe
+      def heinz = this
+    }
+    """ becomes
+    """
+    class Bug2 { /*(*/ups/*)*/ =>
+      def karl = ups
+      def heinz = this
+    }
+    """ -> TaggedAsLocalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("ups"))
+
+  @Test
+  def testRenameWithSelfReferenceAndNestedTraits1002803() = new FileSet {
+    """
+    trait Bug3 { renameMe =>
+      trait Inner1 { renameMe =>
+        def evil = {
+          trait Bug3 { /*(*/renameMe/*)*/ =>
+            def alias1 = renameMe
+            def alias2 = alias1
+            def alias3 = this
+          }
+          42
+        }
+
+        def alias = renameMe
+      }
+      val alias = renameMe
+    }
+    """ becomes
+    """
+    trait Bug3 { renameMe =>
+      trait Inner1 { renameMe =>
+        def evil = {
+          trait Bug3 { /*(*/hanneloreHostasch/*)*/ =>
+            def alias1 = hanneloreHostasch
+            def alias2 = alias1
+            def alias3 = this
+          }
+          42
+        }
+
+        def alias = renameMe
+      }
+      val alias = renameMe
+    }
+    """ -> TaggedAsLocalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("hanneloreHostasch"))
 }

--- a/src/test/scala/scala/tools/refactoring/tests/util/SourceHelpersTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/util/SourceHelpersTest.scala
@@ -1,0 +1,37 @@
+package scala.tools.refactoring.tests.util
+
+import org.junit.Test
+import scala.tools.refactoring.util.SourceHelpers
+import org.junit.Assert._
+import scala.tools.refactoring.util.SourceWithSelection
+
+class SourceHelpersTest {
+  @Test
+  def isRangeWithinWithTrivialArgs(): Unit = {
+    testIsRangeWithin("", SourceWithSelection("x", 0, 1), false)
+    testIsRangeWithin("x", SourceWithSelection("x", 0, 1), true)
+    testIsRangeWithin("xx", SourceWithSelection("x", 0, 1), false)
+  }
+
+  @Test
+  def isRangeWithEmptySelections(): Unit = {
+    testIsRangeWithin("", SourceWithSelection("", 0, 0), true)
+    testIsRangeWithin("a", SourceWithSelection("a", 0, 0), true)
+    testIsRangeWithin("b", SourceWithSelection("a", 0, 0), false)
+  }
+
+  @Test
+  def isRangeWithinWithSimpleExamples(): Unit = {
+    testIsRangeWithin("abab", SourceWithSelection("0abab5", 4, 5), true)
+    testIsRangeWithin("abab", SourceWithSelection("0abab5", 1, 5), true)
+    testIsRangeWithin("abab", SourceWithSelection("0abab5", 1, 6), false)
+    testIsRangeWithin("abab", SourceWithSelection("0abab5", 2, 4), true)
+    testIsRangeWithin("ab", SourceWithSelection("012a", 3, 4), false)
+    testIsRangeWithin("abba", SourceWithSelection("012abba", 3, 4), true)
+  }
+
+  private def testIsRangeWithin(text: String, selection: SourceWithSelection, expected: Boolean): Unit = {
+    val result = SourceHelpers.isRangeWithin(text, selection)
+    assertEquals(expected, result)
+  }
+}


### PR DESCRIPTION
Self references need special treatment since their representation in typed ASTs is incomplete. This PR takes care of this for `Rename` and `MarkOccurrences`. See [#1002803](https://scala-ide-portfolio.assembla.com/spaces/scala-ide/tickets/1002803-rename-fails-with-self-references/details#) as well as https://github.com/scala-ide/scala-ide/pull/1132.