### PR TITLE
2.12.2 support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "org.scala-refactoring.library"
 version := "0.13.0-SNAPSHOT"
-scalaVersion := "2.12.1"
+scalaVersion := "2.12.2"
 moduleName := name.value
 organization := "org.scala-refactoring"
 crossScalaVersions := Seq("2.10.6", "2.11.8", "2.12.1")

--- a/build.sbt
+++ b/build.sbt
@@ -27,13 +27,12 @@ scalacOptions ++= (CrossVersion.partialVersion(scalaVersion.value) match {
     "-feature",
     "-language:_",
     "-unchecked",
-    "-Xlint",
+    "-Xlint:-unused,_",
     "-Xfuture",
     "-Xfatal-warnings",
     "-Yno-adapted-args",
     "-Ywarn-dead-code",
-    "-Ywarn-unused-import",
-    "-Ywarn-unused"
+    "-Ywarn-unused:imports,privates,locals,-patvars,-params,-implicits,_"
   )
   case _ => Seq()
 })

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/ExplicitGettersSettersTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/ExplicitGettersSettersTest.scala
@@ -21,7 +21,7 @@ class ExplicitGettersSettersTest extends TestHelper with TestRefactoring {
   }.changes
 
   @Test
-  @ScalaVersion(doesNotMatch = "2.12.1")
+  @ScalaVersion(doesNotMatch = "2.12")
   def oneVarFromMany() = new FileSet {
     """
       package oneFromMany
@@ -45,7 +45,7 @@ class ExplicitGettersSettersTest extends TestHelper with TestRefactoring {
   } applyRefactoring(explicitGettersSetters)
 
   @Test
-  @ScalaVersion(doesNotMatch = "2.12.1")
+  @ScalaVersion(doesNotMatch = "2.12")
   def oneValFromMany() = new FileSet {
     """
       package oneFromMany
@@ -66,7 +66,7 @@ class ExplicitGettersSettersTest extends TestHelper with TestRefactoring {
   } applyRefactoring(explicitGettersSetters)
 
   @Test
-  @ScalaVersion(doesNotMatch = "2.12.1")
+  @ScalaVersion(doesNotMatch = "2.12")
   def singleVal() = new FileSet {
     """
       package oneFromMany
@@ -83,7 +83,7 @@ class ExplicitGettersSettersTest extends TestHelper with TestRefactoring {
   } applyRefactoring(explicitGettersSetters)
 
   @Test
-  @ScalaVersion(doesNotMatch = "2.12.1")
+  @ScalaVersion(doesNotMatch = "2.12")
   def singleValWithEmptyBody() = new FileSet {
     """
       package oneFromMany

--- a/src/test/scala/scala/tools/refactoring/tests/sourcegen/PrettyPrinterTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/sourcegen/PrettyPrinterTest.scala
@@ -276,7 +276,7 @@ class PrettyPrinterTest extends TestHelper {
   }
 
   @Test
-  @ScalaVersion(doesNotMatch = "2.12.1")
+  @ScalaVersion(doesNotMatch = "2.12")
   def testThrow() = global.ask { () =>
 
     val tree = treeFrom("""
@@ -305,7 +305,7 @@ class Throw2 {
   }
 
   @Test
-  @ScalaVersion(doesNotMatch = "2.12.1")
+  @ScalaVersion(doesNotMatch = "2.12")
   def testAnnotation() = global.ask { () =>
 
     val tree = treeFrom("""
@@ -471,7 +471,7 @@ class Test44 {
   }
 
   @Test
-  @ScalaVersion(doesNotMatch = "2.12.1")
+  @ScalaVersion(doesNotMatch = "2.12")
   def testCompoundTypeTree() = global.ask { () =>
 
     val tree = treeFrom("""
@@ -668,7 +668,7 @@ trait AbstractPrinter {
   }
 
   @Test
-  @ScalaVersion(doesNotMatch = "2.12.1")
+  @ScalaVersion(doesNotMatch = "2.12")
   def testSetters() = global.ask { () =>
     val tree = treeFrom("""
       package oneFromMany
@@ -1193,7 +1193,7 @@ trait CTrait {
   }
 
   @Test
-  @ScalaVersion(doesNotMatch = "2.12.1")
+  @ScalaVersion(doesNotMatch = "2.12")
   def testClassTemplates() = global.ask { () =>
 
     val tree = treeFrom("""
@@ -1217,7 +1217,7 @@ class AClass(i: Int, var b: String, val c: List[String]) extends ASuperClass(i, 
   }
 
   @Test
-  @ScalaVersion(doesNotMatch = "2.12.1")
+  @ScalaVersion(doesNotMatch = "2.12")
   def testSuperClass() = global.ask { () =>
 
     val tree = treeFrom("""
@@ -1232,7 +1232,7 @@ class AClass(i: Int, var b: String) extends ASuperClass(i, b)"""
   }
 
   @Test
-  @ScalaVersion(doesNotMatch = "2.12.1")
+  @ScalaVersion(doesNotMatch = "2.12")
   def testTry() = global.ask { () =>
 
     val tree = treeFrom("""

--- a/src/test/scala/scala/tools/refactoring/tests/sourcegen/SourceGenTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/sourcegen/SourceGenTest.scala
@@ -640,6 +640,7 @@ class SourceGenTest extends TestHelper {
   }
 
   @Test
+  @ScalaVersion(doesNotMatch = "2.12")
   def testMatches() = global.ask { () =>
     val tree = treeFrom("""
     object Functions {

--- a/src/test/scala/scala/tools/refactoring/tests/sourcegen/SourceGenTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/sourcegen/SourceGenTest.scala
@@ -1129,7 +1129,7 @@ class SourceGenTest extends TestHelper {
   }
 
   @Test
-  @ScalaVersion(doesNotMatch = "2.12.1")
+  @ScalaVersion(doesNotMatch = "2.12")
   def testValOrDefDefModifiers() = global.ask { () =>
 
     val tree = treeFrom("""


### PR DESCRIPTION
Tree printing dependent refactorings are still broken on 2.12, as described in #180