### PR TITLE
Make renaming packages work

### DIFF
--- a/src/main/scala/scala/tools/refactoring/analysis/GlobalIndexes.scala
+++ b/src/main/scala/scala/tools/refactoring/analysis/GlobalIndexes.scala
@@ -34,7 +34,8 @@ trait GlobalIndexes extends Indexes with DependentSymbolExpanders with Compilati
           OverridesInSuperClasses with
           ClassVals with
           CaseClassVals with
-          TermsWithMissingRanges {
+          TermsWithMissingRanges with
+          PackageObjects {
 
             val cus = compilationUnits
           }

--- a/src/main/scala/scala/tools/refactoring/analysis/GlobalIndexes.scala
+++ b/src/main/scala/scala/tools/refactoring/analysis/GlobalIndexes.scala
@@ -71,6 +71,13 @@ trait GlobalIndexes extends Indexes with DependentSymbolExpanders with Compilati
       }).distinct
     }
 
+    def rootOf(tree: Tree): Option[Tree] = {
+      cus.collectFirst {
+        case cu if cu.root.pos.source.file == tree.pos.source.file =>
+          cu.root
+      }
+    }
+
     @tailrec
     private def linkSymbols(uf: UnionFind[Symbol], syms:List[Symbol], seen:HashSet[Symbol]): UnionFind[Symbol] = {
       if (syms.nonEmpty){

--- a/src/main/scala/scala/tools/refactoring/analysis/Indexes.scala
+++ b/src/main/scala/scala/tools/refactoring/analysis/Indexes.scala
@@ -69,6 +69,11 @@ trait Indexes {
     def rootsOf(trees: List[global.Tree]): List[global.Tree]
 
     /**
+     * Attempts to find the root of a single tree
+     */
+    def rootOf(tree: global.Tree): Option[global.Tree]
+
+    /**
      * For the given Symbol - which is a class or object - returns a
      * list of all sub- and super classes, in no particular order.
      */

--- a/src/main/scala/scala/tools/refactoring/analysis/SymbolExpanders.scala
+++ b/src/main/scala/scala/tools/refactoring/analysis/SymbolExpanders.scala
@@ -33,7 +33,7 @@ trait DependentSymbolExpanders extends TracingImpl {
 
           if (posSet == Set(NoPosition)) Seq()
           else if (res == Seq(s)) Seq()
-          else posSet.map(pos => PositionDebugging.formatCompact(pos))
+          else posSet.map(pos => PositionDebugging.format(pos))
         }
 
         if (debugInfo.nonEmpty) {
@@ -236,6 +236,20 @@ trait DependentSymbolExpanders extends TracingImpl {
           }
         }
       }
+    }
+  }
+
+  /**
+   * Associates package objects with their packages
+   */
+  trait PackageObjects extends SymbolExpander { this: IndexLookup =>
+    protected abstract override def doExpand(s: Symbol): List[Symbol] = {
+      relatedPackageDefs(s) ::: super.doExpand(s)
+    }
+
+    private def relatedPackageDefs(s: Symbol): List[Symbol] = s match {
+      case s: ModuleSymbol if s.isPackageObject => List(s.owner)
+      case _ => Nil
     }
   }
 }

--- a/src/main/scala/scala/tools/refactoring/common/Change.scala
+++ b/src/main/scala/scala/tools/refactoring/common/Change.scala
@@ -35,6 +35,8 @@ case class TextChange(sourceFile: SourceFile, from: Int, to: Int, text: String) 
  */
 case class NewFileChange(fullName: String, text: String) extends Change
 
