### PR TITLE
Reorganized imports preserve existing end of line

### DIFF
--- a/src/main/scala/scala/tools/refactoring/common/Change.scala
+++ b/src/main/scala/scala/tools/refactoring/common/Change.scala
@@ -62,7 +62,7 @@ object Change {
     }
 
     (source /: sortedChanges) { (src, change) =>
-      src.substring(0, change.from) + change.text + src.substring(change.to)
+      src.take(change.from) + change.text + src.drop(change.to)
     }
   }
 

--- a/src/main/scala/scala/tools/refactoring/implementations/OrganizeImports.scala
+++ b/src/main/scala/scala/tools/refactoring/implementations/OrganizeImports.scala
@@ -6,10 +6,10 @@ package scala.tools.refactoring
 package implementations
 
 import scala.tools.refactoring.common.Change
+import scala.tools.refactoring.common.InteractiveScalaCompiler
 import scala.tools.refactoring.implementations.oimports.OrganizeImportsWorker
 import scala.tools.refactoring.sourcegen.Formatting
 import scala.util.control.NonFatal
-import scala.tools.refactoring.common.InteractiveScalaCompiler
 
 object OrganizeImports {
   /**

--- a/src/main/scala/scala/tools/refactoring/implementations/oimports/RegionTransformations.scala
+++ b/src/main/scala/scala/tools/refactoring/implementations/oimports/RegionTransformations.scala
@@ -12,7 +12,6 @@ import scala.tools.refactoring.common.TreeTraverser
 import scala.tools.refactoring.sourcegen.Formatting
 import scala.tools.refactoring.transformation.TreeFactory
 import scala.tools.refactoring.transformation.TreeTransformations
-import scala.util.Properties
 
 class RegionTransformationsContext[G <: Global](val global: G) extends CompilationUnitDependencies
     with InteractiveScalaCompiler
@@ -43,7 +42,7 @@ class RegionTransformationsContext[G <: Global](val global: G) extends Compilati
         val nextPosition = nextPositionInitiator(region)
         def separatorRegion = {
           val pos = nextPosition()
-          region.copy(imports = Nil, from = pos, to = pos + 1, printAtTheEndOfRegion = Properties.lineSeparator + Properties.lineSeparator + region.indentation)
+          region.copy(imports = Nil, from = pos, to = pos + 1, printAtTheEndOfRegion = region.formatting.lineDelimiter + region.formatting.lineDelimiter + region.indentation)
         }
         def copyRegionWithNewPosition(regionToCopy: Int => Region) = {
           val pos = nextPosition()
@@ -62,7 +61,7 @@ class RegionTransformationsContext[G <: Global](val global: G) extends Compilati
         val allImports =
           Algos.groupImports(getImportExpression)(groups, region.imports).toList
         allImports match {
-          case Nil => List(region.copy(imports = Nil, to = region.to + Properties.lineSeparator.length, printAtTheEndOfRegion = ""))
+          case Nil => List(region.copy(imports = Nil, printAtTheEndOfRegion = ""))
           case imps :: Nil => List(region)
           case imps => toRegions(imps, Nil)
         }
@@ -188,7 +187,7 @@ class RegionTransformationsContext[G <: Global](val global: G) extends Compilati
             val imp = mkImportFromStrings(qualifier, name)
             imp.setPos(topLeastPkgPos)
         }
-        RegionBuilder[ttb.global.type, ttb.type](ttb)(imports, topLeastPackage.symbol, formatting, Properties.lineSeparator + Properties.lineSeparator + topNonPkgIndent).head
+        RegionBuilder[ttb.global.type, ttb.type](ttb)(imports, topLeastPackage.symbol, formatting, formatting.lineDelimiter + formatting.lineDelimiter + topNonPkgIndent).head
       }
 
       def apply(regions: List[Region], root: Tree, formatting: Formatting) = {

--- a/src/main/scala/scala/tools/refactoring/implementations/oimports/TreeToolbox.scala
+++ b/src/main/scala/scala/tools/refactoring/implementations/oimports/TreeToolbox.scala
@@ -311,7 +311,7 @@ class TreeToolbox[G <: Global](val global: G) {
       copy(imports = transformation(imports))
 
     @tailrec
-    private def findNonBlankLine(to: Int): Int = if (to == source.content.length - 1)
+    private def findNonBlankLine(to: Int): Int = if (to == source.content.length)
       to
     else if (source.content(to) != '\r' && source.content(to) != '\n')
       to

--- a/src/main/scala/scala/tools/refactoring/sourcegen/Formatting.scala
+++ b/src/main/scala/scala/tools/refactoring/sourcegen/Formatting.scala
@@ -4,6 +4,8 @@
 
 package scala.tools.refactoring.sourcegen
 
+import scala.util.Properties
+
 /**
  * Holds default formatting preferences.
  */
@@ -30,4 +32,7 @@ trait Formatting {
    * `import util.Try`
    */
   def dropScalaPackage = false
+
+  /** Used when new line is added to source file and EOL is needed. */
+  def lineDelimiter = Properties.lineSeparator
 }

--- a/src/test/scala/scala/tools/refactoring/tests/RefactoringTestSuite.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/RefactoringTestSuite.scala
@@ -79,5 +79,6 @@ import scala.tools.refactoring.common.TracingHelpersTest
     classOf[OrganizeImportsAlgosTest],
     classOf[TracingHelpersTest],
     classOf[OrganizeImportsWithMacrosTest],
-    classOf[OrganizeImportsScalaSpecificTests]))
+    classOf[OrganizeImportsScalaSpecificTests],
+    classOf[OrganizeImportsEndOfLineTest]))
 class RefactoringTestSuite {}

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsBaseTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsBaseTest.scala
@@ -16,6 +16,7 @@ abstract class OrganizeImportsBaseTest extends TestHelper with TestRefactoring {
     val refactoring = new OrganizeImports {
       val global = OrganizeImportsBaseTest.this.global
       override val dropScalaPackage = formatting.dropScalaPackage
+      override val lineDelimiter = formatting.lineDelimiter
     }
     type RefactoringParameters = refactoring.RefactoringParameters
     val params: RefactoringParameters

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsEndOfLineTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsEndOfLineTest.scala
@@ -36,7 +36,7 @@ class OrganizeImportsEndOfLineTest extends OrganizeImportsBaseTest {
   @Test
   def shouldPreserveUnixLineSeparator_v2() = new FileSet {
     "package testunix\n\nimport scala.util.Try\nimport java.util.List\n" becomes
-      "package testunix\n\n\n"
+      "package testunix\n\n"
   } applyRefactoring organizeWithUnixEOL
 
   @Test
@@ -60,7 +60,7 @@ class OrganizeImportsEndOfLineTest extends OrganizeImportsBaseTest {
   @Test
   def shouldPreserveWindowsLineSeparator_v2() = new FileSet {
     "package testwin\r\n\r\nimport scala.util.Try\r\nimport java.util.List\r\n" becomes
-      "package testwin\r\n\r\n\n"
+      "package testwin\r\n\r\n"
   } applyRefactoring organizeWithWindowsEOL
 
   @Test

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsEndOfLineTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsEndOfLineTest.scala
@@ -1,0 +1,77 @@
+package scala.tools.refactoring
+package tests.implementations.imports
+
+import scala.tools.refactoring.implementations.OrganizeImports
+import scala.tools.refactoring.implementations.OrganizeImports.Dependencies
+import scala.tools.refactoring.sourcegen.Formatting
+
+class OrganizeImportsEndOfLineTest extends OrganizeImportsBaseTest {
+  private def organizeCustomized(
+    formatting: Formatting,
+    groupPkgs: List[String] = List("java", "scala", "org", "com"),
+    useWildcards: Set[String] = Set("scalaz", "scalaz.Scalaz"),
+    dependencies: Dependencies.Value = Dependencies.FullyRecompute,
+    organizeLocalImports: Boolean = true)(pro: FileSet) = new OrganizeImportsRefatoring(pro, formatting) {
+    val oiConfig = OrganizeImports.OrganizeImportsConfig(
+      importsStrategy = Some(OrganizeImports.ImportsStrategy.ExpandImports),
+      wildcards = useWildcards,
+      groups = groupPkgs)
+    val params = {
+      new refactoring.RefactoringParameters(
+        deps = dependencies,
+        organizeLocalImports = organizeLocalImports,
+        config = Some(oiConfig))
+    }
+  }.mkChanges
+
+  private def organizeWithUnixEOL(pro: FileSet) = organizeCustomized(formatting = new Formatting { override def lineDelimiter = "\n" })(pro)
+  private def organizeWithWindowsEOL(pro: FileSet) = organizeCustomized(formatting = new Formatting { override def lineDelimiter = "\r\n" })(pro)
+
+  @Test
+  def shouldPreserveUnixLineSeparator_v1() = new FileSet {
+    "package testunix\n\nimport scala.util.Try\nimport java.util.List" becomes
+      "package testunix\n\n"
+  } applyRefactoring organizeWithUnixEOL
+
+  @Test
+  def shouldPreserveUnixLineSeparator_v2() = new FileSet {
+    "package testunix\n\nimport scala.util.Try\nimport java.util.List\n" becomes
+      "package testunix\n\n\n"
+  } applyRefactoring organizeWithUnixEOL
+
+  @Test
+  def shouldPreserveUnixLineSeparator_v3() = new FileSet {
+    "package testunix\n\nimport scala.util.Try\nimport java.util.List\n\nclass A(val t: Try[Int], val l: List[Int])" becomes
+      "package testunix\n\nimport java.util.List\n\nimport scala.util.Try\n\nclass A(val t: Try[Int], val l: List[Int])"
+  } applyRefactoring organizeWithUnixEOL
+
+  @Test
+  def shouldPreserveUnixLineSeparator_v4() = new FileSet {
+    "package testunix\n\nimport scala.util.Try\nimport scala.util.Either\n\nclass A(val t: Try[Int], val l: Either[Int, Int])" becomes
+      "package testunix\n\nimport scala.util.Either\nimport scala.util.Try\n\nclass A(val t: Try[Int], val l: Either[Int, Int])"
+  } applyRefactoring organizeWithUnixEOL
+
+  @Test
+  def shouldPreserveWindowsLineSeparator_v1() = new FileSet {
+    "package testwin\r\n\r\nimport scala.util.Try\r\nimport java.util.List" becomes
+      "package testwin\r\n\r\n"
+  } applyRefactoring organizeWithWindowsEOL
+
+  @Test
+  def shouldPreserveWindowsLineSeparator_v2() = new FileSet {
+    "package testwin\r\n\r\nimport scala.util.Try\r\nimport java.util.List\r\n" becomes
+      "package testwin\r\n\r\n\n"
+  } applyRefactoring organizeWithWindowsEOL
+
+  @Test
+  def shouldPreserveWindowsLineSeparator_v3() = new FileSet {
+    "package testwin\r\n\r\nimport scala.util.Try\r\nimport java.util.List\r\n\r\nclass A(val t: Try[Int], val l: List[Int])" becomes
+      "package testwin\r\n\r\nimport java.util.List\r\n\r\nimport scala.util.Try\r\n\r\nclass A(val t: Try[Int], val l: List[Int])"
+  } applyRefactoring organizeWithWindowsEOL
+
+  @Test
+  def shouldPreserveWindowsLineSeparator_v4() = new FileSet {
+    "package testwin\r\n\r\nimport scala.util.Try\r\nimport scala.util.Either\r\n\r\nclass A(val t: Try[Int], val l: Either[Int, Int])" becomes
+      "package testwin\r\n\r\nimport scala.util.Either\r\nimport scala.util.Try\r\n\r\nclass A(val t: Try[Int], val l: Either[Int, Int])"
+  } applyRefactoring organizeWithWindowsEOL
+}

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsFullyRecomputeTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsFullyRecomputeTest.scala
@@ -234,7 +234,6 @@ class OrganizeImportsFullyRecomputeTest extends OrganizeImportsBaseTest {
     object Main
     """ becomes
     """
-
     object Main
     """
   } applyRefactoring organize
@@ -253,7 +252,6 @@ class OrganizeImportsFullyRecomputeTest extends OrganizeImportsBaseTest {
     """ becomes
     """
     package importOnTrait
-
     trait A
 
     trait Main extends A {
@@ -387,7 +385,6 @@ class OrganizeImportsFullyRecomputeTest extends OrganizeImportsBaseTest {
     object Main {
     }    """ becomes
     """
-
     object Main {
     }    """
   } applyRefactoring organize

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsRecomputeAndModifyTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsRecomputeAndModifyTest.scala
@@ -96,7 +96,6 @@ class OrganizeImportsRecomputeAndModifyTest extends OrganizeImportsBaseTest {
     object Main
     """ becomes
     """
-
     object Main
     """
   } applyRefactoring organize

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/imports/OrganizeImportsTest.scala
@@ -4,10 +4,10 @@
 
 package scala.tools.refactoring
 package tests.implementations.imports
-
 import scala.language.postfixOps
 import scala.tools.refactoring.implementations.OrganizeImports
 import scala.tools.refactoring.implementations.OrganizeImports.Dependencies
+
 class OrganizeImportsTest extends OrganizeImportsBaseTest {
   private def organize(pro: FileSet) = new OrganizeImportsRefatoring(pro) {
     val oiConfig = OrganizeImports.OrganizeImportsConfig(importsStrategy = Some(OrganizeImports.ImportsStrategy.CollapseImports))
@@ -268,7 +268,6 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
       object Main
     """ becomes
       """
-
       object Main
     """
   } applyRefactoring organize
@@ -287,7 +286,6 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
     """ becomes
       """
       package importOnTrait
-
       trait A
 
       trait Main extends A {
@@ -424,7 +422,6 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
       object Main {
       }    """ becomes
       """
-
       object Main {
       }    """
   } applyRefactoring organize
@@ -931,7 +928,6 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
     import java.util.Collections.emptyList
 
     class Bug {
-
       def test = emptyList
     }
     """
@@ -1026,7 +1022,6 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
     import java.util.Collections
 
     class Bug4 {
-
       def test1 = Arrays.asList(1, 2)
       def test2 = Collections.emptyList
     }
@@ -3708,7 +3703,6 @@ class OrganizeImportsTest extends OrganizeImportsBaseTest {
     package test
 
     object Outer {
-
       class TestTE(val a: (_, _))
     }
     """


### PR DESCRIPTION
additionally this implementation protects against Array Index Out Of
Bounds Exception for following code:

```scala
package a

import c.b.A
```
which should be tailored to
```scala
package a
```