### PR TITLE
Removes options from OrganizeImports

### DIFF
--- a/src/main/scala/scala/tools/refactoring/implementations/OrganizeImports.scala
+++ b/src/main/scala/scala/tools/refactoring/implementations/OrganizeImports.scala
@@ -99,10 +99,7 @@ abstract class OrganizeImports extends MultiStageRefactoring
   class PreparationResult(val missingTypes: List[String] = Nil)
 
   lazy val oiWorker = new OrganizeImportsWorker[global.type](global)
-  import oiWorker.participants._
   import oiWorker.global._
-
-  def DefaultOptions = List(SortImportSelectors)
 
   /**
    * Imports that should be added are passed as tuples in the form
@@ -110,7 +107,6 @@ abstract class OrganizeImports extends MultiStageRefactoring
    */
   class RefactoringParameters(
     val importsToAdd: List[(String, String)] = Nil,
-    val options: List[Participant] = DefaultOptions,
     val deps: Dependencies.Value = Dependencies.RemoveUnneeded,
     val organizeLocalImports: Boolean = true,
     val config: Option[OrganizeImports.OrganizeImportsConfig] = None)

--- a/src/test/scala-2.10/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsScalaSpecificTests.scala
+++ b/src/test/scala-2.10/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsScalaSpecificTests.scala
@@ -13,12 +13,8 @@ class OrganizeImportsScalaSpecificTests extends OrganizeImportsBaseTest {
       importsStrategy = Some(OrganizeImports.ImportsStrategy.ExpandImports),
       wildcards = useWildcards,
       groups = groupPkgs)