+case class MoveToDirChange(sourceFile: AbstractFile, to: String) extends Change
+
 case class RenameSourceFileChange(sourceFile: AbstractFile, to: String) extends Change
 
 object Change {

--- a/src/main/scala/scala/tools/refactoring/implementations/MarkOccurrences.scala
+++ b/src/main/scala/scala/tools/refactoring/implementations/MarkOccurrences.scala
@@ -123,7 +123,12 @@ trait MarkOccurrences extends common.Selections with analysis.Indexes with commo
         // reliable strategy that also works well in the presence of `backtick-identifiers`.
         declaration.namePosition() match {
           case rp: RangePosition =>
-            Some(rp.source.content.slice(rp.start, rp.end).mkString(""))
+            if (SourceWithMarker.atStartOf(rp).moveMarker(Movements.id).marker != rp.end) {
+              trace(s"Name position at ${PositionDebugging.format(rp)} seems to be invalid")
+              None
+            } else {
+              Some(rp.source.content.slice(rp.start, rp.end).mkString(""))
+            }
           case op =>
             trace(s"Expected range position, but found $op")
             None

--- a/src/main/scala/scala/tools/refactoring/implementations/MarkOccurrences.scala
+++ b/src/main/scala/scala/tools/refactoring/implementations/MarkOccurrences.scala
@@ -110,6 +110,7 @@ trait MarkOccurrences extends common.Selections with analysis.Indexes with commo
         tree.symbol
 
       case treeWithoutSymbol =>
+        trace("Selected tree does not have symbol")
         tryFindMissingSymbol(treeWithoutSymbol, root)
     }
 

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
@@ -4400,7 +4400,7 @@ class Blubb
     import com.github.mlangc.experiments.rename.me.Kerl
     import com.github.mlangc.experiments.rename.me.Lausbub
 
-    class Bug {
+    class Bug1 {
       val kerl: Kerl = new Lausbub
     }
     """ becomes
@@ -4410,10 +4410,195 @@ class Blubb
     import com.github.mlangc.experiments.rename.ups.Kerl
     import com.github.mlangc.experiments.rename.ups.Lausbub
 
-    class Bug {
+    class Bug1 {
       val kerl: Kerl = new Lausbub
     }
     """
+
+    """
+    package com.github.mlangc.experiments
+
+    class Bug2 {
+      val kerl1 = {
+        new rename.me.Lausbub
+      }
+
+      import rename.me
+
+      val kerl2: me.Kerl = {
+        ???
+      }
+
+      val kerl3 = {
+        import rename.me.Lausbub
+        new Lausbub
+      }
+    }
+    """ becomes
+    """
+    package com.github.mlangc.experiments
+
+    class Bug2 {
+      val kerl1 = {
+        new rename.ups.Lausbub
+      }
+
+      import rename.ups
+
+      val kerl2: ups.Kerl = {
+        ???
+      }
+
+      val kerl3 = {
+        import rename.ups.Lausbub
+        new Lausbub
+      }
+    }
+    """
   } prepareAndApplyRefactoring(prepareAndRenameTo("ups"))
+
+  @Test
+  def testRenamePackage1002769v3() = new FileSet {
+    """
+    package rename/*<-cursor*/
+
+    class Lausbub
+    """ -> "rename/Lausbub.scala" becomes
+    """
+    package renamed/*<-cursor*/
+
+    class Lausbub
+    """ -> "renamed/Lausbub.scala"
+  } prepareAndApplyRefactoring(prepareAndRenameTo("renamed"))
+
+  @Test
+  def testRenamePackage1002769v4() = new FileSet {
+    """
+    package rename.me/*<-cursor*/
+
+    class Lausbub
+    """ -> "rename/me/Lausbub.scala" becomes
+    """
+    package rename.xxx/*<-cursor*/
+
+    class Lausbub
+    """ -> "rename/xxx/Lausbub.scala"
+  } prepareAndApplyRefactoring(prepareAndRenameTo("xxx"))
+
+  @Test
+  def testRenamePackage1002769v5() = new FileSet {
+    """
+    package rename
+
+    package object me/*<-cursor*/ {
+      class Lausbub
+    }
+    """ -> "rename/me/package.scala" becomes
+    """
+    package rename
+
+    package object xxx/*<-cursor*/ {
+      class Lausbub
+    }
+    """ -> "rename/xxx/package.scala"
+  } prepareAndApplyRefactoring(prepareAndRenameTo("xxx"))
+
+  @Test
+  def testRenamePackage1002769v6() = new FileSet {
+    """
+    package one.library.to./*(*/rename/*)*/.them.all
+    class Lauser
+    """ -> "one/library/to/rename/them/all/Lauser.scala" becomes
+    """
+    package one.library.to./*(*/xxx/*)*/.them.all
+    class Lauser
+    """ -> "one/library/to/xxx/them/all/Lauser.scala"
+
+    """
+    package one.library.to.rename.them
+
+    import one.library.to.rename.them.all.Lauser
+
+    class Ratte(lauser: Lauser)
+    """ -> "one/library/to/rename/them/Ratte.scala" becomes
+    """
+    package one.library.to.xxx.them
+
+    import one.library.to.xxx.them.all.Lauser
+
+    class Ratte(lauser: Lauser)
+    """ -> "one/library/to/xxx/them/Ratte.scala"
+
+    """
+    package one.library.to.rename
+
+    import one.library.to.rename.them.Ratte
+    import one.library.to.rename.them.all.Lauser
+
+    class Fritzi(ratte: Ratte, lauser: Lauser)
+    """ -> "one/library/to/rename/Fritzi.scala" becomes
+    """
+    package one.library.to.xxx
+
+    import one.library.to.xxx.them.Ratte
+    import one.library.to.xxx.them.all.Lauser
+
+    class Fritzi(ratte: Ratte, lauser: Lauser)
+    """ -> "one/library/to/xxx/Fritzi.scala"
+
+    """
+    package one.library.to.rename.them.all
+
+    class Rotzloeffel
+    """ -> "not/in/pkg/dir/Rotzloeffel.scala" becomes
+    """
+    package one.library.to.xxx.them.all
+
+    class Rotzloeffel
+    """ -> "not/in/pkg/dir/Rotzloeffel.scala"
+
+    """
+    package one.library
+
+    class Indifferent
+    """ isNotModified()
+  } prepareAndApplyRefactoring(prepareAndRenameTo("xxx"))
+
+  @Test
+  def testRenamePackage1002769v7() = new FileSet {
+    """
+    package a {
+      package b/*<-cursor*/ {
+        class C
+      }
+    }
+    """ -> "a/b/C.scala" becomes
+    """
+    package a {
+      package xxx/*<-cursor*/ {
+        class C
+      }
+    }
+    """ -> "a/xxx/C.scala"
+
+    """
+    package a {
+      package b {
+        class NotInPrimaryPackage
+      }
+
+      class Mischief
+    }
+    """ -> "a/b/Mischief.scala" becomes
+    """
+    package a {
+      package xxx {
+        class NotInPrimaryPackage
+      }
+
+      class Mischief
+    }
+    """ -> "a/b/Mischief.scala"
+  } prepareAndApplyRefactoring(prepareAndRenameTo("xxx"))
 }
 

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
@@ -4600,5 +4600,21 @@ class Blubb
     }
     """ -> "a/b/Mischief.scala"
   } prepareAndApplyRefactoring(prepareAndRenameTo("xxx"))
+
+  @Test
+  def testRenamePackage1002769v8() = new FileSet {
+    """
+    package a/*<-cursor*/ {
+      class A
+    }
+    package b { }
+    """ -> "a/A.scala" becomes
+    """
+    package xxx/*<-cursor*/ {
+      class A
+    }
+    package b { }
+    """ -> "a/A.scala"
+  } prepareAndApplyRefactoring(prepareAndRenameTo("xxx"))
 }
 

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/RenameTest.scala
@@ -4351,4 +4351,69 @@ class Blubb
     }
     """ -> TaggedAsGlobalRename
   } prepareAndApplyRefactoring(prepareAndRenameTo("ups"))
