### PR TITLE
Changes path dependent types for sake of better defined responsibilities

### DIFF
--- a/src/main/scala-2.10/scala/tools/refactoring/implementations/oimports/ImplicitValDefTraverserPF.scala
+++ b/src/main/scala-2.10/scala/tools/refactoring/implementations/oimports/ImplicitValDefTraverserPF.scala
@@ -1,10 +1,10 @@
 package scala.tools.refactoring
 package implementations.oimports
 
-import implementations.OrganizeImports
+import scala.tools.nsc.Global
 
-class ImplicitValDefTraverserPF[O <: OrganizeImports](val oiInstance: O) {
-  import oiInstance.global._
+class ImplicitValDefTraverserPF[G <: Global](val global: G) {
+  import global._
 
   /** Unsupported for Scala 2.10. */
   def apply(traverser: Traverser): PartialFunction[Tree, Unit] = PartialFunction.empty

--- a/src/main/scala-2.11/scala/tools/refactoring/implementations/oimports/ImplicitValDefTraverserPF.scala
+++ b/src/main/scala-2.11/scala/tools/refactoring/implementations/oimports/ImplicitValDefTraverserPF.scala
@@ -1,11 +1,11 @@
 package scala.tools.refactoring
 package implementations.oimports
 
-import implementations.OrganizeImports
+import scala.tools.nsc.Global
 
-class ImplicitValDefTraverserPF[O <: OrganizeImports](val oiInstance: O) {
-  import oiInstance.global._
-  import oiInstance.global.analyzer._
+class ImplicitValDefTraverserPF[G <: Global](val global: G) {
+  import global._
+  import global.analyzer._
 
   private def continueWithFunction(traverser: Traverser, rhs: Attachable) = rhs match {
     case TypeApply(fun, _) =>

--- a/src/main/scala-2.12/scala/tools/refactoring/implementations/oimports/ImplicitValDefTraverserPF.scala
+++ b/src/main/scala-2.12/scala/tools/refactoring/implementations/oimports/ImplicitValDefTraverserPF.scala
@@ -1,11 +1,11 @@
 package scala.tools.refactoring
 package implementations.oimports
 
-import implementations.OrganizeImports
+import scala.tools.nsc.Global
 
-class ImplicitValDefTraverserPF[O <: OrganizeImports](val oiInstance: O) {
-  import oiInstance.global._
-  import oiInstance.global.analyzer._
+class ImplicitValDefTraverserPF[G <: Global](val global: G) {
+  import global._
+  import global.analyzer._
 
   private def continueWithFunction(traverser: Traverser, rhs: Attachable) = rhs match {
     case TypeApply(fun, _) =>

--- a/src/main/scala/scala/tools/refactoring/implementations/oimports/ImportParticipants.scala
+++ b/src/main/scala/scala/tools/refactoring/implementations/oimports/ImportParticipants.scala
@@ -105,7 +105,7 @@ class AllSelects[G <: Global](val global: G) extends TreeTraverser
   }
 }
 
-class NotPackageImportParticipants[G <: Global](val global: G) extends TreeTraverser
+class ImportParticipants[G <: Global](val global: G) extends TreeTraverser
     with TreeTransformations
     with UnusedImportsFinder
     with common.EnrichedTrees

--- a/src/main/scala/scala/tools/refactoring/implementations/oimports/OrganizeImportsWorker.scala
+++ b/src/main/scala/scala/tools/refactoring/implementations/oimports/OrganizeImportsWorker.scala
@@ -2,41 +2,48 @@ package scala.tools.refactoring.implementations.oimports
 
 import scala.tools.refactoring.common.Change
 import scala.tools.refactoring.implementations.OrganizeImports
+import scala.tools.nsc.interactive.Global
+import scala.tools.refactoring.common.Selections
+import scala.tools.refactoring.common.InteractiveScalaCompiler
+import scala.tools.refactoring.sourcegen.Formatting
+import scala.tools.refactoring.transformation.TreeTransformations
 
-class OrganizeImportsWorker[O <: OrganizeImports](val oi: O) {
-  import oi._
-  import oi.global._
+class OrganizeImportsWorker[G <: Global](val global: G) extends InteractiveScalaCompiler
+    with TreeTransformations
+    with Selections {
+  import global._
 
-  lazy val treeToolbox = new TreeToolbox[oi.global.type](oi.global)
-  lazy val regionContext = new RegionTransformationsContext[oi.type](oi)
+  lazy val treeToolbox = new TreeToolbox[global.type](global)
+  lazy val regionContext = new RegionTransformationsContext[global.type](global)
   lazy val transformations = new regionContext.RegionTransformations[treeToolbox.type](treeToolbox)
-  lazy val participants = new NotPackageImportParticipants[oi.type](oi)
+  lazy val participants = new NotPackageImportParticipants[global.type](global)
   lazy val defImportsOrganizer = new DefImportsOrganizer[treeToolbox.global.type, treeToolbox.type](treeToolbox)
   lazy val classDefImportsOrganizer = new ClassDefImportsOrganizer[treeToolbox.global.type, treeToolbox.type](treeToolbox)
   lazy val packageDefImportsOrganizer = new PackageDefImportsOrganizer[treeToolbox.global.type, treeToolbox.type](treeToolbox)
 
-  private def organizeLocalImports(root: Tree): List[treeToolbox.Region] = {
-    val defRegions = defImportsOrganizer.transformTreeToRegions(root, oi).map {
+  private def organizeLocalImports(root: Tree, formatting: Formatting): List[treeToolbox.Region] = {
+    import participants._
+    val defRegions = defImportsOrganizer.transformTreeToRegions(root, formatting).map {
       _.transform {
         scala.Function.chain {
-          participants.RemoveDuplicatedByWildcard ::
-            new participants.RemoveUnused(root) ::
+          RemoveDuplicatedByWildcard ::
+            new RemoveUnused(root) ::
             RemoveDuplicates ::
             SortImportSelectors ::
-            participants.SortImports ::
+            SortImports ::
             Nil
         }
       }
     }
 
-    val classDefRegions = classDefImportsOrganizer.transformTreeToRegions(root, oi).map {
+    val classDefRegions = classDefImportsOrganizer.transformTreeToRegions(root, formatting).map {
       _.transform {
         scala.Function.chain {
-          participants.RemoveDuplicatedByWildcard ::
-            new participants.RemoveUnused(root) ::
+          RemoveDuplicatedByWildcard ::
+            new RemoveUnused(root) ::
             RemoveDuplicates ::
             SortImportSelectors ::
-            participants.SortImports ::
+            SortImports ::
             Nil
         }
       }
@@ -44,35 +51,39 @@ class OrganizeImportsWorker[O <: OrganizeImports](val oi: O) {
     classDefRegions ::: defRegions
   }
 
-  def organizeLocal(selection: Selection) = {
-   val rootTree = abstractFileToTree(selection.file)
-    val classDefAndDefRegions = organizeLocalImports(rootTree)
+  def organizeLocal(selection: Selection, formatting: Formatting) = {
+    val rootTree = abstractFileToTree(selection.file)
+    val classDefAndDefRegions = organizeLocalImports(rootTree, formatting)
     val removedDuplicates = transformations.removeScopesDuplicates(classDefAndDefRegions)
     val changes = removedDuplicates.map { _.print }
 
     Change.discardOverlappingChanges(changes).accepted
   }
 
-  def organizeAll(selection: Selection, params: RefactoringParameters) = {
+  
+  type CanCastSelection[SG <: Global] = SG =:= global.type
+  def organizeAll[SG <: Global : CanCastSelection](g: SG)(pathDepSelection: Selections#Selection, params: OrganizeImports#RefactoringParameters, formatting: Formatting) = {
+    val selection = pathDepSelection.asInstanceOf[Selection]
     val rootTree = abstractFileToTree(selection.file)
 
     val classDefAndDefRegions = if (params.organizeLocalImports) {
-      organizeLocalImports(rootTree)
+      organizeLocalImports(rootTree, formatting)
     } else {
       Nil
     }
 
     val config = params.config.get
 
-    val rawPackageRegions = packageDefImportsOrganizer.transformTreeToRegions(rootTree, oi)
+    val rawPackageRegions = packageDefImportsOrganizer.transformTreeToRegions(rootTree, formatting)
 
+    import OrganizeImports.Dependencies
     val packageRegions = params.deps match {
       case Dependencies.FullyRecompute =>
         new transformations.addExpandedImports(selection.root)(rawPackageRegions)
       case Dependencies.RecomputeAndModify =>
         new transformations.recomputeAndModifyUnused(selection.root)(rawPackageRegions)
       case Dependencies.RemoveUnneeded =>
-        new transformations.addNewImports(params.importsToAdd)(rawPackageRegions, selection.root, oi)
+        new transformations.addNewImports(params.importsToAdd)(rawPackageRegions, selection.root, formatting)
       case _ => rawPackageRegions
     }
 
@@ -94,13 +105,13 @@ class OrganizeImportsWorker[O <: OrganizeImports](val oi: O) {
       _.transform {
         scala.Function.chain {
           participants.SortImports ::
-            SortImportSelectors ::
+            participants.SortImportSelectors ::
             new participants.RemoveUnused(rootTree, params.importsToAdd) ::
             (if (config.wildcards.nonEmpty) List(new participants.AlwaysUseWildcards[treeToolbox.type](treeToolbox)(config.wildcards)) else Nil) :::
             expandOrCollapse :::
             participants.SortImports ::
-            SortImportSelectors ::
-            RemoveDuplicates ::
+            participants.SortImportSelectors ::
+            participants.RemoveDuplicates ::
             Nil
         }
       }

--- a/src/main/scala/scala/tools/refactoring/implementations/oimports/OrganizeImportsWorker.scala
+++ b/src/main/scala/scala/tools/refactoring/implementations/oimports/OrganizeImportsWorker.scala
@@ -16,7 +16,7 @@ class OrganizeImportsWorker[G <: Global](val global: G) extends InteractiveScala
   lazy val treeToolbox = new TreeToolbox[global.type](global)
   lazy val regionContext = new RegionTransformationsContext[global.type](global)
   lazy val transformations = new regionContext.RegionTransformations[treeToolbox.type](treeToolbox)
-  lazy val participants = new NotPackageImportParticipants[global.type](global)
+  lazy val participants = new ImportParticipants[global.type](global)
   lazy val defImportsOrganizer = new DefImportsOrganizer[treeToolbox.global.type, treeToolbox.type](treeToolbox)
   lazy val classDefImportsOrganizer = new ClassDefImportsOrganizer[treeToolbox.global.type, treeToolbox.type](treeToolbox)
   lazy val packageDefImportsOrganizer = new PackageDefImportsOrganizer[treeToolbox.global.type, treeToolbox.type](treeToolbox)

--- a/src/main/scala/scala/tools/refactoring/implementations/oimports/RegionTransformations.scala
+++ b/src/main/scala/scala/tools/refactoring/implementations/oimports/RegionTransformations.scala
@@ -3,19 +3,32 @@ package oimports
 
 import scala.annotation.tailrec
 import scala.reflect.internal.util.RangePosition
+import scala.tools.nsc.interactive.Global
+import scala.tools.refactoring.analysis.CompilationUnitDependencies
+import scala.tools.refactoring.common.EnrichedTrees
+import scala.tools.refactoring.common.InteractiveScalaCompiler
+import scala.tools.refactoring.common.TreeExtractors
+import scala.tools.refactoring.common.TreeTraverser
 import scala.tools.refactoring.sourcegen.Formatting
+import scala.tools.refactoring.transformation.TreeFactory
+import scala.tools.refactoring.transformation.TreeTransformations
 import scala.util.Properties
 
-class RegionTransformationsContext[O <: OrganizeImports](val oi: O) {
-  import oi._
-  class RegionTransformations[T <: TreeToolbox[oi.global.type]](val ttb: T) {
+class RegionTransformationsContext[G <: Global](val global: G) extends CompilationUnitDependencies
+    with InteractiveScalaCompiler
+    with TreeTraverser
+    with EnrichedTrees
+    with TreeExtractors
+    with TreeFactory
+    with TreeTransformations  {
+  import global._
+  class RegionTransformations[T <: TreeToolbox[global.type]](val ttb: T) {
     import ttb._
-    import ttb.global._
 
-    private val treeComparables = new TreeComparables[oi.global.type](oi.global)
+    private val treeComparables = new TreeComparables[ttb.global.type](ttb.global)
 
     case class GroupImports(groups: List[String]) {
-      import OrganizeImports.Algos
+      import scala.tools.refactoring.implementations.OrganizeImports.Algos
       private def nextPositionInitiator(region: Region) = {
         var index = region.from
         () => {

--- a/src/main/scala/scala/tools/refactoring/implementations/oimports/TreeToolbox.scala
+++ b/src/main/scala/scala/tools/refactoring/implementations/oimports/TreeToolbox.scala
@@ -6,6 +6,7 @@ import scala.tools.nsc.Global
 import scala.tools.refactoring.common.Change
 import scala.tools.refactoring.common.TextChange
 import scala.util.Properties
+import scala.reflect.internal.util.NoSourceFile
 
 class TreeToolbox[G <: Global](val global: G) {
   import global._
@@ -36,7 +37,7 @@ class TreeToolbox[G <: Global](val global: G) {
 
   import scala.reflect.internal.util.RangePosition
   import scala.tools.refactoring.sourcegen.Formatting
-  class RegionImport(val owner: Symbol, proto: Import, val comments: List[RangePosition] = Nil,
+  class RegionImport(val owner: Symbol = NoSymbol, proto: Import, val comments: List[RangePosition] = Nil,
     val printTransform: (Formatting, (String, String)) => (String, String) = (formatting, prefixSuffix) => prefixSuffix)(val positions: Seq[Position] = Option(proto.pos).toSeq)
       extends Import(proto.expr, proto.selectors) with ImportPrinter with RegionOwner {
     setPos(proto.pos).setType(proto.tpe).setSymbol(proto.symbol)
@@ -303,9 +304,9 @@ class TreeToolbox[G <: Global](val global: G) {
     }
   }
 
-  case class Region(imports: List[Import], owner: Symbol, from: Int,
-      to: Int, source: SourceFile, indentation: String,
-      formatting: Formatting, printAtTheEndOfRegion: String) {
+  case class Region(imports: List[Import], owner: Symbol = NoSymbol, from: Int = -1,
+      to: Int = -1, source: SourceFile = NoSourceFile, indentation: String = "",
+      formatting: Formatting = new Formatting {}, printAtTheEndOfRegion: String = "") {
     def transform(transformation: List[Import] => List[Import]): Region =
       copy(imports = transformation(imports))
 

--- a/src/test/scala-2.10/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsScalaSpecificTests.scala
+++ b/src/test/scala-2.10/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsScalaSpecificTests.scala
@@ -13,10 +13,11 @@ class OrganizeImportsScalaSpecificTests extends OrganizeImportsBaseTest {
       importsStrategy = Some(OrganizeImports.ImportsStrategy.ExpandImports),
       wildcards = useWildcards,
       groups = groupPkgs)
+    import refactoring.oiWorker.participants._
     val params = {
       new refactoring.RefactoringParameters(
         options =
-            refactoring.PrependScalaPackage ::
+            PrependScalaPackage ::
             Nil,
         deps = dependencies,
         organizeLocalImports = organizeLocalImports,

--- a/src/test/scala-2.11/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsScalaSpecificTests.scala
+++ b/src/test/scala-2.11/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsScalaSpecificTests.scala
@@ -13,10 +13,11 @@ class OrganizeImportsScalaSpecificTests extends OrganizeImportsBaseTest {
       importsStrategy = Some(OrganizeImports.ImportsStrategy.ExpandImports),
       wildcards = useWildcards,
       groups = groupPkgs)
+    import refactoring.oiWorker.participants._
     val params = {
       new refactoring.RefactoringParameters(
         options =
-            refactoring.PrependScalaPackage ::
+            PrependScalaPackage ::
             Nil,
         deps = dependencies,
         organizeLocalImports = organizeLocalImports,

--- a/src/test/scala-2.11/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsWithMacrosTest.scala
+++ b/src/test/scala-2.11/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsWithMacrosTest.scala
@@ -16,10 +16,11 @@ class OrganizeImportsWithMacrosTest extends OrganizeImportsBaseTest {
       importsStrategy = Some(OrganizeImports.ImportsStrategy.ExpandImports),
       wildcards = useWildcards,
       groups = groupPkgs)
+    import refactoring.oiWorker.participants._
     val params = {
       new refactoring.RefactoringParameters(
           options =
-            refactoring.PrependScalaPackage ::
+            PrependScalaPackage ::
             Nil,
           deps = dependencies,
           organizeLocalImports = organizeLocalImports,

--- a/src/test/scala-2.12/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsScalaSpecificTests.scala
+++ b/src/test/scala-2.12/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsScalaSpecificTests.scala
@@ -13,10 +13,11 @@ class OrganizeImportsScalaSpecificTests extends OrganizeImportsBaseTest {
       importsStrategy = Some(OrganizeImports.ImportsStrategy.ExpandImports),
       wildcards = useWildcards,
       groups = groupPkgs)
+    import refactoring.oiWorker.participants._
     val params = {
       new refactoring.RefactoringParameters(
         options =
-            refactoring.PrependScalaPackage ::
+            PrependScalaPackage ::
             Nil,
         deps = dependencies,
         organizeLocalImports = organizeLocalImports,

--- a/src/test/scala-2.12/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsWithMacrosTest.scala
+++ b/src/test/scala-2.12/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsWithMacrosTest.scala
@@ -16,10 +16,11 @@ class OrganizeImportsWithMacrosTest extends OrganizeImportsBaseTest {
       importsStrategy = Some(OrganizeImports.ImportsStrategy.ExpandImports),
       wildcards = useWildcards,
       groups = groupPkgs)
+    import refactoring.oiWorker.participants._
     val params = {
       new refactoring.RefactoringParameters(
           options =
-            refactoring.PrependScalaPackage ::
+            PrependScalaPackage ::
             Nil,
           deps = dependencies,
           organizeLocalImports = organizeLocalImports,

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsCollapseSelectorsToWildcardTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsCollapseSelectorsToWildcardTest.scala
@@ -7,7 +7,7 @@ class OrganizeImportsCollapseSelectorsToWildcardTest extends OrganizeImportsBase
   def organize(exclude: Set[String] = Set())(pro: FileSet) = new OrganizeImportsRefatoring(pro) {
     import refactoring._
     val maxIndividualImports = 2
-    val options = List(SortImportSelectors)
+    val options = List(refactoring.oiWorker.participants.SortImportSelectors)
     val oiConfig = OrganizeImports.OrganizeImportsConfig(
       importsStrategy = Some(OrganizeImports.ImportsStrategy.CollapseImports),
       collapseToWildcardConfig = Some(OrganizeImports.CollapseToWildcardConfig(maxIndividualImports, exclude)))

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
@@ -15,8 +15,9 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
   }.mkChanges
 
   private def organizeWithoutCollapsing(pro: FileSet) = new OrganizeImportsRefatoring(pro) {
+    import refactoring.oiWorker.participants._
     val oiConfig = OrganizeImports.OrganizeImportsConfig(None)
-    val params = new RefactoringParameters(options = List(refactoring.SortImportSelectors), config = Some(oiConfig))
+    val params = new RefactoringParameters(options = List(SortImportSelectors), config = Some(oiConfig))
   }.mkChanges
 
   private def organizeExpand(pro: FileSet) = new OrganizeImportsRefatoring(pro) {
@@ -36,10 +37,11 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
       importsStrategy = Some(OrganizeImports.ImportsStrategy.ExpandImports),
       wildcards = useWildcards,
       groups = groupPkgs)
+    import refactoring.oiWorker.participants._
     val params = {
       new refactoring.RefactoringParameters(
         options =
-            refactoring.PrependScalaPackage ::
+            PrependScalaPackage ::
             Nil,
         deps = dependencies,
         organizeLocalImports = organizeLocalImports,

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/PrependOrDropScalaPackageFromRecomputedTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/PrependOrDropScalaPackageFromRecomputedTest.scala
@@ -9,15 +9,16 @@ import sourcegen.Formatting
 import scala.tools.refactoring.implementations.OrganizeImports
 
 class PrependOrDropScalaPackageFromRecomputedTest extends OrganizeImportsBaseTest {
-
   def organizeDropScalaPackage(pro: FileSet) = new OrganizeImportsRefatoring(pro, new Formatting { override val dropScalaPackage = true }) {
+    import refactoring.oiWorker.participants._
     val oiConfig = OrganizeImports.OrganizeImportsConfig(None, scalaPackageStrategy = true)
-    val params = new RefactoringParameters(deps = refactoring.Dependencies.FullyRecompute, options = List(refactoring.DropScalaPackage), config = Some(oiConfig))
+    val params = new RefactoringParameters(deps = refactoring.Dependencies.FullyRecompute, options = List(DropScalaPackage), config = Some(oiConfig))
   }.mkChanges
 
   def organizePrependScalaPackage(pro: FileSet) = new OrganizeImportsRefatoring(pro) {
+    import refactoring.oiWorker.participants._
     val oiConfig = OrganizeImports.OrganizeImportsConfig(None, scalaPackageStrategy = false)
-    val params = new RefactoringParameters(deps = refactoring.Dependencies.FullyRecompute, options = List(refactoring.PrependScalaPackage), config = Some(oiConfig))
+    val params = new RefactoringParameters(deps = refactoring.Dependencies.FullyRecompute, options = List(PrependScalaPackage), config = Some(oiConfig))
   }.mkChanges
 
   @Test

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/PrependOrDropScalaPackageKeepTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/PrependOrDropScalaPackageKeepTest.scala
@@ -11,13 +11,15 @@ import scala.tools.refactoring.implementations.OrganizeImports
 class PrependOrDropScalaPackageKeepTest extends OrganizeImportsBaseTest {
 
   def organizeDropScalaPackage(pro: FileSet) = new OrganizeImportsRefatoring(pro, new Formatting {override val dropScalaPackage = true}) {
+    import refactoring.oiWorker.participants._
     val oiConfig = OrganizeImports.OrganizeImportsConfig(None, scalaPackageStrategy = true)
-    val params = new RefactoringParameters(deps = refactoring.Dependencies.RecomputeAndModify, options = List(refactoring.DropScalaPackage), config = Some(oiConfig))
+    val params = new RefactoringParameters(deps = refactoring.Dependencies.RecomputeAndModify, options = List(DropScalaPackage), config = Some(oiConfig))
   }.mkChanges
 
   def organizePrependScalaPackage(pro: FileSet) = new OrganizeImportsRefatoring(pro) {
+    import refactoring.oiWorker.participants._
     val oiConfig = OrganizeImports.OrganizeImportsConfig(None, scalaPackageStrategy = false)
-    val params = new RefactoringParameters(deps = refactoring.Dependencies.RecomputeAndModify, options = List(refactoring.PrependScalaPackage), config = Some(oiConfig))
+    val params = new RefactoringParameters(deps = refactoring.Dependencies.RecomputeAndModify, options = List(PrependScalaPackage), config = Some(oiConfig))
   }.mkChanges
 
   @Test


### PR DESCRIPTION
This is second (of 3) PR for Organize Imports refactoring 

Changes path dependent types for sake of better
defined responsibilities

OrganizeImports depends on traits like TreeTransformations and so
on but it is not its role to do this sort of job. These things are
push down to OrganizeImportsWorker and its colaborators.
From now all refactored imports are enclosed in regions. And additionally
everywhere if is possible classes depend on `global` directly.