### PR TITLE
[WIP] Implement methods

### DIFF
--- a/src/main/scala/scala/tools/refactoring/implementations/ImplementMethods.scala
+++ b/src/main/scala/scala/tools/refactoring/implementations/ImplementMethods.scala
@@ -1,0 +1,32 @@
+package scala.tools.refactoring.implementations
+
+import scala.tools.refactoring.common.InteractiveScalaCompiler
+import scala.tools.refactoring.{MultiStageRefactoring, analysis}
+
+abstract class ImplementMethods extends MultiStageRefactoring with analysis.Indexes with InteractiveScalaCompiler {
+
+  import global._
+
+  override type PreparationResult = Seq[DefDef]
+
+  override def prepare(s: Selection): Either[PreparationError, PreparationResult] = {
+    val methodsToImplement = for {
+      selectedClassDeclaration <- index.declaration(s.enclosingTree.symbol).toSeq collect {
+        case traitDeclaration: ClassDef => traitDeclaration
+      }
+      unimplementedMethod <- selectedClassDeclaration.impl.body collect {
+        case methodDeclaration: DefDef if methodDeclaration.rhs.isEmpty => methodDeclaration
+      }
+    } yield unimplementedMethod
+    if(methodsToImplement.isEmpty) Left {
+      PreparationError("There are not methods to implement")
+    }
+    else Right(methodsToImplement)
+  }
+
+  override type RefactoringParameters = Unit
+
+  override def perform(selection: Selection, prepared: PreparationResult, params: RefactoringParameters) = {
+    ???
+  }
+}

--- a/src/main/scala/scala/tools/refactoring/implementations/ImplementMethods.scala
+++ b/src/main/scala/scala/tools/refactoring/implementations/ImplementMethods.scala
@@ -10,30 +10,66 @@ abstract class ImplementMethods extends MultiStageRefactoring with analysis.Inde
 
   case class PreparationResult(targetTemplate: Template, methodsToImplement: Seq[DefDef])
 
