### PR TITLE
Be more precise about matching scala versions

### DIFF
--- a/src/test/java/scala/tools/refactoring/tests/util/ScalaVersionTestRule.java
+++ b/src/test/java/scala/tools/refactoring/tests/util/ScalaVersionTestRule.java
@@ -18,12 +18,12 @@ public class ScalaVersionTestRule implements MethodRule {
 
   public Statement apply(Statement stmt, FrameworkMethod meth, Object arg2) {
     ScalaVersion onlyOn = meth.getAnnotation(ScalaVersion.class);
-    String versionString = Properties.versionString();
+    String versionNumberString = Properties.versionNumberString();
 
     if (onlyOn != null) {
-      if (!onlyOn.doesNotMatch().isEmpty() && versionString.contains(onlyOn.doesNotMatch())) {
+      if (!onlyOn.doesNotMatch().isEmpty() && versionNumberString.startsWith(onlyOn.doesNotMatch())) {
         return new EmptyStatement();
-      } else if (versionString.contains(onlyOn.matches())) {
+      } else if (versionNumberString.startsWith(onlyOn.matches())) {
         return stmt;
       } else {
         return new EmptyStatement();


### PR DESCRIPTION
now, f.e. "2.10" will no longer match on scala 2.12.10. To keep the change minimal, I chose this solution.

This was uncovered in the community build, see https://github.com/scala/scala-dev/issues/644#issuecomment-520562911 for more details.