+
+  @Test
+  def testRenamePackage1002769v1() = new FileSet {
+    """
+    package rename.me/*<-cursor*/
+
+    class Franzi
+    """ becomes
+    """
+    package rename.lausbub/*<-cursor*/
+
+    class Franzi
+    """ -> TaggedAsGlobalRename
+  } prepareAndApplyRefactoring(prepareAndRenameTo("lausbub"))
+
+  @Test
+  def testRenamePackage1002769v2() = new FileSet {
+    """
+    package com.github.mlangc.experiments.rename.me/*<-cursor*/
+
+    class Lausbub
+    """ becomes
+    """
+    package com.github.mlangc.experiments.rename.ups/*<-cursor*/
+
+    class Lausbub
+    """ -> TaggedAsGlobalRename
+
+    """
+    package com.github.mlangc.experiments.rename
+
+    package object me {
+      type Kerl = Lausbub
+    }
+    """ becomes
+    """
+    package com.github.mlangc.experiments.rename
+
+    package object ups {
+      type Kerl = Lausbub
+    }
+    """
+
+    """
+    package com.github.mlangc.experiments
+
+    import com.github.mlangc.experiments.rename.me.Kerl
+    import com.github.mlangc.experiments.rename.me.Lausbub
+
+    class Bug {
+      val kerl: Kerl = new Lausbub
+    }
+    """ becomes
+    """
+    package com.github.mlangc.experiments
+
+    import com.github.mlangc.experiments.rename.ups.Kerl
+    import com.github.mlangc.experiments.rename.ups.Lausbub
+
+    class Bug {
+      val kerl: Kerl = new Lausbub
+    }
+    """
+  } prepareAndApplyRefactoring(prepareAndRenameTo("ups"))
 }
+


### PR DESCRIPTION
This PR is dedicated to package renames, that are special for two reasons:

1. Associated package objects must be renamed together with their packages
2. Although not strictly required, package renames typically should be accompanied by associated directory renames

This PR takes care of both issues. Note that up until now there was no `scala.tools.refactoring.common.Change` that models moving files from one directory to another. `scala.tools.refactoring.common.MoveToDirChange` takes care of this. An associated PR for ScalaIDE, that takes advantage of the new API, can be found [here](https://github.com/scala-ide/scala-ide/pull/1140).

Fixes [#1002769](https://scala-ide-portfolio.assembla.com/spaces/scala-ide/tickets/1002769-package-renaming-error-in-the-package-object/details#).