+  /* Helper class to box methods so they can be
+     compared in terms of their signature.
+   */
+  implicit class OverloadedMethod(val method: DefDef) {
+
+    private val key = {
+      import method.{name, tparams, vparamss}
+
+      val vparamsTypes = for {
+        paramList <- vparamss
+        param <- paramList
+      } yield param.tpt.tpe
+
+      (name, tparams, vparamsTypes)
+
+    }
+
+    override def hashCode(): RunId = key.hashCode()
+
+    override def equals(obj: scala.Any): Boolean = obj match {
+      case that: OverloadedMethod => key == that.key
+      case _ => false
+    }
+  }
+
   override def prepare(s: Selection): Either[PreparationError, PreparationResult] = {
 
+    // Get a sequence of methods found in the selected mixed trait.
     val methodsToImplement = for {
       selectedTemplateDeclaration <- index.declaration(s.enclosingTree.symbol).toSeq collect {
-        case traitDeclaration: ClassDef => traitDeclaration
+        case templateDeclaration: ClassDef => templateDeclaration
       }
       unimplementedMethod <- selectedTemplateDeclaration.impl.body collect {
-        case methodDeclaration: DefDef if methodDeclaration.rhs.isEmpty => methodDeclaration
+        case methodDeclaration: DefDef if methodDeclaration.rhs.isEmpty =>
+          methodDeclaration
       }
     } yield unimplementedMethod
 
+    // Use the selection to find the template where the methods should be implemented.
     val targetTemplate = s.expandToNextEnclosingTree.flatMap {
       _.selectedSymbolTree collect {
         case target: Template => target
       }
     }
 
-    if(targetTemplate.isEmpty) Left {
+    targetTemplate map { t => // If the selection has indeed a target template...
+      if(methodsToImplement.isEmpty) Left { //... as long as there are methods in the mixed trait...
+        PreparationError("There are not methods to implement")
+      } else Right { //... these are selected to be defined in the target template.
+        // If and only if they're not already defined there.
+        val implementedMethods: Set[OverloadedMethod] = {
+          t.body collect {
+            case methodDef: DefDef => new OverloadedMethod(methodDef)
+          } toSet
+        }
+        PreparationResult(t, methodsToImplement.filterNot(implementedMethods contains _))
+      }
+    } getOrElse Left {
       PreparationError("No target class in selection")
     }
-    else if(methodsToImplement.isEmpty) Left {
-      PreparationError("There are not methods to implement")
-    }
-    else Right(PreparationResult(targetTemplate.get, methodsToImplement))
   }
 
   override type RefactoringParameters = Unit

--- a/src/main/scala/scala/tools/refactoring/implementations/ImplementMethods.scala
+++ b/src/main/scala/scala/tools/refactoring/implementations/ImplementMethods.scala
@@ -1,32 +1,63 @@
 package scala.tools.refactoring.implementations
 
 import scala.tools.refactoring.common.InteractiveScalaCompiler
+import scala.tools.refactoring.transformation.TreeFactory
 import scala.tools.refactoring.{MultiStageRefactoring, analysis}
 
-abstract class ImplementMethods extends MultiStageRefactoring with analysis.Indexes with InteractiveScalaCompiler {
+abstract class ImplementMethods extends MultiStageRefactoring with analysis.Indexes with TreeFactory with InteractiveScalaCompiler {
 
   import global._
 
-  override type PreparationResult = Seq[DefDef]
+  case class PreparationResult(targetTemplate: Template, methodsToImplement: Seq[DefDef])
 
   override def prepare(s: Selection): Either[PreparationError, PreparationResult] = {
+
     val methodsToImplement = for {
-      selectedClassDeclaration <- index.declaration(s.enclosingTree.symbol).toSeq collect {
+      selectedTemplateDeclaration <- index.declaration(s.enclosingTree.symbol).toSeq collect {
         case traitDeclaration: ClassDef => traitDeclaration
       }
-      unimplementedMethod <- selectedClassDeclaration.impl.body collect {
+      unimplementedMethod <- selectedTemplateDeclaration.impl.body collect {
         case methodDeclaration: DefDef if methodDeclaration.rhs.isEmpty => methodDeclaration
       }
     } yield unimplementedMethod
-    if(methodsToImplement.isEmpty) Left {
+
+    val targetTemplate = s.expandToNextEnclosingTree.flatMap {
+      _.selectedSymbolTree collect {
+        case target: Template => target
+      }
+    }
+
+    if(targetTemplate.isEmpty) Left {
+      PreparationError("No target class in selection")
+    }
+    else if(methodsToImplement.isEmpty) Left {
       PreparationError("There are not methods to implement")
     }
-    else Right(methodsToImplement)
+    else Right(PreparationResult(targetTemplate.get, methodsToImplement))
   }
 
   override type RefactoringParameters = Unit
 
   override def perform(selection: Selection, prepared: PreparationResult, params: RefactoringParameters) = {
-    ???
+    import prepared._
+
+    val findTemplate = filter {
+      case t: Template => t == targetTemplate
+    }
+
+    val addMethods = transform {
+      case tpl @ Template(_,  _, body) if tpl == prepared.targetTemplate =>
+        val methodsBody = Block(Ident("???") :: Nil, EmptyTree)
+        val methodWithRhs = methodsToImplement.map(_ copy (rhs = methodsBody))
+        tpl.copy(body = body ++ methodWithRhs).replaces(tpl)
+    }
+
+    val transformation = topdown {
+      matchingChildren {
+        findTemplate &>
+        addMethods
+      }
+    }
+    Right(transformFile(selection.file, transformation))
   }
 }

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/ImplementMethodsTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/ImplementMethodsTest.scala
@@ -9,39 +9,37 @@ class ImplementMethodsTest extends TestHelper with TestRefactoring {
 
   val fromSource =
     """
+      |package implementMethods
+      |
       |trait T {
-      | def f(x: Int): String
+      |  def f(x: Int): String
       |}
       |
       |object Obj extends /*(*/T/*)*/ {
+      |
+      |  def g(x: Int): Int = 1
+      |
       |}
     """.stripMargin
 
   val toSource =
     """
+      |package implementMethods
+      |
       |trait T {
-      | def f(x: Int): String
+      |  def f(x: Int): String
       |}
       |
-      |object Obj extends T {
-      |  def g(): Int = {
-      |    ???    Left(PreparationError("crash!"))
-
+      |object Obj extends /*(*/T/*)*/ {
+      |
+      |  def g(x: Int): Int = 1
+      |
+      |  def f(x: Int): String = {
+      |    ???
       |  }
+      |
       |}
     """.stripMargin
-
-  /*@Test
-  def addMethod() = {
-    global.ask { () =>
-      val refactoring = new AddMethod {
-        val global: Global = outer.global
-        val file = addToCompiler(UniqueNames.basename(), fromSource)
-        val change = addMethod(file, "Obj", "g", List(Nil), Nil, Some("Int"), AddToObject)
-      }
-      assertEquals(toSource, Change.applyChanges(refactoring.change, fromSource))
-    }
-  }*/
 
   def implementMethods(pro: FileSet) = new TestRefactoringImpl(pro) {
     override val refactoring = new ImplementMethods with TestProjectIndex

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/ImplementMethodsTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/ImplementMethodsTest.scala
@@ -1,0 +1,56 @@
+package scala.tools.refactoring
+package tests.implementations
+
+import scala.tools.refactoring.implementations.ImplementMethods
+import scala.tools.refactoring.tests.util.{TestHelper, TestRefactoring}
+
+class ImplementMethodsTest extends TestHelper with TestRefactoring {
+  outer =>
+
+  val fromSource =
+    """
+      |trait T {
+      | def f(x: Int): String
+      |}
+      |
+      |object Obj extends /*(*/T/*)*/ {
+      |}
+    """.stripMargin
+
+  val toSource =
+    """
+      |trait T {
+      | def f(x: Int): String
+      |}
+      |
+      |object Obj extends T {
+      |  def g(): Int = {
+      |    ???    Left(PreparationError("crash!"))
+
+      |  }
+      |}
+    """.stripMargin
+
+  /*@Test
+  def addMethod() = {
+    global.ask { () =>
+      val refactoring = new AddMethod {
+        val global: Global = outer.global
+        val file = addToCompiler(UniqueNames.basename(), fromSource)
+        val change = addMethod(file, "Obj", "g", List(Nil), Nil, Some("Int"), AddToObject)
+      }
+      assertEquals(toSource, Change.applyChanges(refactoring.change, fromSource))
+    }
+  }*/
+
+  def implementMethods(pro: FileSet) = new TestRefactoringImpl(pro) {
+    override val refactoring = new ImplementMethods with TestProjectIndex
+    val changes = performRefactoring(())
+  }.changes
+
+  @Test
+  def doRefactor() = new FileSet() {
+    fromSource becomes toSource
+  } applyRefactoring implementMethods
+
+}

--- a/src/test/scala/scala/tools/refactoring/tests/implementations/ImplementMethodsTest.scala
+++ b/src/test/scala/scala/tools/refactoring/tests/implementations/ImplementMethodsTest.scala
@@ -7,12 +7,95 @@ import scala.tools.refactoring.tests.util.{TestHelper, TestRefactoring}
 class ImplementMethodsTest extends TestHelper with TestRefactoring {
   outer =>
 
-  val fromSource =
+  def implementMethods(pro: FileSet) = new TestRefactoringImpl(pro) {
+    override val refactoring = new ImplementMethods with TestProjectIndex
+    val changes = performRefactoring(())
+  }.changes
+
+  @Test
+  def implementMethodFromFirstMixing() = new FileSet() {
     """
       |package implementMethods
       |
       |trait T {
       |  def f(x: Int): String
+      |}
+      |
+      |trait S {
+      |  def g(x: Int): Int
+      |}
+      |
+      |object Obj extends /*(*/T/*)*/ with S {
+      |  val x: Int = ???
+      |}
+    """.stripMargin becomes
+    """
+      |package implementMethods
+      |
+      |trait T {
+      |  def f(x: Int): String
+      |}
+      |
+      |trait S {
+      |  def g(x: Int): Int
+      |}
+      |
+      |object Obj extends /*(*/T/*)*/ with S {
+      |  val x: Int = ???
+      |
+      |  def f(x: Int): String = {
+      |    ???
+      |  }
+      |}
+    """.stripMargin
+  } applyRefactoring implementMethods
+
+  @Test
+  def implementMethodFromSecondMixing() = new FileSet() {
+    """
+      |package implementMethods
+      |
+      |trait T {
+      |  def f(x: Int): String
+      |}
+      |
+      |trait S {
+      |  def g(x: Int): Int
+      |}
+      |
+      |object Obj extends T with /*(*/S/*)*/ {
+      |  val x: Int = ???
+      |}
+    """.stripMargin becomes
+    """
+      |package implementMethods
+      |
+      |trait T {
+      |  def f(x: Int): String
+      |}
+      |
+      |trait S {
+      |  def g(x: Int): Int
+      |}
+      |
+      |object Obj extends T with /*(*/S/*)*/ {
+      |  val x: Int = ???
+      |
+      |  def g(x: Int): Int = {
+      |    ???
+      |  }
+      |}
+    """.stripMargin
+  } applyRefactoring implementMethods
+
+  @Test
+  def implementMethodsNotImplemented() = new FileSet() {
+    """
+      |package implementMethods
+      |
+      |trait T {
+      |  def f(x: Int): String
+      |  def g(x: Int): Int
       |}
       |
       |object Obj extends /*(*/T/*)*/ {
@@ -20,14 +103,13 @@ class ImplementMethodsTest extends TestHelper with TestRefactoring {
       |  def g(x: Int): Int = 1
       |
       |}
-    """.stripMargin
-
-  val toSource =
+    """.stripMargin becomes
     """
       |package implementMethods
       |
       |trait T {
       |  def f(x: Int): String
+      |  def g(x: Int): Int
       |}
       |
       |object Obj extends /*(*/T/*)*/ {
@@ -40,15 +122,6 @@ class ImplementMethodsTest extends TestHelper with TestRefactoring {
       |
       |}
     """.stripMargin
-
-  def implementMethods(pro: FileSet) = new TestRefactoringImpl(pro) {
-    override val refactoring = new ImplementMethods with TestProjectIndex
-    val changes = performRefactoring(())
-  }.changes
-
-  @Test
-  def doRefactor() = new FileSet() {
-    fromSource becomes toSource
   } applyRefactoring implementMethods
 
 }


### PR DESCRIPTION
This PR tries to add `ImplementMethod` transformation aimed to offer a similar functionality to widespread IDEs, e.g:

![image](https://user-images.githubusercontent.com/273379/30773048-dfa6ba40-a068-11e7-865e-9f0bdcf62dec.png)

It works through `Selection` mechanism as follows:

1. The user select a template (mixed template) extended in the definition of another (target template)
2. The transformation finds methods without implementation in the **mixed template**...
3. ... adding them to the **target template** as long as they are not implemented in its body.
