### PR TITLE
Enables including trailing line for Windows line separator

### DIFF
--- a/src/main/scala/scala/tools/refactoring/util/SourceHelpers.scala
+++ b/src/main/scala/scala/tools/refactoring/util/SourceHelpers.scala
@@ -69,7 +69,7 @@ object SourceHelpers {
     import scala.tools.refactoring.util.SourceWithMarker.Movements.charToMovement
 
     val commentMvnt = {
-      if (includeTrailingNewline) Movements.comment ~ '\n'.optional
+      if (includeTrailingNewline) Movements.comment ~ '\r'.optional ~ '\n'.optional
       else Movements.comment
     }
 


### PR DESCRIPTION
Problem described in title hits refactoring of Organize Imports for Windows releases.
I need advice to write a test for it.