-    import refactoring.oiWorker.participants._
     val params = {
       new refactoring.RefactoringParameters(
-        options =
-            PrependScalaPackage ::
-            Nil,
         deps = dependencies,
         organizeLocalImports = organizeLocalImports,
         config = Some(oiConfig))

--- a/src/test/scala-2.11/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsScalaSpecificTests.scala
+++ b/src/test/scala-2.11/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsScalaSpecificTests.scala
@@ -13,12 +13,8 @@ class OrganizeImportsScalaSpecificTests extends OrganizeImportsBaseTest {
       importsStrategy = Some(OrganizeImports.ImportsStrategy.ExpandImports),
       wildcards = useWildcards,
       groups = groupPkgs)
-    import refactoring.oiWorker.participants._
     val params = {
       new refactoring.RefactoringParameters(
-        options =
-            PrependScalaPackage ::
-            Nil,
         deps = dependencies,
         organizeLocalImports = organizeLocalImports,
         config = Some(oiConfig))

--- a/src/test/scala-2.11/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsWithMacrosTest.scala
+++ b/src/test/scala-2.11/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsWithMacrosTest.scala
@@ -16,12 +16,8 @@ class OrganizeImportsWithMacrosTest extends OrganizeImportsBaseTest {
       importsStrategy = Some(OrganizeImports.ImportsStrategy.ExpandImports),
       wildcards = useWildcards,
       groups = groupPkgs)
-    import refactoring.oiWorker.participants._
     val params = {
       new refactoring.RefactoringParameters(
-          options =
-            PrependScalaPackage ::
-            Nil,
           deps = dependencies,
           organizeLocalImports = organizeLocalImports,
           config = Some(oiConfig))

--- a/src/test/scala-2.12/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsScalaSpecificTests.scala
+++ b/src/test/scala-2.12/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsScalaSpecificTests.scala
@@ -13,12 +13,8 @@ class OrganizeImportsScalaSpecificTests extends OrganizeImportsBaseTest {
       importsStrategy = Some(OrganizeImports.ImportsStrategy.ExpandImports),
       wildcards = useWildcards,
       groups = groupPkgs)
-    import refactoring.oiWorker.participants._
     val params = {
       new refactoring.RefactoringParameters(
-        options =
-            PrependScalaPackage ::
-            Nil,
         deps = dependencies,
         organizeLocalImports = organizeLocalImports,
         config = Some(oiConfig))

--- a/src/test/scala-2.12/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsWithMacrosTest.scala
+++ b/src/test/scala-2.12/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsWithMacrosTest.scala
@@ -16,12 +16,8 @@ class OrganizeImportsWithMacrosTest extends OrganizeImportsBaseTest {
       importsStrategy = Some(OrganizeImports.ImportsStrategy.ExpandImports),
       wildcards = useWildcards,
       groups = groupPkgs)
-    import refactoring.oiWorker.participants._
     val params = {
       new refactoring.RefactoringParameters(
-          options =
-            PrependScalaPackage ::
-            Nil,
           deps = dependencies,
           organizeLocalImports = organizeLocalImports,
           config = Some(oiConfig))

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsCollapseSelectorsToWildcardTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsCollapseSelectorsToWildcardTest.scala
@@ -7,11 +7,10 @@ class OrganizeImportsCollapseSelectorsToWildcardTest extends OrganizeImportsBase
   def organize(exclude: Set[String] = Set())(pro: FileSet) = new OrganizeImportsRefatoring(pro) {
     import refactoring._
     val maxIndividualImports = 2
-    val options = List(refactoring.oiWorker.participants.SortImportSelectors)
     val oiConfig = OrganizeImports.OrganizeImportsConfig(
       importsStrategy = Some(OrganizeImports.ImportsStrategy.CollapseImports),
       collapseToWildcardConfig = Some(OrganizeImports.CollapseToWildcardConfig(maxIndividualImports, exclude)))
-    val params = new RefactoringParameters(options = options, deps = Dependencies.FullyRecompute, config = Some(oiConfig))
+    val params = new RefactoringParameters(deps = Dependencies.FullyRecompute, config = Some(oiConfig))
   }.mkChanges
 
   @Test

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsFullyRecomputeTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsFullyRecomputeTest.scala
@@ -16,7 +16,7 @@ class OrganizeImportsFullyRecomputeTest extends OrganizeImportsBaseTest {
 
   def organizeWithoutCollapsing(pro: FileSet) = new OrganizeImportsRefatoring(pro) {
     val oiConfig = OrganizeImports.OrganizeImportsConfig(None)
-    val params = new RefactoringParameters(options = List(), deps = refactoring.Dependencies.FullyRecompute, config = Some(oiConfig))
+    val params = new RefactoringParameters(deps = refactoring.Dependencies.FullyRecompute, config = Some(oiConfig))
   }.mkChanges
 
   def organizeExpand(pro: FileSet) = new OrganizeImportsRefatoring(pro) {

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsGroupsTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsGroupsTest.scala
@@ -12,11 +12,10 @@ class OrganizeImportsGroupsTest extends OrganizeImportsBaseTest {
 
   def organize(groups: List[String])(pro: FileSet) = new OrganizeImportsRefatoring(pro) {
     import refactoring._
-    val options = Nil
     val config = OrganizeImports.OrganizeImportsConfig(
       importsStrategy = Some(OrganizeImports.ImportsStrategy.ExpandImports),
       groups = groups)
-    val params = new RefactoringParameters(options = options, deps = Dependencies.FullyRecompute, config = Some(config))
+    val params = new RefactoringParameters(deps = Dependencies.FullyRecompute, config = Some(config))
   }.mkChanges
 
   val source = """

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsRecomputeAndModifyTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsRecomputeAndModifyTest.scala
@@ -11,7 +11,7 @@ class OrganizeImportsRecomputeAndModifyTest extends OrganizeImportsBaseTest {
 
   def organize(pro: FileSet) = new OrganizeImportsRefatoring(pro) {
     val oiConfig = OrganizeImports.OrganizeImportsConfig(None)
-    val params = new RefactoringParameters(deps = refactoring.Dependencies.RecomputeAndModify, options = List(),
+    val params = new RefactoringParameters(deps = refactoring.Dependencies.RecomputeAndModify,
         config = Some(oiConfig))
   }.mkChanges
 
@@ -20,7 +20,6 @@ class OrganizeImportsRecomputeAndModifyTest extends OrganizeImportsBaseTest {
         None,
         groups = groups)
     val params = new RefactoringParameters(deps = refactoring.Dependencies.RecomputeAndModify,
-        options = Nil,
         config = Some(oiConfig))
   }.mkChanges
 
@@ -29,7 +28,6 @@ class OrganizeImportsRecomputeAndModifyTest extends OrganizeImportsBaseTest {
         None,
         wildcards = ws)
     val params = new RefactoringParameters(deps = refactoring.Dependencies.RecomputeAndModify,
-        options = Nil,
         config = Some(oiConfig))
   }.mkChanges
 

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
@@ -15,15 +15,13 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
   }.mkChanges
 
   private def organizeWithoutCollapsing(pro: FileSet) = new OrganizeImportsRefatoring(pro) {
-    import refactoring.oiWorker.participants._
     val oiConfig = OrganizeImports.OrganizeImportsConfig(None)
-    val params = new RefactoringParameters(options = List(SortImportSelectors), config = Some(oiConfig))
+    val params = new RefactoringParameters(config = Some(oiConfig))
   }.mkChanges
 
   private def organizeExpand(pro: FileSet) = new OrganizeImportsRefatoring(pro) {
     val oiConfig = OrganizeImports.OrganizeImportsConfig(importsStrategy = Some(OrganizeImports.ImportsStrategy.ExpandImports))
-    val params = new refactoring.RefactoringParameters(options = Nil,
-      config = Some(oiConfig))
+    val params = new refactoring.RefactoringParameters(config = Some(oiConfig))
   }.mkChanges
 
   private def organizeWithTypicalParams(pro: FileSet) = organizeCustomized()(pro)
@@ -37,12 +35,8 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
       importsStrategy = Some(OrganizeImports.ImportsStrategy.ExpandImports),
       wildcards = useWildcards,
       groups = groupPkgs)
-    import refactoring.oiWorker.participants._
     val params = {
       new refactoring.RefactoringParameters(
-        options =
-            PrependScalaPackage ::
-            Nil,
         deps = dependencies,
         organizeLocalImports = organizeLocalImports,
         config = Some(oiConfig))

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsWildcardsTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsWildcardsTest.scala
@@ -11,11 +11,10 @@ class OrganizeImportsWildcardsTest extends OrganizeImportsBaseTest {
 
   def organize(groups: Set[String])(pro: FileSet) = new OrganizeImportsRefatoring(pro) {
     import refactoring._
-    val options = Nil
     val oiConfig = OrganizeImports.OrganizeImportsConfig(
       importsStrategy = Some(OrganizeImports.ImportsStrategy.PreserveWildcards),
       wildcards = groups)
-    val params = new RefactoringParameters(options = options, deps = Dependencies.FullyRecompute, config = Some(oiConfig))
+    val params = new RefactoringParameters(deps = Dependencies.FullyRecompute, config = Some(oiConfig))
   }.mkChanges
 
   val source = """

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/PrependOrDropScalaPackageFromRecomputedTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/PrependOrDropScalaPackageFromRecomputedTest.scala
@@ -10,15 +10,13 @@ import scala.tools.refactoring.implementations.OrganizeImports
 
 class PrependOrDropScalaPackageFromRecomputedTest extends OrganizeImportsBaseTest {
   def organizeDropScalaPackage(pro: FileSet) = new OrganizeImportsRefatoring(pro, new Formatting { override val dropScalaPackage = true }) {
-    import refactoring.oiWorker.participants._
     val oiConfig = OrganizeImports.OrganizeImportsConfig(None, scalaPackageStrategy = true)
-    val params = new RefactoringParameters(deps = refactoring.Dependencies.FullyRecompute, options = List(DropScalaPackage), config = Some(oiConfig))
+    val params = new RefactoringParameters(deps = refactoring.Dependencies.FullyRecompute, config = Some(oiConfig))
   }.mkChanges
 
   def organizePrependScalaPackage(pro: FileSet) = new OrganizeImportsRefatoring(pro) {
-    import refactoring.oiWorker.participants._
     val oiConfig = OrganizeImports.OrganizeImportsConfig(None, scalaPackageStrategy = false)
-    val params = new RefactoringParameters(deps = refactoring.Dependencies.FullyRecompute, options = List(PrependScalaPackage), config = Some(oiConfig))
+    val params = new RefactoringParameters(deps = refactoring.Dependencies.FullyRecompute, config = Some(oiConfig))
   }.mkChanges
 
   @Test

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/PrependOrDropScalaPackageKeepTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/PrependOrDropScalaPackageKeepTest.scala
@@ -11,15 +11,13 @@ import scala.tools.refactoring.implementations.OrganizeImports
 class PrependOrDropScalaPackageKeepTest extends OrganizeImportsBaseTest {
 
   def organizeDropScalaPackage(pro: FileSet) = new OrganizeImportsRefatoring(pro, new Formatting {override val dropScalaPackage = true}) {
-    import refactoring.oiWorker.participants._
     val oiConfig = OrganizeImports.OrganizeImportsConfig(None, scalaPackageStrategy = true)
-    val params = new RefactoringParameters(deps = refactoring.Dependencies.RecomputeAndModify, options = List(DropScalaPackage), config = Some(oiConfig))
+    val params = new RefactoringParameters(deps = refactoring.Dependencies.RecomputeAndModify, config = Some(oiConfig))
   }.mkChanges
 
   def organizePrependScalaPackage(pro: FileSet) = new OrganizeImportsRefatoring(pro) {
-    import refactoring.oiWorker.participants._
     val oiConfig = OrganizeImports.OrganizeImportsConfig(None, scalaPackageStrategy = false)
-    val params = new RefactoringParameters(deps = refactoring.Dependencies.RecomputeAndModify, options = List(PrependScalaPackage), config = Some(oiConfig))
+    val params = new RefactoringParameters(deps = refactoring.Dependencies.RecomputeAndModify, config = Some(oiConfig))
   }.mkChanges
 
   @Test


### PR DESCRIPTION
'options' has been removed because it exposed specific scala-refactoring
types outside. It is incorrect especially these types usually depend on
'global'. Configuration should rather be passed with simple scala types.